### PR TITLE
Upgrade element based on css class names

### DIFF
--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -86,6 +86,15 @@ var componentHandler = (function() {
    * the element to.
    */
   function upgradeElementInternal(element, jsClass) {
+    if (jsClass === undefined) {
+      for (var i = 0; i < registeredComponents_.length; i++) {
+        if (element.classList.contains(registeredComponents_[i].cssClass)) {
+          upgradeElementInternal(element, registeredComponents_[i].className);
+        }
+      }
+      return;
+    }
+
     // Only upgrade elements that have not already been upgraded.
     var dataUpgraded = element.getAttribute('data-upgraded');
 


### PR DESCRIPTION
Adds the ability to upgrade an element by looking at its class names by calling `componentHandler.upgradeElement(element)`. This mimics the behavior of `upgradeDom()` and `upgradeAllRegistered()`, and is backwards compatible (`componentHandler.upgradeElement(element, 'MaterialButton')` still works). See #804