### PR TITLE
Expose checkbox as widget for developer manipulation.

### DIFF
--- a/src/checkbox/checkbox.js
+++ b/src/checkbox/checkbox.js
@@ -260,5 +260,6 @@ MaterialCheckbox.prototype.mdlDowngrade_ = function() {
 componentHandler.register({
   constructor: MaterialCheckbox,
   classAsString: 'MaterialCheckbox',
-  cssClass: 'mdl-js-checkbox'
+  cssClass: 'mdl-js-checkbox',
+  widget: true
 });


### PR DESCRIPTION
Addresses some [issues](https://stackoverflow.com/questions/31322380/disabling-material-design-lite-toggle-switch/31373882) that developers are hitting. Exposing this allows for disabling and re-enabling of checkboxes pragmatically and having their UX updated.