### PR TITLE
Update input-text-error-color to latest spec Red (Fixes #109)

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -217,7 +217,7 @@ $input-text-label-color: unquote("rgba(#{$color-black}, 0.26)") !default;
 $input-text-bottom-border-color: unquote("rgba(#{$color-black}, 0.12)") !default;
 $input-text-highlight-color: unquote("rgb(#{$color-primary})") !default;
 $input-text-disabled-color: $input-text-bottom-border-color !default;
-$input-text-error-color: unquote("rgb(#{$palette-red-600})") !default;
+$input-text-error-color: unquote("rgb(222, 50, 38)") !default;
 
 /* ==========  Card  ========== */
 


### PR DESCRIPTION
As validated against http://www.google.com/design/spec/components/text-fields.html#text-field
s-single-line-text-field

r: @Garbee 
