### PR TITLE
Fix full screen repainting correctly

### DIFF
--- a/templates/blog/styles.css
+++ b/templates/blog/styles.css
@@ -1,18 +1,10 @@
-body {
-  background-image: url('images/bg.jpg');
-  background-size: cover;
-  background-attachment: fixed;
-  /* FIXME: Temp. workaround for vertical scrollbars */
-  margin: 0;
-}
-
 body::before {
-    background-image: url('/images/head.jpg');
+    background-image: url('images/bg.jpg');
     background-size: cover;
     background-attachment: fixed;
     content: '';
     will-change: transform;
-    z-index: 1;
+    z-index: -1;
     left: 0;
     right: 0;
     bottom: 0;


### PR DESCRIPTION
Fix full screen repainting referred in https://github.com/google/material-design-lite/issues/560 correctly.
The commit https://github.com/google/material-design-lite/commit/afab807463d6e4ebffd773bf66bf6fa3b0216df5 doesn't fix the issue but causes the missing `head.jpg` error in web browser's console.