### PR TITLE
Make icon-font more flexible

### DIFF
--- a/src/fonts/_fonts.scss
+++ b/src/fonts/_fonts.scss
@@ -1,0 +1,14 @@
+$icon-font-path : "../fonts/" !default;
+
+@font-face {
+    font-family : 'Material-Design-Iconic-Font';
+
+    src         : url($icon-font-path + 'Material-Design-Iconic-Font.eot?v=1.1.1');
+
+    src         : url($icon-font-path + 'Material-Design-Iconic-Font.eot?#iefix&v=1.1.1') format('embedded-opentype'),
+                    url($icon-font-path + 'Material-Design-Iconic-Font.woff?v=1.1.1') format('woff'),
+                    url($icon-font-path + 'Material-Design-Iconic-Font.ttf?v=1.1.1') format('truetype');
+
+    font-weight : normal;
+    font-style  : normal;
+}

--- a/src/icons/_icons.scss
+++ b/src/icons/_icons.scss
@@ -1,10 +1,4 @@
-@font-face {
-  font-family: 'Material-Design-Iconic-Font';
-  src: url('../fonts/Material-Design-Iconic-Font.eot?v=1.1.1');
-  src: url('../fonts/Material-Design-Iconic-Font.eot?#iefix&v=1.1.1') format('embedded-opentype'), url('../fonts/Material-Design-Iconic-Font.woff?v=1.1.1') format('woff'), url('../fonts/Material-Design-Iconic-Font.ttf?v=1.1.1') format('truetype');
-  font-weight: normal;
-  font-style: normal;
-}
+@import "../fonts/fonts";
 
 @mixin wsk-icon() {
   font-family: 'Material-Design-Iconic-Font';


### PR DESCRIPTION
With this setting it's much easier to use mdl as a library.

I set the icon path and I'm done:

_styleguide_demo_bp.scss:

``` css
@import "resets/h5bp";
@import "typography/typography";
@import "palette/palette";

$padding: 24px;
$icon-font-path: "packages/wsk_material/sass/fonts/";

.demo-page {
...
}
```
