### PR TITLE
Remove duplicate box-shadow property.

### DIFF
--- a/src/layout/snippets/fixed-drawer-demo.html
+++ b/src/layout/snippets/fixed-drawer-demo.html
@@ -6,7 +6,6 @@
   width: 100%;
   position: relative;
   height: 300px;
-  box-shadow:
 }
 .fixed-drawer-container .mdl-layout__content {
   background: white;


### PR DESCRIPTION
A caution occurred when I see the `COMPONENTS` demo page in Safari 8.0.7 (10600.7.12).
In other demo like `fixed-header-demo.html` and `fixed-header-drawer-demo.html`, `box-shadow` property used only once.
So, I removed duplicate `box-shadow` property.