### PR TITLE
Fixes all styling discrepancy issues with snippets opened in codepen.

### DIFF
--- a/docs/_assets/codepen.js
+++ b/docs/_assets/codepen.js
@@ -21,19 +21,25 @@ function CodeBlockCodePen() {
   this.init();
 }
 
-
-
 // Also insert the MDL Library.
 CodeBlockCodePen.prototype.MDLIBS = [
   // TODO: Remove below before launch. For testing only.
   '<!-- For testing. TODO: Remove before launch -->',
-  '<link rel="stylesheet" href="http://mdl-staging.storage.googleapis.com/material.min.css">',
-  '<script src="http://mdl-staging.storage.googleapis.com/material.min.js"></script>',
+  '<script src="https://mdl-staging.storage.googleapis.com/material.min.js"></script>',
   '<!-- Material Design Lite -->',
   '<script src="$$hosted_libs_prefix$$/$$version$$/material.min.js"></script>',
-  '<link rel="stylesheet" href="$$hosted_libs_prefix$$/$$version$$/material.indigo-pink.min.css">',
   '<!-- Material Design icon font -->',
   '<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">'
+];
+
+// Also insert the MDL CSS.
+CodeBlockCodePen.prototype.MDLCSS = [
+  // TODO: Remove below before launch. For testing only.
+  '/* For testing. TODO: Remove before launch */',
+  '@import url("https://mdl-staging.storage.googleapis.com/material.min.css");',
+  '/* Material Design Lite */',
+  '@import url("$$hosted_libs_prefix$$/$$version$$/material.indigo-pink.min.css");',
+  '',
 ];
 
 /**
@@ -81,7 +87,7 @@ CodeBlockCodePen.prototype.clickHandler = function(form, pre) {
       window.location.origin + '/assets/demos/');
 
     // Extract <style> blocks from the source code.
-    var styleLines = [];
+    var styleLines = this.MDLCSS.slice();
 
     while (code.indexOf('<style>') !== -1) {
       var startIndex = code.indexOf('<style>');

--- a/docs/_templates/snippets.html
+++ b/docs/_templates/snippets.html
@@ -48,6 +48,7 @@
     <pre class="language-markup codepen-button-enabled">{% for snippet in snippet_group %}{% set snippet_file = "../../src/" + component_name + "/snippets/" + snippet.file %}<code id="{{ component_name }}/{{ snippet.file }}">{% filter e('html') %}{% include snippet_file ignore missing %}{% endfilter %}</code><div class="codepen-extra-css">&lt;style&gt;{% set extra_css_file = "../../src/" + component_name + "/snippets/" + snippet.extra_codepen_css %}{% include extra_css_file ignore missing %}&lt;/style&gt;</div>{%- endfor %}{% if snippet_group.length !== 1 || !snippet_group[0].full_width %}<div class="codepen-extra-css">&lt;style&gt;
   body {
     padding: 40px;
+    background-color: #fafafa;
   }
 &lt;/style&gt;</div>{% endif %}</pre>
   </div>


### PR DESCRIPTION
We have to rely on an @import in the CSS instead of adding the MDL CSS in the HTML. This is not consistent with what we ask developers to do in the getting started guide and we'll try to fix this later.

As per the previous discussion the other way to fix this is to make some snippets inline CSS rules more specific but @sgomes is against the idea.

@addyosmani PTAL

Closes #627 
