### PR TITLE
Fixes #547 - avoid duplicate license comments in minified JS build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -217,11 +217,13 @@ gulp.task('scripts', function () {
     .pipe($.sourcemaps.init())
     // Concatenate Scripts
     .pipe($.concat('material.js'))
-    .pipe($.header(banner, {pkg: pkg}))
     .pipe(gulp.dest('./dist'))
     // Minify Scripts
-    .pipe($.uglify({preserveComments: 'some', sourceRoot: '.',
-        sourceMapIncludeSources: true}))
+    .pipe($.uglify({
+      sourceRoot: '.',
+      sourceMapIncludeSources: true
+    }))
+    .pipe($.header(banner, {pkg: pkg}))
     .pipe($.concat('material.min.js'))
     // Write Source Maps
     .pipe($.sourcemaps.write('./'))


### PR DESCRIPTION
Prior to this fix we saw repeated comments in the build for minified
JS. Whilst this is otherwise fine for the unminified build (at this
time) we shouldn’t be including dupes for license headers.

Consequently, this change also shaves 10KB off our minified JS (57KB vs 67KB).

r @sgomes @surma 
