### PR TITLE
Active state for navigation links.

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -165,6 +165,8 @@ $layout-nav-color: unquote("rgb(#{$palette-grey-300})") !default;
 $layout-drawer-bg-color: unquote("rgb(#{$palette-grey-50})") !default;
 $layout-drawer-border-color: unquote("rgb(#{$palette-grey-300})") !default;
 $layout-text-color: unquote("rgb(#{$palette-grey-800})") !default;
+$layout-drawer-navigation-link-active-background: unquote("rgb(#{$color-light-contrast})") !default;
+$layout-drawer-naviagtion-link-active-color: unquote("rgb(#{$color-primary})") !default;
 
 // Header
 $layout-header-bg-color: unquote("rgb(#{$color-primary})") !default;

--- a/src/layout/_layout.scss
+++ b/src/layout/_layout.scss
@@ -134,16 +134,21 @@
     & .mdl-navigation {
       flex-direction: column;
       align-items: stretch;
-    }
 
-    & .mdl-navigation__link {
+      &__link {
       display: block;
       flex-shrink: 0;
       padding: 16px $layout-header-desktop-indent;
       margin: 0;
 
-      @media screen and (max-width: $layout-screen-size-threshold) {
-        padding: 16px $layout-header-mobile-indent;
+        @media screen and (max-width: $layout-screen-size-threshold) {
+          padding: 16px $layout-header-mobile-indent;
+        }
+
+        &--current {
+            background-color: $layout-drawer-navigation-link-active-background;
+            color: $layout-drawer-naviagtion-link-active-color;
+        }
       }
     }
 
@@ -350,16 +355,15 @@
         line-height: $layout-header-desktop-row-height;
         padding: 0 $layout-header-desktop-indent;
 
+        &:hover {
+          background-color: $layout-header-nav-hover-color;
+        }
+
         @media screen and (max-width: $layout-screen-size-threshold) {
           line-height: $layout-header-mobile-row-height;
           padding: 0 $layout-header-mobile-indent;
         }
-      }
-
-      & .mdl-navigation__link:hover {
-        background-color: $layout-header-nav-hover-color;
-      }
-    }
+      }    }
 
   // Obfuscator.
   .mdl-layout__obfuscator {


### PR DESCRIPTION
This provides us a `--current` modifier for a navigation link in the drawer. I tried to adhear to what we discussed in issue #99 in terms of MD alignment as closely as I could. Used the ripple effect background color as the background color as the specification states, then apply the primary color of the theme to the text.

Warning, this looks ugly in the Dashboard template. So that in particular should get addressed on its own.
