### PR TITLE
insert empty <td> in <tfoot> of selectable datatable

### DIFF
--- a/src/data-table/data-table.js
+++ b/src/data-table/data-table.js
@@ -117,22 +117,33 @@ MaterialDataTable.prototype.init = function() {
   if (this.element_) {
 
     var firstHeader = this.element_.querySelector('th');
-    var rows = this.element_.querySelector('tbody').querySelectorAll('tr');
+    var rows_body = this.element_.querySelector('tbody').querySelectorAll('tr');
+    var footer = this.element_.querySelector('tfoot');
 
     if (this.element_.classList.contains(this.CssClasses_.SELECTABLE)) {
       var th = document.createElement('th');
-      var headerCheckbox = this.createCheckbox_(null, rows);
+      var headerCheckbox = this.createCheckbox_(null, rows_body);
       th.appendChild(headerCheckbox);
       firstHeader.parentElement.insertBefore(th, firstHeader);
 
-      for (var i = 0; i < rows.length; i++) {
-        var firstCell = rows[i].querySelector('td');
+      for (var i = 0; i < rows_body.length; i++) {
+        var firstCell = rows_body[i].querySelector('td');
         if (firstCell) {
           var td = document.createElement('td');
-          var rowCheckbox = this.createCheckbox_(rows[i]);
+          var rowCheckbox = this.createCheckbox_(rows_body[i]);
           td.appendChild(rowCheckbox);
-          rows[i].insertBefore(td, firstCell);
+          rows_body[i].insertBefore(td, firstCell);
         }
+      }
+      if (footer){
+          var rows_foot = footer.querySelectorAll('tr');
+          for (var i = 0; i < rows_foot.length; i++) {
+            var firstCell = rows_foot[i].querySelector('td');
+            if (firstCell) {
+              var td = document.createElement('td');
+              rows_foot[i].insertBefore(td, firstCell);
+            }
+          }
       }
     }
 

--- a/src/data-table/data-table.js
+++ b/src/data-table/data-table.js
@@ -117,33 +117,33 @@ MaterialDataTable.prototype.init = function() {
   if (this.element_) {
 
     var firstHeader = this.element_.querySelector('th');
-    var rows_body = this.element_.querySelector('tbody').querySelectorAll('tr');
-    var footer = this.element_.querySelector('tfoot');
+    var bodyRows = this.element_.querySelector('tbody').querySelectorAll('tr');
+    var foot = this.element_.querySelector('tfoot');
 
     if (this.element_.classList.contains(this.CssClasses_.SELECTABLE)) {
       var th = document.createElement('th');
-      var headerCheckbox = this.createCheckbox_(null, rows_body);
+      var headerCheckbox = this.createCheckbox_(null, bodyRows);
       th.appendChild(headerCheckbox);
       firstHeader.parentElement.insertBefore(th, firstHeader);
 
-      for (var i = 0; i < rows_body.length; i++) {
-        var firstCell = rows_body[i].querySelector('td');
+      for (var i = 0; i < bodyRows.length; i++) {
+        var firstCell = bodyRows[i].querySelector('td');
         if (firstCell) {
           var td = document.createElement('td');
-          var rowCheckbox = this.createCheckbox_(rows_body[i]);
+          var rowCheckbox = this.createCheckbox_(bodyRows[i]);
           td.appendChild(rowCheckbox);
-          rows_body[i].insertBefore(td, firstCell);
+          bodyRows[i].insertBefore(td, firstCell);
         }
       }
-      if (footer){
-          var rows_foot = footer.querySelectorAll('tr');
-          for (var i = 0; i < rows_foot.length; i++) {
-            var firstCell = rows_foot[i].querySelector('td');
-            if (firstCell) {
-              var td = document.createElement('td');
-              rows_foot[i].insertBefore(td, firstCell);
-            }
+      if (foot) {
+        var footRows = this.element_.querySelector('tfoot').querySelectorAll('tr');
+        for (var i = 0; i < footRows.length; i++) {
+          var firstCell = footRows[i].querySelector('td');
+          if (firstCell) {
+            var td = document.createElement('td');
+            footRows[i].insertBefore(td, firstCell);
           }
+        }
       }
     }
 

--- a/src/data-table/data-table.js
+++ b/src/data-table/data-table.js
@@ -126,7 +126,7 @@ MaterialDataTable.prototype.init = function() {
       var headerCheckbox = this.createCheckbox_(null, rows);
       th.appendChild(headerCheckbox);
       firstHeader.parentElement.insertBefore(th, firstHeader);
-      
+
       for (var i = 0; i < rows.length; i++) {
         var firstCell = rows[i].querySelector('td');
         if (firstCell) {

--- a/src/data-table/data-table.js
+++ b/src/data-table/data-table.js
@@ -117,32 +117,25 @@ MaterialDataTable.prototype.init = function() {
   if (this.element_) {
 
     var firstHeader = this.element_.querySelector('th');
-    var bodyRows = this.element_.querySelector('tbody').querySelectorAll('tr');
-    var foot = this.element_.querySelector('tfoot');
+    var bodyRows = Array.prototype.slice.call(this.element_.querySelectorAll('tbody tr'));
+    var footRows = Array.prototype.slice.call(this.element_.querySelectorAll('tfoot tr'));
+    var rows = bodyRows.concat(footRows);
 
     if (this.element_.classList.contains(this.CssClasses_.SELECTABLE)) {
       var th = document.createElement('th');
-      var headerCheckbox = this.createCheckbox_(null, bodyRows);
+      var headerCheckbox = this.createCheckbox_(null, rows);
       th.appendChild(headerCheckbox);
       firstHeader.parentElement.insertBefore(th, firstHeader);
-
-      for (var i = 0; i < bodyRows.length; i++) {
-        var firstCell = bodyRows[i].querySelector('td');
+      
+      for (var i = 0; i < rows.length; i++) {
+        var firstCell = rows[i].querySelector('td');
         if (firstCell) {
           var td = document.createElement('td');
-          var rowCheckbox = this.createCheckbox_(bodyRows[i]);
-          td.appendChild(rowCheckbox);
-          bodyRows[i].insertBefore(td, firstCell);
-        }
-      }
-      if (foot) {
-        var footRows = this.element_.querySelector('tfoot').querySelectorAll('tr');
-        for (var i = 0; i < footRows.length; i++) {
-          var firstCell = footRows[i].querySelector('td');
-          if (firstCell) {
-            var td = document.createElement('td');
-            footRows[i].insertBefore(td, firstCell);
+          if (rows[i].parentNode.nodeName.toUpperCase() === "TBODY"){
+            var rowCheckbox = this.createCheckbox_(rows[i]);
+            td.appendChild(rowCheckbox);
           }
+          rows[i].insertBefore(td, firstCell);
         }
       }
     }

--- a/src/data-table/data-table.js
+++ b/src/data-table/data-table.js
@@ -131,7 +131,7 @@ MaterialDataTable.prototype.init = function() {
         var firstCell = rows[i].querySelector('td');
         if (firstCell) {
           var td = document.createElement('td');
-          if (rows[i].parentNode.nodeName.toUpperCase() === "TBODY"){
+          if (rows[i].parentNode.nodeName.toUpperCase() === 'TBODY') {
             var rowCheckbox = this.createCheckbox_(rows[i]);
             td.appendChild(rowCheckbox);
           }


### PR DESCRIPTION
When table is selectable and has a &lt;tfoot&gt;, empty &lt;td&gt;s should be added, so they line up with the checkboxes in &lt;tbody&gt;. 

&lt;tfoot&gt; otherwise has quite unexpected behavior, especially when reading through the official [data-tables-specs](https://www.google.com/design/spec/components/data-tables.html#data-tables-specs)

Is this out of scope for this project?