### PR TITLE
Don't use styleguide to compile css lib (fixes #1366)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -143,7 +143,7 @@ gulp.task('styletemplates', function() {
 gulp.task('styles', function() {
   // For best performance, don't add Sass partials to `gulp.src`
   return gulp.src([
-    'src/styleguide.scss'
+    'src/material-design-lite.scss'
   ])
     // Generate Source Maps
     .pipe($.sourcemaps.init())


### PR DESCRIPTION
r: @sgomes 

Cross-browser tests look good. Not sure if we should merge this in 1.0.3, 1.1 or even 2.0 (as it could technically be a breaking change). My vote goes for 1.0.3, though.