### PR TITLE
Set textare to `display: block` to remove baseline spacing (fixes #1178)

### DIFF
--- a/src/textfield/_textfield.scss
+++ b/src/textfield/_textfield.scss
@@ -83,6 +83,10 @@
   }
 }
 
+.mdl-textfield textarea.mdl-textfield__input {
+  display: block;
+}
+
 // Styling for the label / floating label.
 .mdl-textfield__label {
   bottom: 0;


### PR DESCRIPTION
Before:
<img width="126" alt="screenshot 2015-07-28 17 32 22" src="https://cloud.githubusercontent.com/assets/234957/8937218/fa36b9a0-354e-11e5-93de-d776d9fdaebf.png">
After:
<img width="135" alt="screenshot 2015-07-28 17 32 33" src="https://cloud.githubusercontent.com/assets/234957/8937221/fcb23268-354e-11e5-9b8c-59cc34a8d0a6.png">
