### PR TITLE
Fix radio label wrapping in docs

### DIFF
--- a/src/radio/snippets/radio-off.html
+++ b/src/radio/snippets/radio-off.html
@@ -1,4 +1,4 @@
 <label class="mdl-radio mdl-js-radio mdl-js-ripple-effect" for="option-2">
   <input type="radio" id="option-2" class="mdl-radio__button" name="options" value="2" />
-  <span class="mdl-radio__label">Option 2</span>
+  <span class="mdl-radio__label">Second</span>
 </label>

--- a/src/radio/snippets/radio-on.html
+++ b/src/radio/snippets/radio-on.html
@@ -1,4 +1,4 @@
 <label class="mdl-radio mdl-js-radio mdl-js-ripple-effect" for="option-1">
   <input type="radio" id="option-1" class="mdl-radio__button" name="options" value="1" checked />
-  <span class="mdl-radio__label">Option 1</span>
+  <span class="mdl-radio__label">First</span>
 </label>


### PR DESCRIPTION
Radio labels currently wrap in the docs, due to our overly aggressive table sizing strategy. This fixes the issue for now, until we rework the docs. Fixes #1322.

@surma PTAL.