### PR TITLE
Don’t use gulp-changed on SASS

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -81,9 +81,8 @@ gulp.task('fonts', function () {
 // Compile and Automatically Prefix Stylesheets (dev)
 gulp.task('styles:dev', ['fonts'], function () {
   return gulp.src([
-    'src/**/**/*.scss'
+    'src/**/*.scss'
   ])
-    .pipe($.changed('.tmp/styles', {extension: '.css'}))
     .pipe($.sass({
       precision: 10,
       onError: console.error.bind(console, 'Sass error:')
@@ -204,8 +203,8 @@ gulp.task('serve', ['styles:dev'], function () {
     server: ['.tmp', 'src', '.tmp/styles']
   });
 
-  gulp.watch(['src/**/**/**/*.html'], reload);
-  gulp.watch(['src/**/**/*.{scss,css}'], ['styles:dev', reload]);
+  gulp.watch(['src/**/*.html'], reload);
+  gulp.watch(['src/**/*.{scss,css}'], ['styles:dev', reload]);
   gulp.watch(['src/**/*.js'], ['jshint']);
 });
 


### PR DESCRIPTION
Since we now have somewhat modularized our SCSS code, `gulp-changed` is not working as intended. It has no understanding of the dependency tree. If `_colors.scss` changes, it will be recompiled, but the styles that include `_colors.scss` will not, since `gulp-changed` has removed them from the stream in the `styles:dev` task.

I also removed the `**/**` as they are redundant (`**` will match any level of depth).

@sgomes @addyosmani PTAL
