### PR TITLE
Removing uneeded classes from documentation codepen examples 

### DIFF
--- a/src/progress/snippets/progress-buffering.html
+++ b/src/progress/snippets/progress-buffering.html
@@ -1,5 +1,5 @@
 <!-- MDL Progress Bar with Buffering -->
-<div id="p3" class="mdl-progress mdl-js-progress progress-demo"></div>
+<div id="p3" class="mdl-progress mdl-js-progress"></div>
 <script>
   document.querySelector('#p3').addEventListener('mdl-componentupgraded', function() {
     this.MaterialProgress.setProgress(33);

--- a/src/progress/snippets/progress-default.html
+++ b/src/progress/snippets/progress-default.html
@@ -1,5 +1,5 @@
 <!-- Simple MDL Progress Bar -->
-<div id="p1" class="mdl-progress mdl-js-progress progress-demo"></div>
+<div id="p1" class="mdl-progress mdl-js-progress"></div>
 <script>
   document.querySelector('#p1').addEventListener('mdl-componentupgraded', function() {
     this.MaterialProgress.setProgress(44);

--- a/src/progress/snippets/progress-indeterminate.html
+++ b/src/progress/snippets/progress-indeterminate.html
@@ -1,2 +1,2 @@
 <!-- MDL Progress Bar with Indeterminate Progress -->
-<div id="p2" class="mdl-progress mdl-js-progress mdl-progress__indeterminate progress-demo"></div>
+<div id="p2" class="mdl-progress mdl-js-progress mdl-progress__indeterminate"></div>

--- a/src/textfield/snippets/textfield-expanding.html
+++ b/src/textfield/snippets/textfield-expanding.html
@@ -1,6 +1,6 @@
 <!-- Expandable Textfield -->
 <form action="#">
-  <div class="mdl-textfield mdl-js-textfield mdl-textfield--expandable textfield-demo">
+  <div class="mdl-textfield mdl-js-textfield mdl-textfield--expandable">
     <label class="mdl-button mdl-js-button mdl-button--icon" for="sample6">
       <i class="material-icons">search</i>
     </label>

--- a/src/textfield/snippets/textfield-floating-numeric.html
+++ b/src/textfield/snippets/textfield-floating-numeric.html
@@ -1,6 +1,6 @@
 <!-- Numeric Textfield with Floating Label -->
 <form action="#">
-  <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label textfield-demo">
+  <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
     <input class="mdl-textfield__input" type="text" pattern="-?[0-9]*(\.[0-9]+)?" id="sample4" />
     <label class="mdl-textfield__label" for="sample4">Number...</label>
     <span class="mdl-textfield__error">Input is not a number!</span>

--- a/src/textfield/snippets/textfield-floating-text.html
+++ b/src/textfield/snippets/textfield-floating-text.html
@@ -1,7 +1,7 @@
 <!-- Textfield with Floating Label -->
 
 <form action="#">
-  <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label textfield-demo">
+  <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
     <input class="mdl-textfield__input" type="text" id="sample3" />
     <label class="mdl-textfield__label" for="sample3">Text...</label>
   </div>

--- a/src/textfield/snippets/textfield-multi-line.html
+++ b/src/textfield/snippets/textfield-multi-line.html
@@ -1,6 +1,6 @@
 <!-- Floating Multiline Textfield -->
 <form action="#">
-  <div class="mdl-textfield mdl-js-textfield textfield-demo">
+  <div class="mdl-textfield mdl-js-textfield">
     <textarea class="mdl-textfield__input" type="text" rows= "3" id="sample5" ></textarea>
     <label class="mdl-textfield__label" for="sample5">Text lines...</label>
   </div>

--- a/src/textfield/snippets/textfield-numeric.html
+++ b/src/textfield/snippets/textfield-numeric.html
@@ -1,6 +1,6 @@
 <!-- Numeric Textfield -->
 <form action="#">
-  <div class="mdl-textfield mdl-js-textfield textfield-demo">
+  <div class="mdl-textfield mdl-js-textfield">
     <input class="mdl-textfield__input" type="text" pattern="-?[0-9]*(\.[0-9]+)?" id="sample2" />
     <label class="mdl-textfield__label" for="sample2">Number...</label>
     <span class="mdl-textfield__error">Input is not a number!</span>

--- a/src/textfield/snippets/textfield-text.html
+++ b/src/textfield/snippets/textfield-text.html
@@ -1,6 +1,6 @@
 <!-- Simple Textfield -->
 <form action="#">
-  <div class="mdl-textfield mdl-js-textfield textfield-demo">
+  <div class="mdl-textfield mdl-js-textfield">
     <input class="mdl-textfield__input" type="text" id="sample1" />
     <label class="mdl-textfield__label" for="sample1">Text...</label>
   </div>


### PR DESCRIPTION
A number of codepen examples contain uneeded CSS classes on elements. These classes were mistakenly put in the codepens because they were copied from the on page demos which used them for slight formatting changes.

[Loading documentaion](http://www.getmdl.io/components/index.html#loading-section) contained ```progress-demo```
[Text field documentaion](http://www.getmdl.io/components/index.html#textfields-section) contained ```textfield-demo```