### PR TITLE
Renaming all WSK to MDL

### DIFF
--- a/src/animation/animation.js
+++ b/src/animation/animation.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * Class constructor for Animation WSK component.
- * Implements WSK component design pattern defined at:
+ * Class constructor for Animation MDL component.
+ * Implements MDL component design pattern defined at:
  * https://github.com/jasonmayes/mdl-component-design-pattern
  * @param {HTMLElement} element The element that will be upgraded.
  */

--- a/src/button/button.js
+++ b/src/button/button.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * Class constructor for Button WSK component.
- * Implements WSK component design pattern defined at:
+ * Class constructor for Button MDL component.
+ * Implements MDL component design pattern defined at:
  * https://github.com/jasonmayes/mdl-component-design-pattern
  * @param {HTMLElement} element The element that will be upgraded.
  */

--- a/src/checkbox/checkbox.js
+++ b/src/checkbox/checkbox.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * Class constructor for Checkbox WSK component.
- * Implements WSK component design pattern defined at:
+ * Class constructor for Checkbox MDL component.
+ * Implements MDL component design pattern defined at:
  * https://github.com/jasonmayes/mdl-component-design-pattern
  * @param {HTMLElement} element The element that will be upgraded.
  */

--- a/src/column-layout/column-layout.js
+++ b/src/column-layout/column-layout.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * Class constructor for Column Layout WSK component.
- * Implements WSK component design pattern defined at:
+ * Class constructor for Column Layout MDL component.
+ * Implements MDL component design pattern defined at:
  * https://github.com/jasonmayes/mdl-component-design-pattern
  * @param {HTMLElement} element The element that will be upgraded.
  */

--- a/src/icon-toggle/icon-toggle.js
+++ b/src/icon-toggle/icon-toggle.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * Class constructor for icon toggle WSK component.
- * Implements WSK component design pattern defined at:
+ * Class constructor for icon toggle MDL component.
+ * Implements MDL component design pattern defined at:
  * https://github.com/jasonmayes/mdl-component-design-pattern
  * @param {HTMLElement} element The element that will be upgraded.
  */

--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * Class constructor for Layout WSK component.
- * Implements WSK component design pattern defined at:
+ * Class constructor for Layout MDL component.
+ * Implements MDL component design pattern defined at:
  * https://github.com/jasonmayes/mdl-component-design-pattern
  * @param {HTMLElement} element The element that will be upgraded.
  */

--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -143,7 +143,7 @@ var componentHandler = (function() {
   /**
    * Allows user to be alerted to any upgrades that are performed for a given
    * component type
-   * @param {string} jsClass The class name of the WSK component we wish
+   * @param {string} jsClass The class name of the MDL component we wish
    * to hook into for any upgrades performed.
    * @param {function} callback The function to call upon an upgrade. This
    * function should expect 1 parameter - the HTMLElement which got upgraded.
@@ -184,7 +184,7 @@ window.addEventListener('load', function() {
 
   /**
    * Performs a "Cutting the mustard" test. If the browser supports the features
-   * tested, adds a mdl-js class to the <html> element. It then upgrades all WSK
+   * tested, adds a mdl-js class to the <html> element. It then upgrades all MDL
    * components requiring JavaScript.
    */
   if ('classList' in document.createElement('div') && 'querySelector' in document &&

--- a/src/menu/menu.js
+++ b/src/menu/menu.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * Class constructor for dropdown WSK component.
- * Implements WSK component design pattern defined at:
+ * Class constructor for dropdown MDL component.
+ * Implements MDL component design pattern defined at:
  * https://github.com/jasonmayes/mdl-component-design-pattern
  * @param {HTMLElement} element The element that will be upgraded.
  */

--- a/src/progress/progress.js
+++ b/src/progress/progress.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * Class constructor for Progress WSK component.
- * Implements WSK component design pattern defined at:
+ * Class constructor for Progress MDL component.
+ * Implements MDL component design pattern defined at:
  * https://github.com/jasonmayes/mdl-component-design-pattern
  * @param {HTMLElement} element The element that will be upgraded.
  */

--- a/src/radio/radio.js
+++ b/src/radio/radio.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * Class constructor for Radio WSK component.
- * Implements WSK component design pattern defined at:
+ * Class constructor for Radio MDL component.
+ * Implements MDL component design pattern defined at:
  * https://github.com/jasonmayes/mdl-component-design-pattern
  * @param {HTMLElement} element The element that will be upgraded.
  */

--- a/src/ripple/ripple.js
+++ b/src/ripple/ripple.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * Class constructor for Ripple WSK component.
- * Implements WSK component design pattern defined at:
+ * Class constructor for Ripple MDL component.
+ * Implements MDL component design pattern defined at:
  * https://github.com/jasonmayes/mdl-component-design-pattern
  * @param {HTMLElement} element The element that will be upgraded.
  */

--- a/src/slider/slider.js
+++ b/src/slider/slider.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * Class constructor for Slider WSK component.
- * Implements WSK component design pattern defined at:
+ * Class constructor for Slider MDL component.
+ * Implements MDL component design pattern defined at:
  * https://github.com/jasonmayes/mdl-component-design-pattern
  * @param {HTMLElement} element The element that will be upgraded.
  */

--- a/src/spinner/spinner.js
+++ b/src/spinner/spinner.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * Class constructor for Spinner WSK component.
- * Implements WSK component design pattern defined at:
+ * Class constructor for Spinner MDL component.
+ * Implements MDL component design pattern defined at:
  * https://github.com/jasonmayes/mdl-component-design-pattern
  * @param {HTMLElement} element The element that will be upgraded.
  */
@@ -35,7 +35,7 @@ function MaterialSpinner(element) {
  * @private
  */
 MaterialSpinner.prototype.Constant_ = {
-  WSK_SPINNER_LAYER_COUNT: 4
+  MDL_SPINNER_LAYER_COUNT: 4
 };
 
 /**
@@ -46,12 +46,12 @@ MaterialSpinner.prototype.Constant_ = {
  * @private
  */
 MaterialSpinner.prototype.CssClasses_ = {
-  WSK_SPINNER_LAYER: 'mdl-spinner__layer',
-  WSK_SPINNER_CIRCLE_CLIPPER: 'mdl-spinner__circle-clipper',
-  WSK_SPINNER_CIRCLE: 'mdl-spinner__circle',
-  WSK_SPINNER_GAP_PATCH: 'mdl-spinner__gap-patch',
-  WSK_SPINNER_LEFT: 'mdl-spinner__left',
-  WSK_SPINNER_RIGHT: 'mdl-spinner__right'
+  MDL_SPINNER_LAYER: 'mdl-spinner__layer',
+  MDL_SPINNER_CIRCLE_CLIPPER: 'mdl-spinner__circle-clipper',
+  MDL_SPINNER_CIRCLE: 'mdl-spinner__circle',
+  MDL_SPINNER_GAP_PATCH: 'mdl-spinner__gap-patch',
+  MDL_SPINNER_LEFT: 'mdl-spinner__left',
+  MDL_SPINNER_RIGHT: 'mdl-spinner__right'
 };
 
 /**
@@ -61,25 +61,25 @@ MaterialSpinner.prototype.createLayer = function(index) {
   'use strict';
 
   var layer = document.createElement('div');
-  layer.classList.add(this.CssClasses_.WSK_SPINNER_LAYER);
-  layer.classList.add(this.CssClasses_.WSK_SPINNER_LAYER + '-' + index);
+  layer.classList.add(this.CssClasses_.MDL_SPINNER_LAYER);
+  layer.classList.add(this.CssClasses_.MDL_SPINNER_LAYER + '-' + index);
 
   var leftClipper = document.createElement('div');
-  leftClipper.classList.add(this.CssClasses_.WSK_SPINNER_CIRCLE_CLIPPER);
-  leftClipper.classList.add(this.CssClasses_.WSK_SPINNER_LEFT);
+  leftClipper.classList.add(this.CssClasses_.MDL_SPINNER_CIRCLE_CLIPPER);
+  leftClipper.classList.add(this.CssClasses_.MDL_SPINNER_LEFT);
 
   var gapPatch = document.createElement('div');
-  gapPatch.classList.add(this.CssClasses_.WSK_SPINNER_GAP_PATCH);
+  gapPatch.classList.add(this.CssClasses_.MDL_SPINNER_GAP_PATCH);
 
   var rightClipper = document.createElement('div');
-  rightClipper.classList.add(this.CssClasses_.WSK_SPINNER_CIRCLE_CLIPPER);
-  rightClipper.classList.add(this.CssClasses_.WSK_SPINNER_RIGHT);
+  rightClipper.classList.add(this.CssClasses_.MDL_SPINNER_CIRCLE_CLIPPER);
+  rightClipper.classList.add(this.CssClasses_.MDL_SPINNER_RIGHT);
 
   var circleOwners = [leftClipper, gapPatch, rightClipper];
 
   for (var i = 0; i < circleOwners.length; i++) {
     var circle = document.createElement('div');
-    circle.classList.add(this.CssClasses_.WSK_SPINNER_CIRCLE);
+    circle.classList.add(this.CssClasses_.MDL_SPINNER_CIRCLE);
     circleOwners[i].appendChild(circle);
   }
 
@@ -120,7 +120,7 @@ MaterialSpinner.prototype.init = function() {
   'use strict';
 
   if (this.element_) {
-    for (var i = 1; i <= this.Constant_.WSK_SPINNER_LAYER_COUNT; i++) {
+    for (var i = 1; i <= this.Constant_.MDL_SPINNER_LAYER_COUNT; i++) {
       this.createLayer(i);
     }
 

--- a/src/switch/switch.js
+++ b/src/switch/switch.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * Class constructor for Checkbox WSK component.
- * Implements WSK component design pattern defined at:
+ * Class constructor for Checkbox MDL component.
+ * Implements MDL component design pattern defined at:
  * https://github.com/jasonmayes/mdl-component-design-pattern
  * @param {HTMLElement} element The element that will be upgraded.
  */

--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * Class constructor for Tabs WSK component.
- * Implements WSK component design pattern defined at:
+ * Class constructor for Tabs MDL component.
+ * Implements MDL component design pattern defined at:
  * https://github.com/jasonmayes/mdl-component-design-pattern
  * @param {HTMLElement} element The element that will be upgraded.
  */
@@ -52,10 +52,10 @@ MaterialTabs.prototype.CssClasses_ = {
   ACTIVE_CLASS: 'is-active',
   UPGRADED_CLASS: 'is-upgraded',
 
-  WSK_JS_RIPPLE_EFFECT: 'mdl-js-ripple-effect',
-  WSK_RIPPLE_CONTAINER: 'mdl-tabs__ripple-container',
-  WSK_RIPPLE: 'mdl-ripple',
-  WSK_JS_RIPPLE_EFFECT_IGNORE_EVENTS: 'mdl-js-ripple-effect--ignore-events'
+  MDL_JS_RIPPLE_EFFECT: 'mdl-js-ripple-effect',
+  MDL_RIPPLE_CONTAINER: 'mdl-tabs__ripple-container',
+  MDL_RIPPLE: 'mdl-ripple',
+  MDL_JS_RIPPLE_EFFECT_IGNORE_EVENTS: 'mdl-js-ripple-effect--ignore-events'
 };
 
 /**
@@ -65,9 +65,9 @@ MaterialTabs.prototype.CssClasses_ = {
 MaterialTabs.prototype.initTabs_ = function(e) {
   'use strict';
 
-  if (this.element_.classList.contains(this.CssClasses_.WSK_JS_RIPPLE_EFFECT)) {
+  if (this.element_.classList.contains(this.CssClasses_.MDL_JS_RIPPLE_EFFECT)) {
     this.element_.classList.add(
-      this.CssClasses_.WSK_JS_RIPPLE_EFFECT_IGNORE_EVENTS);
+      this.CssClasses_.MDL_JS_RIPPLE_EFFECT_IGNORE_EVENTS);
   }
 
   // Select element tabs, document panels
@@ -119,12 +119,12 @@ function MaterialTab(tab, ctx) {
   'use strict';
 
   if (tab) {
-    if (ctx.element_.classList.contains(ctx.CssClasses_.WSK_JS_RIPPLE_EFFECT)) {
+    if (ctx.element_.classList.contains(ctx.CssClasses_.MDL_JS_RIPPLE_EFFECT)) {
       var rippleContainer = document.createElement('span');
-      rippleContainer.classList.add(ctx.CssClasses_.WSK_RIPPLE_CONTAINER);
-      rippleContainer.classList.add(ctx.CssClasses_.WSK_JS_RIPPLE_EFFECT);
+      rippleContainer.classList.add(ctx.CssClasses_.MDL_RIPPLE_CONTAINER);
+      rippleContainer.classList.add(ctx.CssClasses_.MDL_JS_RIPPLE_EFFECT);
       var ripple = document.createElement('span');
-      ripple.classList.add(ctx.CssClasses_.WSK_RIPPLE);
+      ripple.classList.add(ctx.CssClasses_.MDL_RIPPLE);
       rippleContainer.appendChild(ripple);
       tab.appendChild(rippleContainer);
     }

--- a/src/textfield/textfield.js
+++ b/src/textfield/textfield.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * Class constructor for Textfield WSK component.
- * Implements WSK component design pattern defined at:
+ * Class constructor for Textfield MDL component.
+ * Implements MDL component design pattern defined at:
  * https://github.com/jasonmayes/mdl-component-design-pattern
  * @param {HTMLElement} element The element that will be upgraded.
  */

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * Class constructor for Tooltip WSK component.
- * Implements WSK component design pattern defined at:
+ * Class constructor for Tooltip MDL component.
+ * Implements MDL component design pattern defined at:
  * https://github.com/jasonmayes/mdl-component-design-pattern
  * @param {HTMLElement} element The element that will be upgraded.
  */


### PR DESCRIPTION
Did not update the compiled files as to not step on any other commits. These changes can naturally get integrated with the next time someone runs it. Turns out, two objects still had WSK in some property names. They were updated as well with this.

Fixes #229 
