### PR TITLE
Add miniscule delay to tab buttons to fix #310

### DIFF
--- a/src/layout/_layout.scss
+++ b/src/layout/_layout.scss
@@ -555,8 +555,7 @@
       left: 0;
       position: absolute;
       background: $layout-header-tab-highlight;
-      -webkit-animation: border-expand 0.2s cubic-bezier(0.4, 0.0, 0.4, 1) 0s alternate forwards;
-      -moz-animation: border-expand 0.2s cubic-bezier(0.4, 0.0, 0.4, 1) 0s alternate forwards;
+      animation: border-expand 0.2s cubic-bezier(0.4, 0.0, 0.4, 1) 0.01s alternate forwards;
       transition: all 1s cubic-bezier(0.4, 0.0, 1, 1);
     }
 

--- a/src/tabs/_tabs.scss
+++ b/src/tabs/_tabs.scss
@@ -70,8 +70,7 @@
     left: 0px;
     position: absolute;
     background: $tab-highlight-color;
-    -webkit-animation: border-expand 0.2s cubic-bezier(0.4, 0.0, 0.4, 1) 0s alternate forwards;
-    -moz-animation: border-expand 0.2s cubic-bezier(0.4, 0.0, 0.4, 1) 0s alternate forwards;
+    animation: border-expand 0.2s cubic-bezier(0.4, 0.0, 0.4, 1) 0.01s alternate forwards;
     transition: all 1s cubic-bezier(0.4, 0.0, 1, 1);
   }
 
@@ -103,19 +102,7 @@
   }
 }
 
-@-webkit-keyframes border-expand {
-  0% {
-    opacity: 0;
-    width: 0;
-  }
-
-  100% {
-    opacity: 1;
-    width: 100%;
-  }
-}
-
-@-moz-keyframes border-expand {
+@keyframes border-expand {
   0% {
     opacity: 0;
     width: 0;


### PR DESCRIPTION
Follow-up on #310. Not the cleanest solution, but it works.

This also makes use use the prefixer instead of specifying prefixed attributes ourselves.
