### PR TITLE
Adding a maximum header height for about page

### DIFF
--- a/docs/_assets/main.css
+++ b/docs/_assets/main.css
@@ -4,6 +4,7 @@ html > body {
 }
 .docs-layout .docs-layout-header.mdl-layout__header {
   height: 560px;
+  max-height: 50%;
   flex-shrink: 0;
   background-size: auto;
   background-repeat: no-repeat;


### PR DESCRIPTION
@addyosmani @santokii PTAL.

This is how the about page looks on a Nexus 7 without the fix:

![image](https://cloud.githubusercontent.com/assets/409615/8497348/5d4c4cf6-2174-11e5-9d15-3393bd301740.png)

With the fix:

![image](https://cloud.githubusercontent.com/assets/409615/8497367/8801d614-2174-11e5-818a-b62ebae4b890.png)
