### PR TITLE
Replace HTML escaping to use URL escaping…

### DIFF
--- a/docs/_templates/snippets.html
+++ b/docs/_templates/snippets.html
@@ -36,7 +36,7 @@
                      scale="exactfit"
                      quality="low"
                      wmode="transparent"
-                     FlashVars="text={% filter e('html') %}{% include snippet_file ignore missing %}{% endfilter %}"/>
+                     FlashVars="text={% filter url_encode %}{% include snippet_file ignore missing %}{% endfilter %}"/>
             </object>
           </button>
         </div>


### PR DESCRIPTION
… for the copy-paste text passed to the flash object.

This was causing an issue with certain special character like `%`. URL escaping is actually what the Adobe documentation says we should use: http://help.adobe.com/en_US/flex/using/WS2db454920e96a9e51e63e3d11c0bf626ae-7feb.html#WS2db454920e96a9e51e63e3d11c0bf69084-7f5e__WS2db454920e96a9e51e63e3d11c0bf626ae-7ff7
