### PR TITLE
Avoid public-read ACL on GCS buckets

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -506,7 +506,6 @@ gulp.task('zip:templates', function() {
 gulp.task('publish:code', ['zip:mdl', 'zip:templates'], function() {
   // Build dest path, info message, cache control and gsutil cmd to copy
   // each object into a GCS bucket. The dest is a version specific path.
-  // The gsutil -a option sets the ACL on each object copied.
   // The gsutil -m option requests parallel copies.
   // The gsutil -h option is used to set metadata headers
   // (cache control, in this case).
@@ -564,7 +563,7 @@ function mdlPublish(pubScope) {
   // Build gsutil commands to recursively sync local distribution tree
   // to the dest bucket and to recursively set permissions to public-read.
   // The gsutil -m option requests parallel copies.
-  // The gsutil -R option does recursive acl setting.
+  // The gsutil -R option is used for recursive file copy.
   // The gsutil -h option is used to set metadata headers (cache control, in this case).
   var gsutilSyncCmd = 'gsutil -m rsync -d -R dist ' + dest;
   var gsutilCacheCmd = 'gsutil -m setmeta ' + cacheControl + ' ' + dest + '/**';


### PR DESCRIPTION
Setting a bucket or object to public-read will remove all OWNER and WRITER permissions from everyone except the bucket or object owner.

This is why deploying from one account would then fail publishing from another.

The ACLs are now updated automatically by setting default ACL on the buckets:

```
$ gsutil defacl ch -g all:R -u service-account-email:O gs://bucket
```

`all:R` makes sure all objects will be READable by anyone on the web.

`service-account-email:O` will add the service account to the OWNERs of each uploaded object so that drone can push changes to the staging bucket even if someone else has previously made a manual update.

The above has already been done to the staging bucket.

@marcacohen I finally got to the bottom of the weirdness observed with access issues using gsutil. It seems to keep access and refresh tokens from another account previously set by `gcloud config set account <acct>` - it's exactly what I've been doing, switching back and forth from mine to service account. That's why I couldn't understand a thing. I'll file an internal bug. I had to resort to login with different accounts from different machines.
