### PR TITLE
Hardcoded colors in _colors.scss

### DIFF
--- a/src/_colors.scss
+++ b/src/_colors.scss
@@ -106,7 +106,7 @@ $layout-header-nav-hover-color: unquote("rgba(#{$palette-grey-700}, 0.6)") !defa
 $layout-header-tab-text-color: unquote("rgba(#{$color-primary-contrast}, 0.6)") !default;
 
 // Tabs
-$layout-header-tab-highlight: unquote("rgb(#{$palette-grey-300})") !default;
+$layout-header-tab-highlight: unquote("rgb(#{$color-accent})") !default;
 
 /* ==========  Content Tabs  ========== */
 


### PR DESCRIPTION
While working with layout’s tabs, I noticed that the highlight color is not the accent color (as prescribed by the [spec](https://spec.googleplex.com/quantum/components/tabs.html#tabs-usage)) but a hardcoded grey value. I fixed that in this PR.

There are still a lot more hardcoded color values in the the vicinity (and probably more in general). Should these be looked over? There are probably certain combinations of primary and accent colors that aren’t very easy on the eye with these hardcoded colors.
