### PR TITLE
Blue box around switch

### DIFF
--- a/src/switch/_switch.scss
+++ b/src/switch/_switch.scss
@@ -32,6 +32,13 @@ $switch-helper-size: 8px;
   &.is-upgraded {
     padding-left: $switch-track-length - 8px;
   }
+
+  // avoids blue box around switch
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .wsk-switch__input {


### PR DESCRIPTION
If you click on switch a bit faster (no double click) a blue box appears around the switch.
Disadvantage of these properties is that it disables selection... but I could not find another solution.

There is another problem with switch on FF (at least on Mac v 37.0.1) You can see a little curser on the right side of the switch. I could not make a screenshot of a blinking cursor but if you try it you will see what I mean. No solution so far for this...

![screenshot-1755](https://cloud.githubusercontent.com/assets/116654/7066238/d383758a-dec0-11e4-9fa5-8756ce9e03c6.png)
