### PR TITLE
Add syntax highlighting for bash code blocks.

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -133,6 +133,7 @@
     <script src="{{page.include_prefix}}assets/prism-markup.min.js"></script>
     <script src="{{page.include_prefix}}assets/prism-javascript.min.js"></script>
     <script src="{{page.include_prefix}}assets/prism-css.min.js"></script>
+    <script src="{{page.include_prefix}}assets/prism-bash.min.js"></script>
     <script src="{{page.include_prefix}}assets/main.js"></script>
     <!-- Built with love using Material Design Lite -->
   </body>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -426,6 +426,7 @@ gulp.task('assets', function () {
       'node_modules/prismjs/components/prism-markup.min.js',
       'node_modules/prismjs/components/prism-javascript.min.js',
       'node_modules/prismjs/components/prism-css.min.js',
+      'node_modules/prismjs/components/prism-bash.min.js',
       'node_modules/prismjs/dist/prism-default/prism-default.css'
     ])
     .pipe($.if(/\.js/i, $.replace('$$version$$', pkg.version)))


### PR DESCRIPTION
Makes bash code syntax highlighted. Will look like this:

![image](https://cloud.githubusercontent.com/assets/3766663/8522574/baef96e2-23ef-11e5-9822-d51d7a36fd97.png)

From: 

![image](https://cloud.githubusercontent.com/assets/3766663/8522584/ccc03c32-23ef-11e5-9cc7-2d7d72e92eed.png)
