### PR TITLE
Set textfield internal nodes to block (fixes #1236)

### DIFF
--- a/src/textfield/_textfield.scss
+++ b/src/textfield/_textfield.scss
@@ -59,7 +59,7 @@
 .mdl-textfield__input {
   border: none;
   border-bottom: 1px solid $input-text-bottom-border-color;
-  display: inline-block;
+  display: block;
   font-size: $input-text-font-size;
   margin: 0;
   padding: $input-text-padding 0;
@@ -92,6 +92,7 @@
   right: 0;
   pointer-events: none;
   position: absolute;
+  display: block;
   top: ($input-text-padding + $input-text-vertical-spacing);
   width: 100%;
   overflow: hidden;
@@ -156,6 +157,7 @@
   font-size: 12px;
   margin-top: 3px;
   visibility: hidden;
+  display: block;
 
   .mdl-textfield.is-invalid & {
     visibility: visible;


### PR DESCRIPTION
r: @addyosmani @Garbee 

I’m not sure if we can do this. It solves the mentioned issue and I couldn’t find any regressions, but I’m not sure I have thought about all the possible implications. Please double check.