### PR TITLE
#1355 - Auto Check Checkboxes when the row has the is-selected class

### DIFF
--- a/src/data-table/data-table.js
+++ b/src/data-table/data-table.js
@@ -116,7 +116,9 @@
     var checkbox = document.createElement('input');
     checkbox.type = 'checkbox';
     checkbox.classList.add('mdl-checkbox__input');
+
     if (row) {
+      checkbox.checked = row.classList.contains(this.CssClasses_.IS_SELECTED);
       checkbox.addEventListener('change', this.selectRow_(checkbox, row));
     } else if (rows) {
       checkbox.addEventListener('change', this.selectRow_(checkbox, null, rows));

--- a/test/unit/data-table.js
+++ b/test/unit/data-table.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*global describe, it, expect, MaterialDataTable, componentHandler */
+
+describe('MaterialDataTable', function () {
+
+  function createTable() {
+    var table = document.createElement('table');
+    table.classList.add('mdl-data-table');
+    table.classList.add('mdl-js-data-table');
+
+    table.createTHead();
+    var headTh = document.createElement('th');
+    table.querySelector('thead').appendChild(headTh);
+
+    var tBodyRow = table.insertRow(0);
+    tBodyRow.insertCell(0);
+
+    return table;
+  }
+
+  it('should be globally available', function () {
+    expect(MaterialDataTable).to.be.a('function');
+  });
+
+  it('should upgrade successfully', function () {
+    var el = document.createElement('div');
+    el.appendChild(createTable());
+
+    componentHandler.upgradeElement(el, 'MaterialDataTable');
+    expect($(el)).to.have.data('upgraded', ',MaterialDataTable');
+  });
+
+  it('should have is-checked class when the row has the is-selected class', function () {
+    var el = document.createElement('div');
+    var table = createTable();
+    table.classList.add('mdl-data-table--selectable');
+    var row = table.insertRow();
+    row.classList.add('is-selected');
+    row.insertCell();
+
+    el.appendChild(table);
+    document.body.appendChild(el);
+
+    var queryTable = document.querySelector('.mdl-data-table');
+    componentHandler.upgradeElement(queryTable, 'MaterialDataTable');
+    expect(queryTable.querySelector('tbody:nth-child(2) label').classList.contains('is-checked')).to.be.true;
+  });
+
+});

--- a/test/unit/data-table.js
+++ b/test/unit/data-table.js
@@ -38,23 +38,20 @@ describe('MaterialDataTable', function () {
   });
 
   it('should upgrade successfully', function () {
-    var el = document.createElement('div');
-    el.appendChild(createTable());
+    var table = createTable();
 
-    componentHandler.upgradeElement(el, 'MaterialDataTable');
-    expect($(el)).to.have.data('upgraded', ',MaterialDataTable');
+    componentHandler.upgradeElement(table, 'MaterialDataTable');
+    expect($(table)).to.have.data('upgraded', ',MaterialDataTable');
   });
 
   it('should have is-checked class when the row has the is-selected class', function () {
-    var el = document.createElement('div');
     var table = createTable();
     table.classList.add('mdl-data-table--selectable');
     var row = table.insertRow();
     row.classList.add('is-selected');
     row.insertCell();
 
-    el.appendChild(table);
-    document.body.appendChild(el);
+    document.body.appendChild(table);
 
     var queryTable = document.querySelector('.mdl-data-table');
     componentHandler.upgradeElement(queryTable, 'MaterialDataTable');


### PR DESCRIPTION
As discussed here: #1355

The main problem is:

When you add a .mdl-data-table to your markup and you need to auto-check a few checkboxes when generating the markup, you just can't. This PR will allow to watch for the .is-selected class in the <tr class="is-selected">... row and automatically check the checkbox.

I also added some basic tests for the data-table.js.
This component has 0 tests right now.

This should be available for V1.1.
Please, let me know if the code needs more improvements.

This PR is a replacement to https://github.com/google/material-design-lite/pull/1372