### PR TITLE
Add disabled state for colored buttons. Move all disabled to bottom.

### DIFF
--- a/src/button/_button.scss
+++ b/src/button/_button.scss
@@ -58,13 +58,6 @@
     background-color: $button-active-color;
   }
 
-  // Bump up specificity by using [disabled] twice.
-  &[disabled][disabled] {
-    color: $button-secondary-color-disabled;
-    cursor: auto;
-    background-color: transparent;
-  }
-
   &.mdl-button--colored {
     color: $button-primary-color-alt;
 
@@ -112,13 +105,6 @@ input.mdl-button[type="submit"] {
       & .mdl-ripple {
         background: $button-ripple-color-alt;
       }
-    }
-
-    // Bump up specificity by using [disabled] twice.
-    &[disabled][disabled] {
-      background-color: $button-primary-color-disabled;
-      color: $button-secondary-color-disabled;
-      @include shadow-2dp();
     }
   }
 
@@ -188,13 +174,6 @@ input.mdl-button[type="submit"] {
       & .mdl-ripple {
         background: $button-fab-ripple-color-alt;
       }
-    }
-
-    // Bump up specificity by using [disabled] twice.
-    &[disabled][disabled] {
-      background-color: $button-primary-color-disabled;
-      color: $button-secondary-color-disabled;
-      @include shadow-2dp();
     }
   }
 
@@ -278,5 +257,42 @@ input.mdl-button[type="submit"] {
   &.mdl-button--raised, &.mdl-button--fab {
     color: $button-fab-text-color-alt;
     background-color: $button-fab-color-alt;
+  }
+}
+
+// Disabled buttons
+
+.mdl-button {
+  // Bump up specificity by using [disabled] twice.
+  &[disabled][disabled] {
+    color: $button-secondary-color-disabled;
+    cursor: auto;
+    background-color: transparent;
+  }
+
+  &--fab {
+    // Bump up specificity by using [disabled] twice.
+    &[disabled][disabled] {
+      background-color: $button-primary-color-disabled;
+      color: $button-secondary-color-disabled;
+      @include shadow-2dp();
+    }
+  }
+
+  &--raised {
+    // Bump up specificity by using [disabled] twice.
+    &[disabled][disabled] {
+      background-color: $button-primary-color-disabled;
+      color: $button-secondary-color-disabled;
+      @include shadow-2dp();
+    }
+  }
+  &--colored {
+    // Bump up specificity by using [disabled] twice.
+    &[disabled][disabled] {
+      background-color: $button-primary-color-disabled;
+      color: $button-secondary-color-disabled;
+      @include shadow-2dp();
+    }
   }
 }


### PR DESCRIPTION
Adding disable state for colored buttons to fix issue #907. While i was here, I moved all the disabled states down to the bottom to ensure maximum specificity for the component.