### PR TITLE
Change contract/expand behavior of waterfall layout

### DIFF
--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -143,7 +143,7 @@ MaterialLayout.prototype.headerTransitionEndHandler = function() {
 MaterialLayout.prototype.headerClickHandler = function() {
   'use strict';
 
-  if(this.header_.classList.contains(this.CssClasses_.COMPACT_CLASS)) {
+  if (this.header_.classList.contains(this.CssClasses_.COMPACT_CLASS)) {
     this.header_.classList.remove(this.CssClasses_.COMPACT_CLASS);
     this.header_.classList.add(this.CssClasses_.ANIMATING_CLASS);
   }


### PR DESCRIPTION
This is a followup on #42.

As I worked out with @sgomes, we are now ignoring scroll events until the animation is finished (effectively removing the jitter bug). However, that fix alone would not allow a header to expand ever again in the specific corner-case.

As a solution I made the header expand on click. For now, this also works outside of the corner-case, which I like but that is obviously open for discussion.

@sgomes @addyosmani PTAL
