### PR TITLE
Bugfix for component handlers callbacks

### DIFF
--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -128,8 +128,8 @@ var componentHandler = (function() {
         instance[componentConfigProperty_] = registeredClass;
         createdComponents_.push(instance);
         // Call any callbacks the user has registered with this component type.
-        for (var j = 0, len = registeredClass.callbacks.length; j < len; i++) {
-          registeredClass.callbacks[i](element);
+        for (var j = 0, len = registeredClass.callbacks.length; j < len; j++) {
+          registeredClass.callbacks[j](element);
         }
 
         if (registeredClass.widget) {


### PR DESCRIPTION
Fixed javascript error that occured when trying to use "componentHandler.registerUpgradedCallback" caused by using the outer loop variable instead of the inner one.