### PR TITLE
Fix overflow bars on code samples.

### DIFF
--- a/docs/_assets/main.css
+++ b/docs/_assets/main.css
@@ -27,6 +27,9 @@ html > body {
   padding: 0px;
   font-size: 100%;
 }
+.docs-layout pre[class*=language-]>code[data-language] {
+  overflow:auto;
+}
 pre[class*=language-]>code[data-language="markup"]::before {
   content: "html";
 }


### PR DESCRIPTION
Currently all code samples have overflow scrollbars due to prism setting overflow to a set "scroll" state. Setting this to "auto" shows no scrollbars unless necessary.
