### PR TITLE
Allow tab navigation to be used for external links

### DIFF
--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -448,8 +448,10 @@
       }
 
       tab.addEventListener('click', function(e) {
-        e.preventDefault();
-        selectTab();
+        if (tab.getAttribute('href').charAt(0) === '#') {
+          e.preventDefault();
+          selectTab();
+        }
       });
 
       tab.show = selectTab;


### PR DESCRIPTION
I tried using the tab navigation with a mix between panels on the same page as well as external links. External links didn't work because the clicks get intercepted and the code then tries to match the href to a panel name which is then displayed. I changed the code so the panel logic is only used when the href starts with a hash symbol.