### PR TITLE
Remove border-bottom from layout-title (#105)

### DIFF
--- a/src/layout/_layout.scss
+++ b/src/layout/_layout.scss
@@ -113,7 +113,6 @@
     & > .mdl-layout-title {
       line-height: $layout-desktop-header-height;
       padding-left: $layout-header-basic-desktop-indent;
-      border-bottom: 1px solid $layout-drawer-border-color;
 
       @media screen and (max-width: $layout-screen-size-threshold) {
         line-height: $layout-mobile-header-height;


### PR DESCRIPTION
As part of the UX review in #105, this drops the border-bottom from the mdl-layout-title.

![](http://i.imgur.com/gu3qVhk.png)
