### PR TITLE
Drop module check and export.

### DIFF
--- a/docs/_assets/customizer.js
+++ b/docs/_assets/customizer.js
@@ -504,6 +504,6 @@ MaterialCustomizer = (function() {
 })();
 
 // For NodeJS usage
-if (module) {
+if (typeof module !== 'undefined') {
   module.exports = MaterialCustomizer;
 }


### PR DESCRIPTION
Since we are in strict mode this throws an error in the browser. If we
want to support this being used in multiple contexts we should wrap it
in a UMD module which would be a more hardened solution.

This was added in 7c71c9b6, however it looks like it was not added
because of a usecase, so I think we are good to drop it for now.

<img width="973" alt="screen shot 2015-07-06 at 1 59 03 pm" src="https://cloud.githubusercontent.com/assets/883126/8529991/48887928-23ec-11e5-8bf5-72fce1dcb7ef.png">
