### PR TITLE
Remove superfluous display property on .mdl-button

### DIFF
--- a/src/button/_button.scss
+++ b/src/button/_button.scss
@@ -23,7 +23,6 @@
   border: none;
   border-radius: $button-border-radius;
   color: $button-secondary-color;
-  display: block;
   position: relative;
   height: $button-height;
   min-width: $button-min-width;


### PR DESCRIPTION
`.mdl-button` has the `display` property set twice.