### PR TITLE
updates Layout so mdl-layout is the root element

### DIFF
--- a/src/layout/_layout.scss
+++ b/src/layout/_layout.scss
@@ -35,14 +35,9 @@
 
 // Main layout class.
 .mdl-layout {
+  position: absolute;
   width: 100%;
   height: 100%;
-  display: flex;
-  flex-direction: column;
-  overflow-y: auto;
-  overflow-x: hidden;
-  position: relative;
-  -webkit-overflow-scrolling: touch;
 }
 
 // Utility classes for screen sizes.
@@ -54,10 +49,15 @@
   display: none;
 }
 
-.mdl-layout__container {
-  position: absolute;
+.mdl-layout__inner-container {
   width: 100%;
   height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  overflow-x: hidden;
+  position: relative;
+  -webkit-overflow-scrolling: touch;
 }
 
 
@@ -157,7 +157,7 @@
     }
 
     @media screen and (min-width: $layout-screen-size-threshold + 1px) {
-      .mdl-layout--fixed-drawer > & {
+      .mdl-layout--fixed-drawer > .mdl-layout__inner-container > & {
         transform: translateX(0);
       }
     }
@@ -205,7 +205,7 @@
     }
 
     @media screen and (min-width: $layout-screen-size-threshold + 1px) {
-      .mdl-layout--fixed-drawer > & {
+      .mdl-layout--fixed-drawer > .mdl-layout__inner-container > & {
         display: none;
       }
     }
@@ -238,13 +238,13 @@
       min-height: $layout-mobile-header-height;
     }
 
-    .mdl-layout--fixed-drawer:not(.is-small-screen) > & {
+    .mdl-layout--fixed-drawer:not(.is-small-screen) > .mdl-layout__inner-container > & {
       margin-left: $layout-drawer-width;
       width: calc(100% - #{$layout-drawer-width});
     }
 
     @media screen and (min-width: $layout-screen-size-threshold) {
-      .mdl-layout--fixed-drawer > & {
+      .mdl-layout--fixed-drawer > .mdl-layout__inner-container > & {
         .mdl-layout__header-row {
           padding-left: 40px;
         }
@@ -292,7 +292,7 @@
         display: none;
       }
 
-      .mdl-layout--fixed-header > & {
+      .mdl-layout--fixed-header > .mdl-layout__inner-container > & {
         display: flex;
       }
     }
@@ -401,20 +401,20 @@
     z-index: 1;
     -webkit-overflow-scrolling: touch;
 
-    .mdl-layout--fixed-drawer > & {
+    .mdl-layout--fixed-drawer > .mdl-layout__inner-container > & {
       margin-left: $layout-drawer-width;
     }
 
-    .mdl-layout__container.has-scrolling-header & {
+    .mdl-layout.has-scrolling-header & {
       overflow: visible;
     }
 
     @media screen and (max-width: $layout-screen-size-threshold) {
-      .mdl-layout--fixed-drawer > & {
+      .mdl-layout--fixed-drawer > .mdl-layout__inner-container > & {
         margin-left: 0;
       }
 
-      .mdl-layout__container.has-scrolling-header & {
+      .mdl-layout.has-scrolling-header & {
         overflow-y: auto;
         overflow-x: hidden;
       }
@@ -463,7 +463,7 @@
     flex-shrink: 0;
     overflow: hidden;
 
-    .mdl-layout__container > & {
+    .mdl-layout > .mdl-layout__inner-container > & {
       position: absolute;
       top: 0;
       left: 0;

--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -70,7 +70,7 @@
    * @private
    */
   MaterialLayout.prototype.CssClasses_ = {
-    CONTAINER: 'mdl-layout__container',
+    INNER_CONTAINER: 'mdl-layout__inner-container',
     HEADER: 'mdl-layout__header',
     DRAWER: 'mdl-layout__drawer',
     CONTENT: 'mdl-layout__content',
@@ -211,12 +211,6 @@
    */
   MaterialLayout.prototype.init = function() {
     if (this.element_) {
-      var container = document.createElement('div');
-      container.classList.add(this.CssClasses_.CONTAINER);
-      this.element_.parentElement.insertBefore(container, this.element_);
-      this.element_.parentElement.removeChild(this.element_);
-      container.appendChild(this.element_);
-
       var directChildren = this.element_.childNodes;
       for (var c = 0; c < directChildren.length; c++) {
         var child = directChildren[c];
@@ -261,7 +255,7 @@
         } else if (this.header_.classList.contains(
             this.CssClasses_.HEADER_SCROLL)) {
           mode = this.Mode_.SCROLL;
-          container.classList.add(this.CssClasses_.HAS_SCROLLING_HEADER);
+          this.element_.classList.add(this.CssClasses_.HAS_SCROLLING_HEADER);
         }
 
         if (mode === this.Mode_.STANDARD) {
@@ -283,10 +277,6 @@
           this.contentScrollHandler_();
         }
       }
-
-      var eatEvent = function(ev) {
-        ev.preventDefault();
-      };
 
       // Add drawer toggling button to our layout, if we have an openable drawer.
       if (this.drawer_) {
@@ -312,8 +302,6 @@
         // not be present.
         this.element_.classList.add(this.CssClasses_.HAS_DRAWER);
 
-        this.drawer_.addEventListener('mousewheel', eatEvent);
-
         // If we have a fixed header, add the button to the header rather than
         // the layout.
         if (this.element_.classList.contains(this.CssClasses_.FIXED_HEADER)) {
@@ -327,7 +315,6 @@
         this.element_.appendChild(obfuscator);
         obfuscator.addEventListener('click',
             this.drawerToggleHandler_.bind(this));
-        obfuscator.addEventListener('mousewheel', eatEvent);
       }
 
       // Initialize tabs, if any.
@@ -397,6 +384,13 @@
           new MaterialLayoutTab(tabs[i], tabs, panels, this);
         }
       }
+
+      var innerContainer = document.createElement('div');
+      innerContainer.classList.add(this.CssClasses_.INNER_CONTAINER);
+      while (this.element_.firstChild) {
+        innerContainer.appendChild(this.element_.firstChild);
+      }
+      this.element_.appendChild(innerContainer);
 
       this.element_.classList.add(this.CssClasses_.IS_UPGRADED);
     }


### PR DESCRIPTION
Read #1356 for context.

`mdl-layout` is now the root element
`mdl-layout__container` is no longer available
During the upgrade, all children of `mdl-layout` are moved inside `mdl-layout__inner-container` and the inner container is the only child of `mdl-layout`.

The `eatEvent` was causing a few issues in the scrolling example, so I removed it. Doesn't seem to cause any other issues.