### PR TITLE
Further codepen fixes

### DIFF
--- a/docs/_templates/snippets.html
+++ b/docs/_templates/snippets.html
@@ -51,8 +51,9 @@
     background: #fafafa;
     position: relative;
   }
-  body > * {
+  body > *[class^="mdl-"] {
     margin: 20px 20px;
+    float: left;
   }
 &lt;/style&gt;</div>{% endif %}</pre>
   </div>


### PR DESCRIPTION
- Extract the `<script>` tags into the JS codepen tab
- Add light grey background into codepen to match the site styling (makes white components look better)
- Add margin in between each components to avoid them looking squashed (for example the 2 progress bars)

@addyosmani  PTAL

Fixes #655 
