### PR TITLE
Fix visual on component pages (fixes #277)

### DIFF
--- a/docs/_assets/main.css
+++ b/docs/_assets/main.css
@@ -284,3 +284,11 @@ button a {
   color: inherit;
   text-decoration: none;
 }
+
+.component-description {
+  max-width: 720px;
+  padding: 40px;
+}
+.component-description .mdl-button:first-of-type {
+  margin-top: 8px;
+}

--- a/docs/_templates/component.html
+++ b/docs/_templates/component.html
@@ -1,20 +1,15 @@
 {% extends 'layout.html' %}
 
 {% block content %}
+  <div class="component-description mdl-cell mdl-cell--12-col">
+    <div>
+      <a href="../">back to all </a>
+    </div>
 
-<div>
-  <a href="../">back to all </a>
-</div>
+    <div>
+    <a href="demo.html" class="mdl-button mdl-js-button mdl-button--raised">demo</a></button>
+    </div>
 
-<div>
-  <button class="mdl-button mdl-js-button mdl-button--raised">
-    <a href="demo.html">demo</a></button>
-</div>
-
-
-
-{{content|safe}}
-
+    {{content|safe}}
+  </div>
 {% endblock %}
-
-


### PR DESCRIPTION
The grid was being applied from the outer template which made everything look weird. Also fixed the button markup.
