### PR TITLE
Issue if Drawer has mdl-layout--small-screen-only or large-screen-only…

### DIFF
--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -101,7 +101,11 @@ MaterialLayout.prototype.CssClasses_ = {
   IS_DRAWER_OPEN: 'is-visible',
   IS_ACTIVE: 'is-active',
   IS_UPGRADED: 'is-upgraded',
-  IS_ANIMATING: 'is-animating'
+  IS_ANIMATING: 'is-animating',
+
+  ON_LARGE_SCREEN : 'mdl-layout--large-screen-only',
+  ON_SMALL_SCREEN  : 'mdl-layout--small-screen-only'
+
 };
 
 /**
@@ -286,6 +290,14 @@ MaterialLayout.prototype.init = function() {
     if (this.drawer_) {
       var drawerButton = document.createElement('div');
       drawerButton.classList.add(this.CssClasses_.DRAWER_BTN);
+
+      if (this.drawer_.classList.contains(this.CssClasses_.ON_LARGE_SCREEN)) {
+        //If drawer has ON_LARGE_SCREEN class then add it to the drawer toggle button as well.
+        drawerButton.classList.add(this.CssClasses_.ON_LARGE_SCREEN);
+      } else if (this.drawer_.classList.contains(this.CssClasses_.ON_SMALL_SCREEN)) {
+        //If drawer has ON_SMALL_SCREEN class then add it to the drawer toggle button as well.
+        drawerButton.classList.add(this.CssClasses_.ON_SMALL_SCREEN);
+      }
       var drawerButtonIcon = document.createElement('i');
       drawerButtonIcon.classList.add(this.CssClasses_.ICON);
       drawerButtonIcon.textContent = this.Constant_.MENU_ICON;


### PR DESCRIPTION
Issue if Drawer has mdl-layout--small-screen-only or large-screen-only. Then the hamburger Icon needs to be hidden on small/large screen.  Fixed this by adding same class on drawer to slider-Icon(hamburger). 

Created a fiddle here. You can see it just by clicking the slider icon.
http://jsfiddle.net/u9L12t1r/

This way the media query automatically hides the Icon

If not then Slider Icon is visible. but empty overlay appears when clicked as drawer has mdl-layout--small-screen-only class. 

Thanks