### PR TITLE
add publish:gcs gulp task to push microsite to gcs bucket

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -62,11 +62,11 @@
       </div>
       <nav class="docs-navigation mdl-navigation">
         <a href="{{page.include_prefix}}" class="mdl-navigation__link about">About</a>
-        <a href="{{page.include_prefix}}started" class="mdl-navigation__link started">Getting Started</a>
-        <a href="{{page.include_prefix}}templates" class="mdl-navigation__link templates">Templates</a>
-        <a href="{{page.include_prefix}}components" class="mdl-navigation__link components">Components</a>
-        <a href="{{page.include_prefix}}styles" class="mdl-navigation__link styles">Styles</a>
-        <a href="{{page.include_prefix}}customize" class="mdl-navigation__link customize">Customize</a>
+        <a href="{{page.include_prefix}}started/index.html" class="mdl-navigation__link started">Getting Started</a>
+        <a href="{{page.include_prefix}}templates/index.html" class="mdl-navigation__link templates">Templates</a>
+        <a href="{{page.include_prefix}}components/index.html" class="mdl-navigation__link components">Components</a>
+        <a href="{{page.include_prefix}}styles/index.html" class="mdl-navigation__link styles">Styles</a>
+        <a href="{{page.include_prefix}}customize/index.html" class="mdl-navigation__link customize">Customize</a>
       </nav>
       <div class="docs-special">
         <a href="https://github.com/google/material-design-lite" class="github docs-special--button"><i class="material-icons">link</i><span>GitHub</span></a>

--- a/docs/_templates/templates.html
+++ b/docs/_templates/templates.html
@@ -16,7 +16,7 @@
       </button>
       Download
     </a>
-    <a href="{{page.include_prefix}}templates/{{ template.name }}" target="_blank" class="mdl-cell mdl-cell--6-col-desktop mdl-cell--4-col-tablet mdl-cell--2-col-phone">
+    <a href="{{page.include_prefix}}templates/{{ template.name }}/index.html" target="_blank" class="mdl-cell mdl-cell--6-col-desktop mdl-cell--4-col-tablet mdl-cell--2-col-phone">
       <button class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--icon">
         <i class="material-icons">arrow_forward</i>
       </button>


### PR DESCRIPTION
In addition to adding the publish:gcs gulp task to push the microsite to Google Cloud Storage, this PR also improves the publish:cdn task, which pushes just the runtime elements (CSS+JS) to GCS. The latter task may be obsoleted by the former, since the complete microsite includes the runtime elements too. But I'm leaving the former task intact because it makes that piece explicit and independent of the microsite distribution. Also, it gives us some flexibility if we ever wanted to serve the microsite and the runtime objects from diff places (probably unlikely).
