### PR TITLE
Align icons in headerbar (fixes #787)

### DIFF
--- a/templates/dashboard/styles.css
+++ b/templates/dashboard/styles.css
@@ -22,7 +22,9 @@ html, body {
   height: 48px;
   border-radius: 24px;
 }
-
+.demo-layout .demo-header .mdl-textfield {
+  padding-top: 27px;
+}
 .demo-layout .mdl-layout__header .mdl-layout__drawer-button {
   color: rgba(0, 0, 0, 0.54);
 }


### PR DESCRIPTION
![screenshot 2015-07-07 16 06 17](https://cloud.githubusercontent.com/assets/234957/8549324/2bc00316-24c2-11e5-94f7-7590368e7b68.png)

r: @sgomes 