### PR TITLE
perf improvement for hosted MDL guidance

### DIFF
--- a/docs/_templates/started.html
+++ b/docs/_templates/started.html
@@ -37,9 +37,9 @@
         <div class="mdl-tabs__panel is-active" id="tab1">
           <div class="code-with-text">
             Just add the following <code>&lt;link&gt;</code> and <code>&lt;script&gt;</code> elements into your HTML pages (27kB gzipped):
-            <pre class="language-markup"><code>&lt;link rel="stylesheet" href="$$hosted_libs_prefix$$/$$version$$/material.indigo-pink.min.css"&gt;
-&lt;script src="$$hosted_libs_prefix$$/$$version$$/material.min.js"&gt;&lt;/script&gt;
-&lt;link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons"&gt;</code></pre>
+            <pre class="language-markup"><code>&lt;link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons"&gt;
+&lt;link rel="stylesheet" href="$$hosted_libs_prefix$$/$$version$$/material.indigo-pink.min.css"&gt;
+&lt;script defer src="$$hosted_libs_prefix$$/$$version$$/material.min.js"&gt;&lt;/script&gt;</code></pre>
           </div>
           <h4>Choose color scheme</h4>
           <p>


### PR DESCRIPTION
The docs have this about using mdl off the CDN:
![image](https://cloud.githubusercontent.com/assets/39191/8528852/dba72258-23ca-11e5-85b1-af96bc0771a0.png)

It's unclear from that, whether this all *needs* to be in the `<head>` or what.. 

But based on https://github.com/google/material-design-lite/blob/master/src/mdlComponentHandler.js#L259-L271 it appears the JS can be deferred.

The simplest and most practical solution is likely to just add a `[defer]` attribute onto the script tag. We'll have faster loading and make sure the script file won't block paint, as it shouldn't. 

I've also changed the order of the requests to get the webfont request out early as it can add extra latency to viewing the icons.