### PR TITLE
Hide tooltips differently for size calculations (fixes #493)

### DIFF
--- a/src/tooltip/_tooltip.scss
+++ b/src/tooltip/_tooltip.scss
@@ -24,17 +24,18 @@
   background: $tooltip-background-color;
   border-radius: 2px;
   color: $tooltip-text-color;
-  display: none;
+  display: inline-block;
   font-size: 10px;
   font-weight: 500;
   line-height: 14px;
   max-width: 170px;
   position: fixed;
+  top: -500px;
+  left: -500px;
   padding: 8px;
   text-align: center;
 }
 .mdl-tooltip.is-active {
-  display: inline-block;
   animation: pulse 200ms $animation-curve-linear-out-slow-in forwards;
 }
 


### PR DESCRIPTION
The tooltip has no dimensions when hidden with `display: none;`. So I changed that to have the tooltip centered again. @sgomes @addyosmani PTAL!
