### PR TITLE
Material tabs shouldn't event.preventDefault().

### DIFF
--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -401,7 +401,6 @@ function MaterialLayoutTab(tab, tabs, panels, layout) {
     }
 
     tab.addEventListener('click', function(e) {
-      e.preventDefault();
       var href = tab.href.split('#')[1];
       var panel = layout.content_.querySelector('#' + href);
       layout.resetTabState_(tabs);


### PR DESCRIPTION
Otherwise, the href tags do not get updated, which prevents the ability to bookmark different tab locations.