### PR TITLE
Revert "Fix iOS data table scrolling. Fixes #1194."

### DIFF
--- a/src/data-table/_data-table.scss
+++ b/src/data-table/_data-table.scss
@@ -24,11 +24,6 @@
   white-space: nowrap;
   font-size: $data-table-font-size;
   background-color: unquote("rgb(#{$color-white})");
-  /*
-   * Transform in Safari to solve rendering issue.
-   * See https://github.com/google/material-design-lite/issues/1194
-   */
-  -webkit-transform: translate3d(0,0,0);
 
   thead {
     padding-bottom: 3px;


### PR DESCRIPTION
The original issue (#1194) is not reproducible on devices or simulator with a current iOS release anymore. The fix introduced regressions for tooltips, so we are reverting.