### PR TITLE
Add hidden attribute reset for legacy browser support.

### DIFF
--- a/src/resets/_resets.scss
+++ b/src/resets/_resets.scss
@@ -31,3 +31,11 @@ body {
 main {
   display: block;
 }
+
+/*
+* Apply no display to elements with the hidden attribute.
+* IE 9 and 10 support.
+*/
+*[hidden] {
+  display: none !important; 
+}


### PR DESCRIPTION
Using the hidden attribute in the snackbar setup for simplicity. This helps with browser support (primarily IE10 in the case of snackbar.)
