### PR TITLE
link for wiki added in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ Please keep in mind that one of the goals of MDL is to adhere to the Material
 Design specs and therefore some requests might not be within the scope of this
 project.
 
-## Contribute
-If you found a bug, have any questions or want to contribute. Follow our [guidelines](https://github.com/google/material-design-lite/blob/master/CONTRIBUTING.md), and help improve the Material Design Lite.
+## Want to contribute?
+If you found a bug, have any questions or want to contribute. Follow our [guidelines](https://github.com/google/material-design-lite/blob/master/CONTRIBUTING.md), and help improve the Material Design Lite. For more information visit our [wiki](https://github.com/google/material-design-lite/wiki).
 
 ## Do you include any features that a framework comes with?
 


### PR DESCRIPTION
The wiki has a very good content.
When someone sees the project for the first time, not to know that the wiki is being used. So I think valid to add a link in the readme.md.

I changed the "Contribute" by "Want to Contribute?" For more friendly tip :)