### PR TITLE
Codepen improvements

### DIFF
--- a/docs/_assets/main.css
+++ b/docs/_assets/main.css
@@ -632,6 +632,9 @@ body:not(.about) .mdl-navigation__link.download > button {
   color: rgba(255,255,255,0.5);
   background-color: rgba(0,0,0,0.6);
 }
+.snippet-group .snippet-code .codepen-extra-css {
+  display:none;
+}
 .no-flash .snippet-group .snippet-code code.highlighted::after,
 .no-flash .snippet-group .copy{
   display: none;

--- a/docs/_templates/snippets.html
+++ b/docs/_templates/snippets.html
@@ -45,6 +45,10 @@
     </div>
   </div>
   <div class="snippet-code">
-    <pre class="language-markup codepen-button-enabled">{% for snippet in snippet_group %}{% set snippet_file = "../../src/" + component_name + "/snippets/" + snippet.file %}<code id="{{ component_name }}/{{ snippet.file }}">{% filter e('html') %}{% include snippet_file ignore missing %}{% endfilter %}</code>{%- endfor %}</pre>
+    <pre class="language-markup codepen-button-enabled">{% for snippet in snippet_group %}{% set snippet_file = "../../src/" + component_name + "/snippets/" + snippet.file %}<code id="{{ component_name }}/{{ snippet.file }}">{% filter e('html') %}{% include snippet_file ignore missing %}{% endfilter %}</code><div class="codepen-extra-css">&lt;style&gt;{% set extra_css_file = "../../src/" + component_name + "/snippets/" + snippet.extra_codepen_css %}{% include extra_css_file ignore missing %}&lt;/style&gt;</div>{%- endfor %}{% if snippet_group.length !== 1 || !snippet_group[0].full_width %}<div class="codepen-extra-css">&lt;style&gt;
+  body {
+    padding: 40px;
+  }
+&lt;/style&gt;</div>{% endif %}</pre>
   </div>
 </div>


### PR DESCRIPTION
This fixes a bunch of issues
- Open in new tab: fixes #606 
- Replaces relative image URLs: fixes #460
- Processing only done when the button is clicked
- Inserting body padding only for demos that are not full-width: fixes #607 and fixes #459 
- Allow inserting custom codepen CSS for each snippet with the `extra_codepen_css` in components.md: fixes #607
- Switched fro `innerText` to `textContent`: fixes part of #616
