### PR TITLE
Upgrade element without js class

### DIFF
--- a/test/unit/button.js
+++ b/test/unit/button.js
@@ -44,4 +44,13 @@
       expect($(btn.childNodes[1])).to.have.class('mdl-button__ripple-container');
       expect($(btn.childNodes[1].firstChild)).to.have.class('mdl-ripple');
     });
+
+    it('Should be upgraded to a MaterialButton FAB with ripples successfully (without specifying jsClass)', function () {
+      var el = document.createElement('div');
+      el.innerHTML = '<button class="mdl-button mdl-js-button mdl-button--fab mdl-button--colored mdl-js-ripple-effect">♥</button>';
+      var btn = el.firstChild;
+      componentHandler.upgradeElement(btn);
+      expect($(btn.childNodes[1])).to.have.class('mdl-button__ripple-container');
+      expect($(btn.childNodes[1].firstChild)).to.have.class('mdl-ripple');
+    });
   });


### PR DESCRIPTION
The implementation in dc16def16b769190a763f7c44a0796ac7e5b22ea has a bug. The test case included was not enough to spot that and I updated the test case to reveal the bug.

My implementation of the same feature doesn't have that bug and also covers another bug/issue:
using `dataUpgraded.indexOf(jsClass) !== -1` to detect upgraded component would have a false positive for 'MaterialButton' if another component 'MaterialButtonLarge' is upgraded.