### PR TITLE
Assign class string as widget name.

### DIFF
--- a/src/data-table/data-table.js
+++ b/src/data-table/data-table.js
@@ -73,13 +73,13 @@ MaterialDataTable.prototype.selectRow_ = function(checkbox, row, rows) {
       if (checkbox.checked) {
         for (i = 0; i < rows.length; i++) {
           el = rows[i].querySelector('td').querySelector('.mdl-checkbox');
-          el.widget.check();
+          el.MaterialCheckbox.check();
           rows[i].classList.add(this.CssClasses_.IS_SELECTED);
         }
       } else {
         for (i = 0; i < rows.length; i++) {
           el = rows[i].querySelector('td').querySelector('.mdl-checkbox');
-          el.widget.uncheck();
+          el.MaterialCheckbox.uncheck();
           rows[i].classList.remove(this.CssClasses_.IS_SELECTED);
         }
       }

--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -108,7 +108,7 @@ var componentHandler = (function() {
 
         if (registeredClass.widget) {
           // Assign per element instance for control over API
-          element.widget = instance;
+          element[jsClass] = instance;
         }
       } else {
         throw 'Unable to find a registered component for the given class.';

--- a/src/progress/demo.html
+++ b/src/progress/demo.html
@@ -17,10 +17,10 @@
   </div>
   <script>
     document.querySelector('#p1').addEventListener('mdl-componentupgraded', function() {
-      this.widget.setProgress(44);
+      this.MaterialProgress.setProgress(44);
     });
     document.querySelector('#p3').addEventListener('mdl-componentupgraded', function() {
-      this.widget.setProgress(33);
-      this.widget.setBuffer(87);
+      this.MaterialProgress.setProgress(33);
+      this.MaterialProgress.setBuffer(87);
     });
   </script>

--- a/test/unit/menu.js
+++ b/test/unit/menu.js
@@ -37,10 +37,10 @@
       componentHandler.upgradeElement(el, 'MaterialMenu');
 
       it('should start the showing animation on show()', function(done) {
-        expect($(el.widget.container_)).to.not.have.class('is-visible');
-        el.widget.show();
+        expect($(el.MaterialMenu.container_)).to.not.have.class('is-visible');
+        el.MaterialMenu.show();
         window.setTimeout(function() {
-          expect($(el.widget.container_)).to.have.class('is-visible');
+          expect($(el.MaterialMenu.container_)).to.have.class('is-visible');
 
           var ev = document.createEvent('HTMLEvents');
           ev.initEvent('transitionend', true, true)
@@ -50,10 +50,10 @@
       });
 
       it('should start the hiding animation on hide()', function(done) {
-        expect($(el.widget.container_)).to.have.class('is-visible');
-        el.widget.hide();
+        expect($(el.MaterialMenu.container_)).to.have.class('is-visible');
+        el.MaterialMenu.hide();
         window.setTimeout(function() {
-          expect($(el.widget.container_)).to.not.have.class('is-visible');
+          expect($(el.MaterialMenu.container_)).to.not.have.class('is-visible');
 
           var ev = document.createEvent('HTMLEvents');
           ev.initEvent('transitionend', true, true)
@@ -63,10 +63,10 @@
       });
 
       it('should start the showing animating on toggle() when invisible', function(done) {
-        expect($(el.widget.container_)).to.not.have.class('is-visible');
-        el.widget.toggle();
+        expect($(el.MaterialMenu.container_)).to.not.have.class('is-visible');
+        el.MaterialMenu.toggle();
         window.setTimeout(function() {
-          expect($(el.widget.container_)).to.have.class('is-visible');
+          expect($(el.MaterialMenu.container_)).to.have.class('is-visible');
 
           var ev = document.createEvent('HTMLEvents');
           ev.initEvent('transitionend', true, true)
@@ -76,10 +76,10 @@
       });
 
       it('should start the hiding animating on toggle() when visible', function(done) {
-        expect($(el.widget.container_)).to.have.class('is-visible');
-        el.widget.toggle();
+        expect($(el.MaterialMenu.container_)).to.have.class('is-visible');
+        el.MaterialMenu.toggle();
         window.setTimeout(function() {
-          expect($(el.widget.container_)).to.not.have.class('is-visible');
+          expect($(el.MaterialMenu.container_)).to.not.have.class('is-visible');
 
           var ev = document.createEvent('HTMLEvents');
           ev.initEvent('transitionend', true, true)
@@ -103,12 +103,12 @@
 
       var el = ctr.querySelector('ul');
       componentHandler.upgradeElement(el, 'MaterialMenu');
-      
+
       var ev = document.createEvent('MouseEvents');
       ev.initEvent('click', true, true);
       ctr.querySelector('#clickable').dispatchEvent(ev);
       window.setTimeout(function() {
-        expect($(el.widget.container_)).to.have.class('is-visible');
+        expect($(el.MaterialMenu.container_)).to.have.class('is-visible');
         document.body.removeChild(ctr);
         done();
       }, 100);

--- a/test/unit/progress.js
+++ b/test/unit/progress.js
@@ -30,12 +30,12 @@ describe('progress tests', function () {
   it('Should have a setProgress method', function () {
     var el = document.createElement('div');
     componentHandler.upgradeElement(el, 'MaterialProgress');
-    expect(el.widget.setProgress).to.be.a('function');
+    expect(el.MaterialProgress.setProgress).to.be.a('function');
   });
 
   it('Should have a setBuffer method', function () {
     var el = document.createElement('div');
     componentHandler.upgradeElement(el, 'MaterialProgress');
-    expect(el.widget.setBuffer).to.be.a('function');
+    expect(el.MaterialProgress.setBuffer).to.be.a('function');
   });
 });

--- a/test/unit/spinner.js
+++ b/test/unit/spinner.js
@@ -30,15 +30,15 @@ describe('spinner tests', function () {
   it('Should start a MaterialSpinner successfully', function () {
     var el = document.createElement('div');
     componentHandler.upgradeElement(el, 'MaterialSpinner');
-    el.widget.start();
+    el.MaterialSpinner.start();
     expect($(el)).to.have.class('is-active');
   });
 
   it('Should stop a MaterialSpinner successfully', function () {
     var el = document.createElement('div');
     componentHandler.upgradeElement(el, 'MaterialSpinner');
-    el.widget.start();
-    el.widget.stop();
+    el.MaterialSpinner.start();
+    el.MaterialSpinner.stop();
     expect($(el)).to.not.have.class('is-active');
   });
 


### PR DESCRIPTION
Fixes #352 

This PR sets the ClassAsString to be assigned for widget property names. This means a user can add any number of widget's to an element instead of just one.

For example:

``` javascript
var el = document.querySelector('.mdl-js-progress');
// Old behavior
el.widget.setProgress()
// New behavior
el.MaterialProgress.setProgress()
```

The primary con here is naming is restricted to properties that don't already exist on HTMLElement objects, but this shouldn't be a major issue.
