### PR TITLE
Enable flicky scrolling on iOS Safari

### DIFF
--- a/docs/_assets/components.css
+++ b/docs/_assets/components.css
@@ -165,8 +165,8 @@ mdl-components-dd {
   }
 
   .mdl-components .mdl-components__nav {
-    position: absolute;
-    top: 0;
+    position: fixed;
+    top: 64px;
     left: 0;
     display: block;
     flex-wrap: nowrap;

--- a/src/layout/_layout.scss
+++ b/src/layout/_layout.scss
@@ -390,6 +390,7 @@
     overflow-x: hidden;
     flex-grow: 1;
     z-index: 1;
+    -webkit-overflow-scrolling: touch;
 
     .mdl-layout--fixed-drawer > & {
       margin-left: $layout-drawer-width;

--- a/src/layout/_layout.scss
+++ b/src/layout/_layout.scss
@@ -42,6 +42,7 @@
   overflow-y: auto;
   overflow-x: hidden;
   position: relative;
+  -webkit-overflow-scrolling: touch;
 }
 
 // Utility classes for screen sizes.


### PR DESCRIPTION
This needs extensive testing for the different kinds of headers `layout` has.

This will not make V1.