### PR TITLE
Adding mdl-grid--hide-<SCREEN_SIZE> classes to grid.

### DIFF
--- a/src/grid/README.md
+++ b/src/grid/README.md
@@ -100,6 +100,9 @@ The MDL CSS classes apply various predefined visual enhancements and behavioral 
 | MDL class | Effect | Remarks |
 |-----------|--------|---------|
 | `mdl-grid` | Defines a container as an MDL grid component | Required on "outer" div element |
+| `mdl-grid--hide-desktop` | Hides the mdl-grid when in desktop mode | Optional on "outer" div elements |
+| `mdl-grid--hide-tablet` | Hides the mdl-grid when in tablet mode | Optional on "outer" div elements |
+| `mdl-grid--hide-phone` | Hides the mdl-grid when in phone mode | Optional on "outer" div elements |
 | `mdl-cell` | Defines a container as an MDL cell | Required on "inner" div elements |
 | `mdl-cell--N-col` | Sets the column size for the cell to N | N is 1-12 inclusive, defaults to 4; optional on "inner" div elements|
 | `mdl-cell--N-col-desktop` | Sets the column size for the cell to N in desktop mode only | N is 1-12 inclusive; optional on "inner" div elements|

--- a/src/grid/_grid.scss
+++ b/src/grid/_grid.scss
@@ -75,6 +75,10 @@
     padding: $grid-phone-margin - ($grid-phone-gutter / 2);
   }
 
+  .mdl-grid--hide-phone {
+    display: none !important;
+  }
+
   .mdl-cell {
     margin: $grid-phone-gutter / 2;
     @include partial-size($grid-cell-default-columns, $grid-phone-columns,
@@ -116,6 +120,10 @@
     padding: $grid-tablet-margin - ($grid-tablet-gutter / 2);
   }
 
+  .mdl-grid--hide-tablet {
+    display: none !important;
+  }
+
   .mdl-cell {
     margin: $grid-tablet-gutter / 2;
     @include partial-size($grid-cell-default-columns, $grid-tablet-columns,
@@ -155,6 +163,10 @@
 @media (min-width: $grid-desktop-breakpoint) {
   .mdl-grid {
     padding: $grid-desktop-margin - ($grid-desktop-gutter / 2);
+  }
+
+  .mdl-grid--hide-desktop {
+    display: none !important;
   }
 
   .mdl-cell {


### PR DESCRIPTION
Allows user to hide the entire grid. Currently if you want to hide all cells in a grid the grid's padding hangs around and can mess with your desired layout.