### PR TITLE
Give <html> and <body> a heigth in resets (fixes #541)

### DIFF
--- a/src/resets/_resets.scss
+++ b/src/resets/_resets.scss
@@ -18,6 +18,19 @@
 @import "../resets/mobile";
 
 /*
+ * Make body take up the entire screen
+ */
+html {
+  width: 100%;
+  height: 100%;
+}
+
+body {
+  width: 100%;
+  min-height: 100%;
+}
+
+/*
 * Remove body margin so layout containers don't cause extra overflow.
 */
 body {


### PR DESCRIPTION
The visual tests (`mdl.surma`, 2015/06/30 11:06 UTC) don’t show any notable regressions except for scrollbars now showing up in the `demo.html` in IE. Please take a look and let me know if this is actually mergeable.

PTAL @addyosmani @sgomes 
