### PR TITLE
Hiding tooltips on scroll

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -64,6 +64,7 @@ MaterialTooltip.prototype.handleMouseEnter_ = function(event) {
   this.element_.style.marginLeft = -1 * (this.element_.offsetWidth / 2) + 'px';
   this.element_.style.top = props.top + props.height + 10 + 'px';
   this.element_.classList.add(this.CssClasses_.IS_ACTIVE);
+  window.addEventListener('scroll', this.boundMouseLeaveHandler, false);
 };
 
 /**
@@ -76,6 +77,7 @@ MaterialTooltip.prototype.handleMouseLeave_ = function(event) {
 
   event.stopPropagation();
   this.element_.classList.remove(this.CssClasses_.IS_ACTIVE);
+  window.removeEventListener('scroll', this.boundMouseLeaveHandler);
 };
 
 /**

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -65,6 +65,7 @@ MaterialTooltip.prototype.handleMouseEnter_ = function(event) {
   this.element_.style.top = props.top + props.height + 10 + 'px';
   this.element_.classList.add(this.CssClasses_.IS_ACTIVE);
   window.addEventListener('scroll', this.boundMouseLeaveHandler, false);
+  window.addEventListener('touchmove', this.boundMouseLeaveHandler, false);
 };
 
 /**
@@ -78,6 +79,7 @@ MaterialTooltip.prototype.handleMouseLeave_ = function(event) {
   event.stopPropagation();
   this.element_.classList.remove(this.CssClasses_.IS_ACTIVE);
   window.removeEventListener('scroll', this.boundMouseLeaveHandler);
+  window.removeEventListener('touchmove', this.boundMouseLeaveHandler, false);
 };
 
 /**


### PR DESCRIPTION
I experienced the tooltip to stay visible, during scrolling (FF 39, MacBook Pro OS X 10.10.3, touchpad). To fix this, I added an event-listener & hide the tooltip on scrolling.