### PR TITLE
Issue with menu overlapping header

### DIFF
--- a/src/layout/_layout.scss
+++ b/src/layout/_layout.scss
@@ -386,6 +386,7 @@
     // Fix IE10 bug.
     -ms-flex: 0 1 auto;
 
+    position: relative;
     display: inline-block;
     overflow-y: auto;
     overflow-x: hidden;


### PR DESCRIPTION
Fixed issue that happend when .mdl-menu resided within
.mdl-layout__content wrapper.
The header got overlapped, so I added position relative to the
.mdl-layout__content wrapper.

See diffrence here:
https://jsfiddle.net/hbqo0z8e/1/