### PR TITLE
remove ripple effect

### DIFF
--- a/src/button/snippets/raised-ripple-accent.html
+++ b/src/button/snippets/raised-ripple-accent.html
@@ -1,4 +1,4 @@
-<!-- Accent-colored raised button with ripple -->
-<button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
+<!-- Accent-colored raised button -->
+<button class="mdl-button mdl-js-button mdl-button--raised mdl-button--accent">
   Button
 </button>


### PR DESCRIPTION
Two Example of Accent-colored raised button with ripple is same code on in http://www.getmdl.io/components/index.html#buttons-section 

```
<!-- Accent-colored raised button with ripple -->
<button class="mdl-button mdl-js-button mdl-button--raised mdl-button--accent mdl-js-ripple-effect">
  Button
</button>
<!-- Accent-colored raised button with ripple -->
<button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
  Button
</button>
```

so I remove `with ripple` on the comment and  `mdl-js-ripple-effect` on the code. 