### PR TITLE
Add support to provide name and value to data table selections.

### DIFF
--- a/src/data-table/data-table.js
+++ b/src/data-table/data-table.js
@@ -100,6 +100,12 @@ MaterialDataTable.prototype.createCheckbox_ = function(row, rows) {
   checkbox.classList.add('mdl-checkbox__input');
   if (row) {
     checkbox.addEventListener('change', this.selectRow_(checkbox, row));
+    if (row.dataset.mdlDataTableSelectableName) {
+      checkbox.name = row.dataset.mdlDataTableSelectableName;
+    }
+    if (row.dataset.mdlDataTableSelectableValue) {
+      checkbox.value = row.dataset.mdlDataTableSelectableValue;
+    }
   } else if (rows) {
     checkbox.addEventListener('change', this.selectRow_(checkbox, null, rows));
   }


### PR DESCRIPTION
This allows developers to add the following attributes to *rows* of the table body. This will then tell the data table JS to set the name and value of the checkbox to what is provided as the attribute values.

`data-mdl-data-table-selectable-name` and `data-mdl-data-table-selectable-value` are the attributes that are available for definition.

Use-case: Using the checkboxes in a submitted form to say, delete records or specify which records are to be modified.