### PR TITLE
Fixing demo so card headers display as they should.

### DIFF
--- a/docs/_assets/main.css
+++ b/docs/_assets/main.css
@@ -356,6 +356,11 @@ body:not(.about) .docs-layout-title {
   color: #c2185b;
 }
 
+.docs-layout-content h2.mdl-card__title-text {
+  padding-top: 0;
+  margin-bottom: 0;
+}
+
 .docs-layout-content a {
   @extend mdl-color-text--cyan-600;
   text-decoration: none;


### PR DESCRIPTION
Existing setup causes major excessive space around header due to h2 styling. This addresses that for the card demos.
