### PR TITLE
Created downgrade method for MaterialProgress.

### DIFF
--- a/src/progress/progress.js
+++ b/src/progress/progress.js
@@ -96,6 +96,16 @@ MaterialProgress.prototype.init = function() {
   }
 };
 
+/*
+* Downgrade the component
+*/
+MaterialProgress.prototype.mdlDowngrade_ = function() {
+  'use strict';
+  while (this.element_.firstChild) {
+    this.element_.removeChild(this.element_.firstChild);
+  }
+};
+
 // The component registers itself. It can assume componentHandler is available
 // in the global scope.
 componentHandler.register({


### PR DESCRIPTION
The `MaterialProgress` doesn't contain a downgrade method therefore it is impossible to downgrade because of this condition: https://github.com/google/material-design-lite/blob/master/src/mdlComponentHandler.js#L275-L278

This PR includes a downgrade method for `MaterialProgress` and removes the bars so they don't get duplicated upon upgrading.