### PR TITLE
Make menu elements stretch to parent's width

### DIFF
--- a/src/menu/_menu.scss
+++ b/src/menu/_menu.scss
@@ -124,6 +124,7 @@
   text-decoration: none;
   cursor: pointer;
   height: 48px;
+  width: 100%;
   line-height: 48px;
   white-space: nowrap;
   opacity: 0;


### PR DESCRIPTION
Followup on #176. 

This probably never got noticed as our demos use `<li>` inside the `<ul>` but the documentation proposes `<button>`.
