### PR TITLE
fixes git clone --bare to git clone to run npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ to our CSS-only experience.
 Clone the repo using Git:
 
 ```bash
-git clone --bare https://github.com/google/material-design-lite.git
+git clone https://github.com/google/material-design-lite.git
 ```
 
 Alternatively you can [download](https://github.com/google/material-design-lite/archive/master.zip)


### PR DESCRIPTION
removed --bare flag to clone repo and be able to run npm install issue #1272 