### PR TITLE
Don't save space for a burger icon when drawer is fixed (fixes #1032)

### DIFF
--- a/src/layout/_layout.scss
+++ b/src/layout/_layout.scss
@@ -243,6 +243,12 @@
       width: calc(100% - #{$layout-drawer-width});
     }
 
+    .mdl-layout--fixed-drawer > & {
+      .mdl-layout__header-row {
+        padding-left: 40px;
+      }
+    }
+
     & > .mdl-layout-icon {
       position: absolute;
       left: $layout-header-desktop-indent;


### PR DESCRIPTION
That commit message made me hungry.

Before:
<img width="620" alt="screenshot 2015-07-22 17 00 16" src="https://cloud.githubusercontent.com/assets/234957/8830457/3d1eea2c-3094-11e5-9dff-d58e2186bafb.png">

After:
<img width="521" alt="screenshot 2015-07-22 17 06 54" src="https://cloud.githubusercontent.com/assets/234957/8830462/422e61aa-3094-11e5-99b0-de5d32c49fa2.png">
