### PR TITLE
Small fix to the vertical centering of the new copy-to-clipboard icon

### DIFF
--- a/docs/_assets/main.css
+++ b/docs/_assets/main.css
@@ -577,6 +577,7 @@ body:not(.about) .mdl-navigation__link.download > button {
   text-transform: none;
   font-size: 13px;
   font-weight: normal;
+  line-height: 28px;
 }
 .snippet-group .snippet-caption .copy-to-clipboard-button .material-icons {
   background-color: #00BCD4;
@@ -586,6 +587,7 @@ body:not(.about) .mdl-navigation__link.download > button {
   line-height: 24px;
   font-size: 16px;
   color: white;
+  top: 3px;
 }
 .snippet-group .snippet-caption .snippet-copy embed {
   height: 100%;


### PR DESCRIPTION
Slightly improves the vertical centering of the new copy-to-clipboard icon.

It seemed a little bit off. With this PR it is now like this:

![image](https://cloud.githubusercontent.com/assets/3766663/8504229/d159c39a-21cd-11e5-92af-4189cb99cc3f.png)
