### PR TITLE
Add needed `http://` to link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Material Design Lite
 
-> A library of [Material Design](www.google.com/design/spec/material-design/introduction.html) components in CSS, JS and HTML
+> A library of [Material Design](http://www.google.com/design/spec/material-design/introduction.html) components in CSS, JS and HTML
 
 ## Quick start
 


### PR DESCRIPTION
This link missed a protocol and thus was 404-ing.
