### PR TITLE
Don't rely on global querySelector() for MaterialTabs

### DIFF
--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -116,7 +116,7 @@ function MaterialTab(tab, ctx) {
     tab.addEventListener('click', function(e) {
       e.preventDefault();
       var href = tab.href.split('#')[1];
-      var panel = document.querySelector('#' + href);
+      var panel = ctx.element_.querySelector('#' + href);
       ctx.resetTabState_();
       ctx.resetPanelState_();
       tab.classList.add(ctx.CssClasses_.ACTIVE_CLASS);


### PR DESCRIPTION
In the particular case of MaterialTabs, where content and tab elements share a parent, it is unnecessary to rely on the a global `querySelector()` and complicates testing. 
