### PR TITLE
Make mocha-phantom use tap reporter

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -239,7 +239,7 @@ gulp.task('default', ['clean', 'mocha'], function (cb) {
 
 gulp.task('mocha', ['styles'], function () {
   return gulp.src('./test/index.html')
-    .pipe($.mochaPhantomjs({reporter: 'list'}));
+    .pipe($.mochaPhantomjs({reporter: 'tap'}));
 });
 
 gulp.task('test', ['jshint', 'jscs', 'mocha']);


### PR DESCRIPTION
Especially useful on dumb or just weird terminals.
Before:

![screenshot from 2015-06-24 11 42 01](https://cloud.githubusercontent.com/assets/25405/8328176/6577e846-1a66-11e5-92dd-1fd5bd9a8eb6.png)

After:

![screenshot from 2015-06-24 11 42 38](https://cloud.githubusercontent.com/assets/25405/8328179/6a1d53ae-1a66-11e5-8326-d0bd8f994792.png)

R: @marcacohen 
