### PR TITLE
Gulp hotfixing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ script:
   - npm install
   # ensure the build works
   # this will also run gulp test
-  - gulp
+  - gulp all
 deploy:
   bash:
     when:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -191,7 +191,7 @@ gulp.task('styles-grid', function () {
 });
 
 // Concatenate And Minify JavaScript
-gulp.task('scripts', function () {
+gulp.task('scripts', ['jscs', 'jshint'], function () {
   var sources = [
     // Component handler
     'src/mdlComponentHandler.js',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,6 +25,7 @@ var fs = require('fs');
 var merge = require('merge-stream');
 var $ = require('gulp-load-plugins')();
 var del = require('del');
+var vinylPaths = require('vinyl-paths');
 var runSequence = require('run-sequence');
 var browserSync = require('browser-sync');
 var codeFiles = '';
@@ -496,14 +497,6 @@ gulp.task('zip:mdl', function() {
     .pipe(gulp.dest('dist'));
 });
 
-gulp.task('zip:mdl-source', function() {
-  return gulp.src(['dist/material?(.min)@(.js|.css)?(.map)', 'LICENSE',
-    'bower.json', 'package.json', './sr?/**/*', 'gulpfile.js'])
-    .pipe(gulp.dest('_release'))
-    .pipe($.zip('mdl-source.zip'))
-    .pipe(gulp.dest('dist'));
-});
-
 // Generate release archive containing the library, templates and assets
 // for templates. Note that it is intentional for some templates to include
 // a customised version of the material.min.css file for their own needs.
@@ -531,7 +524,7 @@ gulp.task('zip:templates', function() {
   .pipe(gulp.dest('dist'));
 });
 
-gulp.task('zip', ['zip:templates', 'zip:mdl', 'zip:mdl-source']);
+gulp.task('zip', ['zip:templates', 'zip:mdl']);
 
 gulp.task('genCodeFiles', function() {
   return gulp.src(['dist/material.*@(js|css)?(.map)', 'dist/mdl.zip', 'dist/mdl-templates.zip'],
@@ -666,6 +659,21 @@ gulp.task('templates:mdl', function() {
     .pipe($.csso())
     .pipe($.rename({suffix: '.min'}))
     .pipe(gulp.dest('dist/templates'));
+});
+
+gulp.task('_release', function() {
+  return gulp.src(['dist/material?(.min)@(.js|.css)?(.map)', 'LICENSE',
+    'bower.json', 'package.json', './sr?/**/*', 'gulpfile.js'])
+    .pipe(gulp.dest('_release'));
+});
+
+gulp.task('publish:bower', ['_release'], function() {
+  return gulp.src('_release')
+  .pipe($.subtree({
+    remote: 'origin',
+    branch: 'release'
+  }))
+  .pipe(vinylPaths(del));
 });
 
 gulp.task('templates:styles', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -667,7 +667,7 @@ gulp.task('_release', function() {
     .pipe(gulp.dest('_release'));
 });
 
-gulp.task('publish:bower', ['_release'], function() {
+gulp.task('publish:release', ['_release'], function() {
   return gulp.src('_release')
   .pipe($.subtree({
     remote: 'origin',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -318,15 +318,9 @@ gulp.task('components', ['demos'], function() {
     .pipe($.frontMatter({property: 'page', remove: true}))
     .pipe($.marked())
     .pipe((function () {
-      var componentPages = [];
       return through.obj(function(file, enc, cb) {
         file.page.component = file.relative.split('/')[0];
-        componentPages.push(file.page);
         this.push(file);
-        cb();
-      },
-      function(cb) {
-        site.components = componentPages;
         cb();
       });
     })())
@@ -381,15 +375,9 @@ gulp.task('demos', ['demoresources'], function() {
       .pipe($.frontMatter({property: 'page', remove: true}))
       .pipe($.marked())
       .pipe((function () {
-        var componentPages = [];
         return through.obj(function(file, enc, cb) {
             file.page.component = component;
-            componentPages.push(file.page);
             this.push(file);
-            cb();
-          },
-          function(cb) {
-            site.components = componentPages;
             cb();
           });
       })())
@@ -451,6 +439,19 @@ gulp.task('assets', function () {
     .pipe(gulp.dest('dist/assets'));
 });
 
+function watch() {
+  gulp.watch(['src/**/*.js', '!src/**/README.md'],
+    ['scripts', 'demos', 'components', reload]);
+  gulp.watch(['src/**/*.{scss,css}'],
+    ['styles', 'styles-grid', 'styletemplates', reload]);
+  gulp.watch(['src/**/*.html'], ['pages', reload]);
+  gulp.watch(['src/**/*.{svg,png,jpg}'], ['images', reload]);
+  gulp.watch(['src/**/README.md'], ['pages', reload]);
+  gulp.watch(['templates/**/*'], ['templates', reload]);
+  gulp.watch(['docs/**/*'], ['pages', 'assets', reload]);
+  gulp.watch(['package.json', 'bower.json', 'LICENSE'], ['metadata']);
+}
+
 /**
  * Serves the landing page from "out" directory.
  */
@@ -462,13 +463,7 @@ gulp.task('serve:browsersync', function () {
     }
   });
 
-  gulp.watch(['src/**/*.js', '!src/**/README.md'],
-      ['scripts', 'demos', 'components', reload]);
-  gulp.watch(['src/**/*.{scss,css}'], ['styles', 'demos', reload]);
-  gulp.watch(['src/**/*.html'], ['demos', reload]);
-  gulp.watch(['src/**/README.md'], ['components', reload]);
-  gulp.watch(['templates/**/*'], ['templates', reload]);
-  gulp.watch(['docs/**/*'], ['pages', 'assets', reload]);
+  watch();
 });
 
 gulp.task('serve', function() {
@@ -478,13 +473,7 @@ gulp.task('serve', function() {
     livereload: true
   });
 
-  gulp.watch(['src/**/*.js', '!src/**/README.md'],
-      ['scripts', 'demos', 'components']);
-  gulp.watch(['src/**/*.{scss,css}'], ['styles', 'demos']);
-  gulp.watch(['src/**/*.html'], ['demos']);
-  gulp.watch(['src/**/README.md'], ['components']);
-  gulp.watch(['templates/**/*'], ['templates']);
-  gulp.watch(['docs/**/*'], ['pages', 'assets']);
+  watch();
 
   gulp.src('./dist/index.html')
     .pipe($.open('', {url: 'http://localhost:5000'}));
@@ -698,10 +687,10 @@ gulp.task('templates:images', function() {
   return gulp.src([
     'templates/*/images/**/*'
   ])
-  .pipe($.imagemin({
+  .pipe($.cache($.imagemin({
     progressive: true,
     interlaced: true
-  }))
+  })))
   .pipe(gulp.dest('dist/templates'));
 });
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "gulp-shell": "^0.4.2",
     "gulp-size": "^1.0.0",
     "gulp-sourcemaps": "^1.3.0",
+    "gulp-subtree": "^0.1.0",
     "gulp-tap": "^0.1.3",
     "gulp-uglify": "^1.0.1",
     "gulp-useref": "^1.0.1",
@@ -57,7 +58,8 @@
     "require-dir": "^0.3.0",
     "run-sequence": "^1.0.2",
     "swig": "^1.4.2",
-    "through2": "^0.6.3"
+    "through2": "^0.6.3",
+    "vinyl-paths": "^1.0.0"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Follow-up on #862. This is still more of a hotfix, a gulpfile overhaul is still highlt desirable.

This needs both extensiv review and sanity checks!

Short summary of what has changed:

* `gulp serve` and `gulp serve:browsersync` *don’t* imply a rebuild anymore.
* `gulp default` (and therefore `gulp`) only build the library, not the microsite or other secondary artifacts.
* `gulp all` is like the old default task, builds everything.
* `gulp styles` does not imply `gulp templatestyles` anymore.
* `gulp zip` builds both `dist/mdl.zip` and `dist/mdl-templates.zip`.
* `gulp publish:bower` 
  * runs `gulp _release` which builds a `_release` folder containing the library build as well as `src/` together with `gulpfile.js`. If you run `npm install` in `_release`, you can `gulp build` your own MDL.
  * Uses `gulp-subtree` to push the new release to the `release` branch on `origin`.

r: @addyosmani @Garbee @crhym3