### PR TITLE
Generate bundles for JS/CSS as well as site/templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "gulp-connect": "^2.2.0",
     "gulp-css-inline-images": "^0.1.1",
     "gulp-csso": "^1.0.0",
+    "gulp-filter": "^2.0.2",
     "gulp-flatten": "0.0.4",
     "gulp-front-matter": "^1.2.2",
     "gulp-gh-pages": "^0.5.0",


### PR DESCRIPTION
r: @marcacohen 

After tagging the release I noticed that we're currently generating a release containing the CSS/JS/Source Map files but should probably also create a release with the templates/sites and this content too (similar to Bootstrap). Wdyt?

Moved this logic out from the `publish:code` step into a `gulp zip:mdl` and `gulp zip:site` so they are now dependencies. Also noticed we should probably be including the LICENSE file somewhere in the output :)
