### PR TITLE
UpgradeAllRegistered within specific node

### DIFF
--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -57,12 +57,20 @@ var componentHandler = (function() {
    * to create a new instance of.
    * @param {string} cssClass the name of the CSS class elements of this type
    * will have.
+   * @param {!Element | document} element The element under which the upgrade
+   * would occur.
    */
-  function upgradeDomInternal(jsClass, cssClass) {
+  function upgradeDomInternal(jsClass, cssClass, element) {
+    if (element === undefined) {
+      element = document;
+    } else if (!(element instanceof Element || element === document)) {
+      throw new Error('Invalid argument provided to upgrade MDL nodes.');
+    }
     if (jsClass === undefined && cssClass === undefined) {
       for (var i = 0; i < registeredComponents_.length; i++) {
         upgradeDomInternal(registeredComponents_[i].className,
-            registeredComponents_[i].cssClass);
+            registeredComponents_[i].cssClass,
+            element);
       }
     } else {
       if (cssClass === undefined) {
@@ -72,7 +80,7 @@ var componentHandler = (function() {
         }
       }
 
-      var elements = document.querySelectorAll('.' + cssClass);
+      var elements = element.querySelectorAll('.' + cssClass);
       for (var n = 0; n < elements.length; n++) {
         upgradeElementInternal(elements[n], jsClass);
       }
@@ -174,12 +182,20 @@ var componentHandler = (function() {
   }
 
   /**
-   * Upgrades all registered components found in the current DOM. This is
-   * automatically called on window load.
+   * Upgrades all registered components found under the given root node in the
+   * current DOM. This is automatically called on window load.
+   *
+   * @param {!Element | document} rootNode The element node under which the
+   * upgrade would occur.
    */
-  function upgradeAllRegisteredInternal() {
+  function upgradeAllRegisteredInternal(rootNode) {
+    if (rootNode === undefined) {
+      rootNode = document;
+    } else if (!(rootNode instanceof Element || rootNode === document)) {
+      throw new Error('Invalid argument provided to upgrade MDL nodes.');
+    }
     for (var n = 0; n < registeredComponents_.length; n++) {
-      upgradeDomInternal(registeredComponents_[n].className);
+      upgradeDomInternal(registeredComponents_[n].className, undefined, rootNode);
     }
   }
 


### PR DESCRIPTION
Goal: To allow users upgrade all registered components *under* a specific element node.
Use case: The user use aJax to load a big chunk of html into a, say, div container. And he'd like to upgrade the MDL components in that chunk of html.
Benefit: This change allows the user to do `componentHandler.upgradeAllRegistered(container);`, which in the end uses `container.querySelectorAll` instead of `document.querySelectorAll`, which I think would be more efficient.

Changes:
* Added the first `param {!Element | document} rootNode` to `upgradeAllRegisteredInternal` for specifying the query scope.
* Added the third `param {!Element | document} element` to `upgradeDomInternal` for specifying the query scope.

This affects the interface of `upgradeAllRegistered` and `upgradeDom` but is backward compatible.