### PR TITLE
Text fields: max width of 100%

### DIFF
--- a/src/textfield/_textfield.scss
+++ b/src/textfield/_textfield.scss
@@ -27,6 +27,7 @@
 
   box-sizing: border-box;
   width: 300px;
+  max-width: 100%;
   margin: 0;
   padding: $input-text-vertical-spacing 0;
 


### PR DESCRIPTION
So they can be used inside smaller containers