### PR TITLE
Readme.md links to the wrong location for the "Cutting the mustard" test

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ templates:
 
 > Templates are not officially supported in IE9 and legacy browsers that do not
 pass the minimum-requirements defined in our
-[cutting-the-mustard test](https://github.com/google/material-design-lite/blob/master/src/mdlComponentHandler.js#L262-L275).
+[cutting-the-mustard test](https://github.com/google/material-design-lite/blob/87c48c22416c3e83850f7711365b2a43ba19c5ce/src/mdlComponentHandler.js#L336-L349).
 
 ## Versioning
 


### PR DESCRIPTION
[Readme.md](https://github.com/google/material-design-lite/blob/master/README.md) contains the following link: [cutting-the-mustard test](https://github.com/google/material-design-lite/blob/master/src/mdlComponentHandler.js#L262-L275). It's supposed to link to the "Cutting the mustard" test in mdlComponentHandler.js but the line numbers it links to have since changed and it no longer links to the correct location.

This PR pins the link to the most recent commit so the line numbers won't change. This will become dated but less often than the line numbers changing.