### PR TITLE
fix #994, removed unnecessary 100% width from menu item

### DIFF
--- a/src/menu/_menu.scss
+++ b/src/menu/_menu.scss
@@ -134,7 +134,6 @@
   text-decoration: none;
   cursor: pointer;
   height: 48px;
-  width: 100%;
   line-height: 48px;
   white-space: nowrap;
   opacity: 0;


### PR DESCRIPTION
Removed unnecessary 100% width from block element .mdl-menu__item to fix #994.