### PR TITLE
Add tooltip top position

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -71,7 +71,12 @@ MaterialTooltip.prototype.handleMouseEnter_ = function(event) {
     this.element_.style.marginLeft = marginLeft + 'px';
   }
 
-  this.element_.style.top = props.top + props.height + 10 + 'px';
+  if (this.element_.classList.contains('mdl-tooltip--top')) {
+    this.element_.style.top = props.top - this.element_.offsetHeight - 10 + 'px';
+  } else {
+    this.element_.style.top = props.top + props.height + 10 + 'px';
+  }
+
   this.element_.classList.add(this.CssClasses_.IS_ACTIVE);
   window.addEventListener('scroll', this.boundMouseLeaveHandler, false);
   window.addEventListener('touchmove', this.boundMouseLeaveHandler, false);


### PR DESCRIPTION
Hi!

I have a problem whith the tooltip if the element is close to the bottom, similar to button of [Inbox] (https://inbox.google.com/), (next picture)

I added some lines code to resolve this issue. You need to add the class "mdl-tooltip--top" to the element

![seleccion_012](https://cloud.githubusercontent.com/assets/6478816/8608627/23fe6b9e-2662-11e5-91a5-cf0c2664e49e.png) ![seleccion_013](https://cloud.githubusercontent.com/assets/6478816/8608632/2a0b397c-2662-11e5-928c-6f7cd9983877.png)



Check it!

Thanks