### PR TITLE
Add an additional 'show' method for manually selecting the tab.

### DIFF
--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -403,6 +403,16 @@
   };
 
   function MaterialLayoutTab(tab, tabs, panels, layout) {
+
+    function selectTab() {
+        var href = tab.href.split('#')[1];
+        var panel = layout.content_.querySelector('#' + href);
+        layout.resetTabState_(tabs);
+        layout.resetPanelState_(panels);
+        tab.classList.add(layout.CssClasses_.IS_ACTIVE);
+        panel.classList.add(layout.CssClasses_.IS_ACTIVE);
+    }
+
     if (tab) {
       if (layout.tabBar_.classList.contains(
           layout.CssClasses_.JS_RIPPLE_EFFECT)) {
@@ -417,14 +427,10 @@
 
       tab.addEventListener('click', function(e) {
         e.preventDefault();
-        var href = tab.href.split('#')[1];
-        var panel = layout.content_.querySelector('#' + href);
-        layout.resetTabState_(tabs);
-        layout.resetPanelState_(panels);
-        tab.classList.add(layout.CssClasses_.IS_ACTIVE);
-        panel.classList.add(layout.CssClasses_.IS_ACTIVE);
+        selectTab();
       });
 
+      tab.show = selectTab;
     }
   }
 

--- a/test/unit/layout.js
+++ b/test/unit/layout.js
@@ -33,4 +33,68 @@ describe('MaterialLayout', function () {
     expect($(el)).to.have.data('upgraded', ',MaterialLayout');
   });
 
+  describe('Click on the tabs', function (done) {
+     var el;
+     var tab1, tab2;
+     var content1, content2;
+
+     beforeEach(function() {
+       el = document.createElement('div');
+       el.innerHTML = '' +
+       '  <header class="mdl-layout__header">' +
+       '    <div class="mdl-layout__tab-bar mdl-js-ripple-effect">' +
+       '      <a id="tab1" href="#scroll-tab-1" class="mdl-layout__tab is-active">Tab 1</a>' +
+       '      <a id="tab2" href="#scroll-tab-2" class="mdl-layout__tab">Tab 2</a>' +
+       '      <a id="tab3" href="#scroll-tab-3" class="mdl-layout__tab">Tab 3</a>' +
+       '    </div>' +
+       '  </header>' +
+       '  <main class="mdl-layout__content">' +
+       '    <section class="mdl-layout__tab-panel is-active" id="scroll-tab-1">' +
+       '      <div class="page-content"><!-- Your content goes here --></div>' +
+       '    </section>' +
+       '    <section class="mdl-layout__tab-panel" id="scroll-tab-2">' +
+       '      <div class="page-content"><!-- Your content goes here --></div>' +
+       '    </section>' +
+       '    <section class="mdl-layout__tab-panel" id="scroll-tab-3">' +
+       '      <div class="page-content"><!-- Your content goes here --></div>' +
+       '    </section>' +
+       '  </main>';
+
+       var parent = document.createElement('div');
+       parent.appendChild(el); // MaterialLayout.init() expects a parent
+
+       tab1 = el.querySelector('#tab1');
+       tab2 = el.querySelector('#tab2');
+       content1 = el.querySelector('#scroll-tab-1');
+       content2 = el.querySelector('#scroll-tab-2');
+
+       componentHandler.upgradeElement(el, 'MaterialLayout');
+     });
+
+     it('should activate the second tab on click', function (done) {
+       var ev = document.createEvent('MouseEvents');
+       ev.initEvent('click', true, true);
+       tab2.dispatchEvent(ev);
+
+       window.setTimeout(function () {
+         expect($(tab1)).to.not.have.class('is-active');
+         expect($(content1)).to.not.have.class('is-active');
+         expect($(tab2)).to.have.class('is-active');
+         expect($(content2)).to.have.class('is-active');
+         done();
+       }, 100);
+     });
+
+     it('should activate the second tab on custom show method', function (done) {
+       tab2.show();
+
+       window.setTimeout(function () {
+         expect($(tab1)).to.not.have.class('is-active');
+         expect($(content1)).to.not.have.class('is-active');
+         expect($(tab2)).to.have.class('is-active');
+         expect($(content2)).to.have.class('is-active');
+         done();
+       }, 100);
+     });
+   });
 });


### PR DESCRIPTION
Similar to Twitter Bootstrap tab support in which a tab can be fired with a 'show' call. (http://getbootstrap.com/javascript/#tabs).
  
This way we can determine whether the tab was selected programatically or through the mouse 
allows us to leverage the HTML5 History API to monitor browser history.

See: http://www.redotheweb.com/2012/05/17/enable-back-button-handling-with-twitter-bootstrap-tabs-plugin.html for more context.  When using the HTML5 History API, popstate() needs to be able to call a 'show' event instead of a 'click' event since history is pushed normally during onclick events.