### PR TITLE
android-dot-com template: use CSS hosted on CDN

### DIFF
--- a/templates/android-dot-com/index.html
+++ b/templates/android-dot-com/index.html
@@ -27,7 +27,7 @@
     <!-- Page styles -->
     <link href="https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-    <link rel="stylesheet" href="../../material.min.css">
+    <link rel="stylesheet" href="https://storage.googleapis.com/code.getmdl.io/1.0.0/material.min.css">
     <link rel="stylesheet" href="styles.css">
     <style>
     #view-source {


### PR DESCRIPTION
This will be heaviliy copied so point to the one developers should use.