### PR TITLE
Fix components page history behavior

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -63,7 +63,7 @@
           <a href="{{page.include_prefix}}" class="mdl-navigation__link about">About</a>
           <a href="{{page.include_prefix}}started/index.html" class="mdl-navigation__link started">Getting Started</a>
           <a href="{{page.include_prefix}}templates/index.html" class="mdl-navigation__link templates">Templates</a>
-          <a href="{{page.include_prefix}}components/index.html#" class="mdl-navigation__link components">Components</a>
+          <a href="{{page.include_prefix}}components/index.html" class="mdl-navigation__link components">Components</a>
           <a href="{{page.include_prefix}}styles/index.html" class="mdl-navigation__link styles">Styles</a>
           <a href="{{page.include_prefix}}customize/index.html" class="mdl-navigation__link customize">Customize</a>
           <div class="spacer"></div>


### PR DESCRIPTION
- Avoid duplicate navigation history entries and loop on back button when clicking the compspage index
- Avoid duplicate navigation history entries and loop on back button when entering a hash fragment unknown to the navigation page
- Avoid entire page reload when clicking on the compspage index

Please @addyosmani @sgomes 
