### PR TITLE
Add artwork to ribbons on styles page

### DIFF
--- a/docs/_assets/colors.svg
+++ b/docs/_assets/colors.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="195px" height="183px" viewBox="0 0 195 183" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.3.1 (12002) - http://www.bohemiancoding.com/sketch -->
+    <title>Oval 43 + Oval 43 + Oval 43</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="03-Styles" sketch:type="MSArtboardGroup" transform="translate(-623.000000, -3944.000000)">
+            <g id="Oval-43-+-Oval-43-+-Oval-43" sketch:type="MSLayerGroup" transform="translate(623.000000, 3944.000000)">
+                <path d="M130,182.5 C165.622366,182.5 194.5,153.622366 194.5,118 C194.5,82.3776336 165.622366,53.5 130,53.5 C94.3776336,53.5 65.5,82.3776336 65.5,118 C65.5,153.622366 94.3776336,182.5 130,182.5 L130,182.5 Z M130,179.5 C96.0344879,179.5 68.5,151.965512 68.5,118 C68.5,84.0344879 96.0344879,56.5 130,56.5 C163.965512,56.5 191.5,84.0344879 191.5,118 C191.5,151.965512 163.965512,179.5 130,179.5 L130,179.5 Z" id="Shape" fill="#6200EE" sketch:type="MSShapeGroup"></path>
+                <path d="M65,182.5 C100.622366,182.5 129.5,153.622366 129.5,118 C129.5,82.3776336 100.622366,53.5 65,53.5 C29.3776336,53.5 0.5,82.3776336 0.5,118 C0.5,153.622366 29.3776336,182.5 65,182.5 L65,182.5 Z M65,179.5 C31.0344879,179.5 3.5,151.965512 3.5,118 C3.5,84.0344879 31.0344879,56.5 65,56.5 C98.9655121,56.5 126.5,84.0344879 126.5,118 C126.5,151.965512 98.9655121,179.5 65,179.5 L65,179.5 Z" id="Shape" fill="#F0F5C1" sketch:type="MSShapeGroup"></path>
+                <path d="M95,129.5 C130.622366,129.5 159.5,100.622366 159.5,65 C159.5,29.3776336 130.622366,0.5 95,0.5 C59.3776336,0.5 30.5,29.3776336 30.5,65 C30.5,100.622366 59.3776336,129.5 95,129.5 L95,129.5 Z M95,126.5 C61.0344879,126.5 33.5,98.9655121 33.5,65 C33.5,31.0344879 61.0344879,3.5 95,3.5 C128.965512,3.5 156.5,31.0344879 156.5,65 C156.5,98.9655121 128.965512,126.5 95,126.5 L95,126.5 Z" id="Shape" fill="#FF897D" sketch:type="MSShapeGroup"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/docs/_assets/icons.svg
+++ b/docs/_assets/icons.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="168px" height="152px" viewBox="0 0 168 152" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.3.1 (12002) - http://www.bohemiancoding.com/sketch -->
+    <title>Shape</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="03-Styles" sketch:type="MSArtboardGroup" transform="translate(-636.000000, -1338.000000)" stroke="#F5C7C1" fill="#F5C6C1">
+            <g id="Rectangle-142-+-ICONS-+-Shape" sketch:type="MSLayerGroup" transform="translate(0.000000, 1269.000000)">
+                <g id="ICONS-+-Shape" transform="translate(637.000000, 70.000000)" sketch:type="MSShapeGroup">
+                    <path d="M107.464654,1.53846154 L123.610481,17.2615385 L123.994722,17.6923077 L124.617194,17.6923077 L149.592889,17.6923077 C157.784917,17.6923077 164.455349,24.5923077 164.455349,33.0769231 L164.455349,133.076923 C164.455349,141.561538 157.792602,148.461538 149.592889,148.461538 L16.399426,148.461538 C8.19971298,148.461538 1.53696588,141.561538 1.53696588,133.076923 L1.53696588,33.0769231 C1.53696588,24.5923077 8.19971298,17.6923077 16.399426,17.6923077 L41.3751215,17.6923077 L41.9975927,17.6923077 L42.4433128,17.2615385 L58.6429332,1.53846154 L107.587612,1.53846154 L107.464654,1.53846154 Z M107.971853,0 L58.020462,0 L41.3674367,16.1538462 L16.3917411,16.1538462 C7.20068515,16.1538462 0,23.8769231 0,33.0769231 L0,133.076923 C0,142.284615 7.20068515,150 16.399426,150 L149.600574,150 C158.79163,150 166,142.276923 166,133.076923 L166,33.0769231 C166,23.8769231 158.799315,16.1538462 149.600574,16.1538462 L124.624878,16.1538462 L107.971853,0 L107.971853,0 Z" id="Shape"></path>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/docs/_assets/main.css
+++ b/docs/_assets/main.css
@@ -1037,6 +1037,42 @@ code[class*=language-], pre[class*=language-] {
   margin: 40px 0;
   margin-left: -40px;
   height: 320px;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: stretch;
+}
+.styles .styles__ribbon > .ribbon__imagecontainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+.styles .styles__ribbon > .ribbon__imagecontainer > .ribbon__image {
+  display: block;
+  margin-bottom: 16px;
+  border: 0;
+}
+.styles .styles__ribbon > .ribbon__imagecontainer > .ribbon__caption {
+  color: white;
+  text-transform: uppercase;
+  font-size: 16px;
+  font-weight: 300;
+  height: 24px;
+  line-height: 24px;
+  text-align: center;
+}
+.styles .styles__ribbon > .ribbon__imagecontainer > .ribbon__caption.ribbon__caption--split {
+  width: 100%;
+  text-align: left;
+}
+.styles .styles__ribbon > .ribbon__imagecontainer > .ribbon__caption > .material-icons {
+  height: 24px;
+  line-height: 24px;
+  vertical-align: middle;
+}
+.styles .styles__ribbon > .ribbon__imagecontainer > .ribbon__caption.ribbon__caption--split > .material-icons {
+  float: right;
 }
 .styles .content .docs-text-styling h3 {
   text-transform: none;

--- a/docs/_pages/styles.md
+++ b/docs/_pages/styles.md
@@ -78,7 +78,13 @@ include_prefix: ../
     </div>
   </div>
 
-  <div class="styles__ribbon">
+  <div class="styles__ribbon styles__ribbon--icons">
+    <a href="http://google.github.io/material-design-icons/" class="ribbon__imagecontainer">
+      <img src="../assets/icons.svg" class="ribbon__image">
+      <div class="ribbon__caption ribbon__caption--split">
+        Preview icons <i class="material-icons">arrow_forward</i>
+      </div>
+    </a>
   </div>
 
   <div class="styles__content mdl-grid mdl-grid--no-spacing">
@@ -178,7 +184,14 @@ include_prefix: ../
       All icons are released under <strong>Attribution 4.0 International license</strong>.
     </div>
   </div>
-  <div class="styles__ribbon"></div>
+  <div class="styles__ribbon styles__ribbon--colors">
+    <a class="ribbon__imagecontainer">
+      <img src="../assets/colors.svg" class="ribbon__image">
+      <div class="ribbon__caption">
+        Color palette
+      </div>
+    </a>
+  </div>
   <div class="styles__content mdl-grid mdl-grid--no-spacing">
     <div class="mdl-cell mdl-cell--4-col mdl-cell--8-col-tablet left-col">
       <h3>Color palette</h3>


### PR DESCRIPTION
Got the artwork for the ribbons from @santokii. This PR incorporates them.

Looks good in all browsers and mobile. 
- Icon ribbon links to http://google.github.io/material-design-icons/
- Color palette ribbon does not link to anything

![screenshot 2015-07-03 12 33 03](https://cloud.githubusercontent.com/assets/234957/8498576/7794db62-2180-11e5-9058-c8b28740bd77.png)
![screenshot 2015-07-03 12 33 09](https://cloud.githubusercontent.com/assets/234957/8498577/7794ea08-2180-11e5-9bb7-ca966fe2955f.png)

@addyosmani @santokii pls ack.
