### PR TITLE
[textfields] updateClasses only if element is input or textarea

### DIFF
--- a/src/textfield/textfield.js
+++ b/src/textfield/textfield.js
@@ -115,11 +115,13 @@ MaterialTextfield.prototype.updateClasses_ = function() {
   } else {
     this.element_.classList.add(this.CssClasses_.IS_INVALID);
   }
-
-  if (this.input_.value && this.input_.value.length > 0) {
-    this.element_.classList.add(this.CssClasses_.IS_DIRTY);
-  } else {
-    this.element_.classList.remove(this.CssClasses_.IS_DIRTY);
+  
+  if (this.input_.nodeName.toUpperCase() === 'INPUT' || this.input_.nodeName.toUpperCase() === 'TEXTAREA') {
+    if (this.input_.value && this.input_.value.length > 0) {
+      this.element_.classList.add(this.CssClasses_.IS_DIRTY);
+    } else {
+      this.element_.classList.remove(this.CssClasses_.IS_DIRTY);
+    }
   }
 };
 

--- a/src/textfield/textfield.js
+++ b/src/textfield/textfield.js
@@ -104,19 +104,19 @@ MaterialTextfield.prototype.onBlur_ = function(event) {
 MaterialTextfield.prototype.updateClasses_ = function() {
   'use strict';
 
-  if (this.input_.disabled) {
-    this.element_.classList.add(this.CssClasses_.IS_DISABLED);
-  } else {
-    this.element_.classList.remove(this.CssClasses_.IS_DISABLED);
-  }
-
-  if (this.input_.validity.valid) {
-    this.element_.classList.remove(this.CssClasses_.IS_INVALID);
-  } else {
-    this.element_.classList.add(this.CssClasses_.IS_INVALID);
-  }
-
   if (this.input_.nodeName.toUpperCase() === 'INPUT' || this.input_.nodeName.toUpperCase() === 'TEXTAREA') {
+    if (this.input_.disabled) {
+      this.element_.classList.add(this.CssClasses_.IS_DISABLED);
+    } else {
+      this.element_.classList.remove(this.CssClasses_.IS_DISABLED);
+    }
+
+    if (this.input_.validity.valid) {
+      this.element_.classList.remove(this.CssClasses_.IS_INVALID);
+    } else {
+      this.element_.classList.add(this.CssClasses_.IS_INVALID);
+    }
+
     if (this.input_.value && this.input_.value.length > 0) {
       this.element_.classList.add(this.CssClasses_.IS_DIRTY);
     } else {

--- a/src/textfield/textfield.js
+++ b/src/textfield/textfield.js
@@ -115,7 +115,7 @@ MaterialTextfield.prototype.updateClasses_ = function() {
   } else {
     this.element_.classList.add(this.CssClasses_.IS_INVALID);
   }
-  
+
   if (this.input_.nodeName.toUpperCase() === 'INPUT' || this.input_.nodeName.toUpperCase() === 'TEXTAREA') {
     if (this.input_.value && this.input_.value.length > 0) {
       this.element_.classList.add(this.CssClasses_.IS_DIRTY);


### PR DESCRIPTION
Why ?
Users may add the is-dirty along mdl-textfield__input on non input/textarea elements to make the label float. Without this PR the is-dirty is removed on non input/textarea elements

Why toUpperCase() ?
Just to be sure http://ejohn.org/blog/nodename-case-sensitivity/ .