### PR TITLE
Check for existence of `for` target in MaterialTooltip

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -72,7 +72,7 @@ MaterialTooltip.prototype.init = function() {
 
   if (this.element_) {
     var forElId = this.element_.getAttribute('for');
-      forEl;
+      forEl = null;
     if (forElId) {
       forEl = document.getElementById(forElId);
     }


### PR DESCRIPTION
Having a tooltip without a `for` target doesn’t make sense, but the code shouldn’t just error, should it?
