### PR TITLE
Spinner: Hide "Loading..." if inactive

### DIFF
--- a/src/spinner/_spinner.scss
+++ b/src/spinner/_spinner.scss
@@ -23,7 +23,7 @@
   width: $spinner-size;
   height: $spinner-size;
 
-  &:not(.is-upgraded):after {
+  &:not(.is-upgraded).is-active:after {
     content: "Loading...";
   }
 


### PR DESCRIPTION
For un-upgraded spinners, the behavior without `is-active` is
inconsistent with the upgraded behavior. With this patch it's
an empty element in both cases.
