### PR TITLE
Fixing CSS formatting and naming inconsistencies in demos

### DIFF
--- a/docs/_assets/codepen.js
+++ b/docs/_assets/codepen.js
@@ -126,8 +126,8 @@ CodeBlockCodePen.prototype.clickHandler = function(form, pre) {
           '  <head>\n    ' + this.MDLIBS.join('\n    ') + '\n  </head>\n' +
           '  <body>\n    ' + code.split('\n').join('\n    ') + '\n  </body>\n' +
           '</html>',
-        css: '  ' + css,
-        js: '  ' + js}));
+        css: css,
+        js: js}));
     form.appendChild(input);
 
     form.submit();

--- a/docs/_templates/snippets.html
+++ b/docs/_templates/snippets.html
@@ -32,11 +32,11 @@
   </div>
   <div class="snippet-code">
     <pre class="language-markup codepen-button-enabled">{% for snippet in snippet_group %}{% set snippet_file = "../../src/" + component_name + "/snippets/" + snippet.file %}<code id="{{ component_name }}/{{ snippet.file }}">{% filter e('html') %}{% include snippet_file ignore missing %}{% endfilter %}</code><div class="codepen-extra-css">&lt;style&gt;{% set extra_css_file = "../../src/" + component_name + "/snippets/" + snippet.extra_codepen_css %}{% include extra_css_file ignore missing %}&lt;/style&gt;</div>{%- endfor %}{% if snippet_group.length !== 1 || !snippet_group[0].full_width %}<div class="codepen-extra-css">&lt;style&gt;
-  body {
-    padding: 20px;
-    background: #fafafa;
-    position: relative;
-  }
+body {
+  padding: 20px;
+  background: #fafafa;
+  position: relative;
+}
 &lt;/style&gt;</div>{% endif %}<form class="codepen-button" action="https://codepen.io/pen/define" method="POST" target="_blank"></form></pre>
   </div>
 </div>

--- a/src/card/snippets/event.html
+++ b/src/card/snippets/event.html
@@ -1,32 +1,32 @@
 <!-- Event card -->
 <style>
-  .demo-card-event.mdl-card {
-    width: 256px;
-    height: 256px;
-    background: #3E4EB8;
-  }
-  .demo-card-event > .mdl-card__actions {
-    border-color: rgba(255, 255, 255, 0.2);
-  }
-  .demo-card-event > .mdl-card__title {
-    align-items: flex-start;
-  }
-  .demo-card-event > .mdl-card__title > h4 {
-    margin-top: 0;
-  }
-  .demo-card-event > .mdl-card__actions {
-    display: flex;
-    box-sizing:border-box;
-    align-items: center;
-  }
-  .demo-card-event > .mdl-card__title,
-  .demo-card-event > .mdl-card__actions,
-  .demo-card-event > .mdl-card__actions > .mdl-button {
-    color: #fff;
-  }
+.demo-card-event.mdl-card {
+  width: 256px;
+  height: 256px;
+  background: #3E4EB8;
+}
+.demo-card-event > .mdl-card__actions {
+  border-color: rgba(255, 255, 255, 0.2);
+}
+.demo-card-event > .mdl-card__title {
+  align-items: flex-start;
+}
+.demo-card-event > .mdl-card__title > h4 {
+  margin-top: 0;
+}
+.demo-card-event > .mdl-card__actions {
+  display: flex;
+  box-sizing:border-box;
+  align-items: center;
+}
+.demo-card-event > .mdl-card__title,
+.demo-card-event > .mdl-card__actions,
+.demo-card-event > .mdl-card__actions > .mdl-button {
+  color: #fff;
+}
 </style>
 
-<div class="mdl-card mdl-shadow--2dp demo-card-event">
+<div class="demo-card-event mdl-card mdl-shadow--2dp">
   <div class="mdl-card__title mdl-card--expand">
     <h4>
       Featured event:<br>

--- a/src/card/snippets/image.html
+++ b/src/card/snippets/image.html
@@ -1,23 +1,23 @@
 <!-- Image card -->
 <style>
-  .demo-card-image.mdl-card {
-    width: 256px;
-    height: 256px;
-    background: url('../assets/demos/image_card.jpg') center / cover;
-  }
-  .demo-card-image > .mdl-card__actions {
-    height: 52px;
-    padding: 16px;
-    background: rgba(0, 0, 0, 0.2);
-  }
-  .demo-card-image__filename {
-    color: #fff;
-    font-size: 14px;
-    font-weight: 500;
-  }
+.demo-card-image.mdl-card {
+  width: 256px;
+  height: 256px;
+  background: url('../assets/demos/image_card.jpg') center / cover;
+}
+.demo-card-image > .mdl-card__actions {
+  height: 52px;
+  padding: 16px;
+  background: rgba(0, 0, 0, 0.2);
+}
+.demo-card-image__filename {
+  color: #fff;
+  font-size: 14px;
+  font-weight: 500;
+}
 </style>
 
-<div class="mdl-card mdl-shadow--2dp demo-card-image">
+<div class="demo-card-image mdl-card mdl-shadow--2dp">
   <div class="mdl-card__title mdl-card--expand"></div>
   <div class="mdl-card__actions">
     <span class="demo-card-image__filename">Image.jpg</span>

--- a/src/card/snippets/square.html
+++ b/src/card/snippets/square.html
@@ -1,17 +1,17 @@
 <!-- Square card -->
 <style>
-  .demo-card-square.mdl-card {
-    width: 320px;
-    height: 320px;
-  }
-  .demo-card-square > .mdl-card__title {
-    color: #fff;
-    background:
-      url('../assets/demos/dog.png') bottom right 15% no-repeat #46B6AC;
-  }
+.demo-card-square.mdl-card {
+  width: 320px;
+  height: 320px;
+}
+.demo-card-square > .mdl-card__title {
+  color: #fff;
+  background:
+    url('../assets/demos/dog.png') bottom right 15% no-repeat #46B6AC;
+}
 </style>
 
-<div class="mdl-card mdl-shadow--2dp demo-card-square">
+<div class="demo-card-square mdl-card mdl-shadow--2dp">
   <div class="mdl-card__title mdl-card--expand">
     <h2 class="mdl-card__title-text">Update</h2>
   </div>

--- a/src/card/snippets/wide.html
+++ b/src/card/snippets/wide.html
@@ -1,19 +1,19 @@
 <!-- Wide card with share menu button -->
 <style>
-  .demo-card-wide.mdl-card {
-    width: 512px;
-  }
-  .demo-card-wide > .mdl-card__title {
-    color: #fff;
-    height: 176px;
-    background: url('../assets/demos/welcome_card.jpg') center / cover;
-  }
-  .demo-card-wide > .mdl-card__menu {
-    color: #fff;
-  }
+.demo-card-wide.mdl-card {
+  width: 512px;
+}
+.demo-card-wide > .mdl-card__title {
+  color: #fff;
+  height: 176px;
+  background: url('../assets/demos/welcome_card.jpg') center / cover;
+}
+.demo-card-wide > .mdl-card__menu {
+  color: #fff;
+}
 </style>
 
-<div class="mdl-card mdl-shadow--2dp demo-card-wide">
+<div class="demo-card-wide mdl-card mdl-shadow--2dp">
   <div class="mdl-card__title">
     <h2 class="mdl-card__title-text">Welcome</h2>
   </div>

--- a/src/layout/snippets/transparent.html
+++ b/src/layout/snippets/transparent.html
@@ -1,16 +1,17 @@
 <!-- Uses a transparent header that draws on top of the layout's background -->
 <style>
-.layout-transparent {
+.demo-layout-transparent {
   background: url('../assets/demos/transparent.jpg') center / cover;
 }
-.layout-transparent .mdl-layout__header,
-.layout-transparent .mdl-layout__drawer-button {
+.demo-layout-transparent .mdl-layout__header,
+.demo-layout-transparent .mdl-layout__drawer-button {
   /* This background is dark, so we set text to white. Use 87% black instead if
      your background is light. */
   color: white;
 }
 </style>
-<div class="layout-transparent mdl-layout mdl-js-layout">
+
+<div class="demo-layout-transparent mdl-layout mdl-js-layout">
   <header class="mdl-layout__header mdl-layout__header--transparent">
     <div class="mdl-layout__header-row">
       <!-- Title -->

--- a/src/layout/snippets/waterfall-header.html
+++ b/src/layout/snippets/waterfall-header.html
@@ -1,10 +1,11 @@
 <!-- Uses a header that contracts as the page scrolls down. -->
 <style>
-.waterfall-demo-header-nav .mdl-navigation__link:last-of-type  {
+.demo-layout-waterfall .mdl-layout__header-row .mdl-navigation__link:last-of-type  {
   padding-right: 0;
 }
 </style>
-<div class="mdl-layout mdl-js-layout mdl-layout--overlay-drawer-button">
+
+<div class="demo-layout-waterfall mdl-layout mdl-js-layout mdl-layout--overlay-drawer-button">
   <header class="mdl-layout__header mdl-layout__header--waterfall">
     <!-- Top row, always visible -->
     <div class="mdl-layout__header-row">
@@ -27,7 +28,7 @@
     <div class="mdl-layout__header-row">
       <div class="mdl-layout-spacer"></div>
       <!-- Navigation -->
-      <nav class="waterfall-demo-header-nav mdl-navigation">
+      <nav class="mdl-navigation">
         <a class="mdl-navigation__link" href="">Link</a>
         <a class="mdl-navigation__link" href="">Link</a>
         <a class="mdl-navigation__link" href="">Link</a>


### PR DESCRIPTION
Sorry to raise this issue, I was reluctant as it may seem trivial.

I was just fixing #1009 which requires some CSS to be added to the code example. I wasn't sure how it should be formatted or named so I checked all other examples that contain CSS (there are 6) and there were a number of inconsistencies.

1 ) **Class naming**

The naming convention was different in a number of places, the [card documentation](http://www.getmdl.io/components/index.html#cards-section) appears to contain the best naming convention, for example:
```
.demo-card-event
.demo-card-wide
.demo-card-square
.demo-card-image
```
This follows `demo-[component name]-[demo name]` so I've fixed the two examples in [layout](http://www.getmdl.io/components/index.html#layout-section/layout) that didn't follow this convention.

2 ) **Indentation**

Some of the examples indented the CSS inside the `<style>` element:
```css
<style>
  .demo-card-wide.mdl-card {
    width: 512px;
  }
<style>
```
others kept it at the same level:
```css
<style>
.demo-card-wide.mdl-card {
  width: 512px;
}
</style>
```
The indented looks better in the documentation but when you open it in a codepen it adds those two spaces before the CSS which makes it a bit of a pain to work with.

3 ) **Class location on element**

Sometimes it was first:
```<div class="demo-card-event mdl-card">```

Sometimes it was last:
```<div class="mdl-card demo-card-event">```

This is trivial but I felt I may as well make it consistent and moved them to be first, I felt this was easiest for developers to see the class name could be removed.

Let me know what you think of this and if any other changes are required. I'll do #1009 once this is okay.