### PR TITLE
Use code points rather than ligatures in nav

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -94,15 +94,15 @@
           <div class="spacer"></div>
           <a href="https://github.com/google/material-design-lite" class="mdl-navigation__link mdl-navigation__link--icon github"><i class="material-icons">link</i><span>GitHub</span></a>
           <a href="{{page.include_prefix}}started/index.html#download" class="mdl-navigation__link mdl-navigation__link--icon download">
-            <i class="material-icons">file_download</i><span>Download</span>
+            <i class="material-icons">&#xE2C4;</i><span>Download</span>
             <button class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--fab mdl-button--mini-fab mdl-color--lime-A200">
-              <i class="material-icons">file_download</i>
+              <i class="material-icons">&#xE2C4;</i>
             </button>
           </a>
         </nav>
       </div>
-      <i class="material-icons scrollindicator scrollindicator--right">keyboard_arrow_right</i>
-      <i class="material-icons scrollindicator scrollindicator--left">keyboard_arrow_left</i>
+      <i class="material-icons scrollindicator scrollindicator--right">&#xE315;</i>
+      <i class="material-icons scrollindicator scrollindicator--left">&#xE314;</i>
     </header>
     <main class="docs-layout-content mdl-layout__content mdl-color-text--grey-600">
       <div class="content mdl-grid mdl-grid--no-spacing" id="content">


### PR DESCRIPTION
This not only fixes the dreaded keyboard symbol nav issue but also makes the nav items itself clickable again. This stems from the fact that the ligature was `keyboard_arrow_left`, but only the `keyboard` part was turned into a ligature so an invisible `_arrow_left` was covering the nav items.

<img width="644" alt="screenshot 2015-08-13 14 47 01" src="https://cloud.githubusercontent.com/assets/234957/9252614/40ea114c-41d1-11e5-9826-4986743ef5f8.png">
