### PR TITLE
Adding extra git commands that windows users should run to receive correct line endings

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Windows users, if you have trouble compiling due to line endings then make sure 
 ```
 git config core.eol lf
 git config core.autocrlf input
+git rm --cached -r .
+git reset --hard
 ```
 
 > Remember, the master branch is considered unstable. Do not use this in production. Use a tagged state of the repository, npm, or bower for stability!


### PR DESCRIPTION
As discussed in #743 and #1299 for Windows users to receive the correct line endings they need to reset their git repository after they set ```core.eol```

I spent a couple hours trying to debug this.

P.S. First EVER pull request, sorry if I'm doing it wrong.