### PR TITLE
Add missing files to release folder (fixes #1422)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -657,7 +657,8 @@ gulp.task('templates:mdl', function() {
 
 gulp.task('_release', function() {
   return gulp.src(['dist/material?(.min)@(.js|.css)?(.map)', 'LICENSE',
-    'README.md', 'bower.json', 'package.json', './sr?/**/*', 'gulpfile.js'])
+    'README.md', 'bower.json', 'package.json', '.jscsrc', '.jshintrc',
+    './sr?/**/*', 'gulpfile.js', './util?/**/*'])
     .pipe(gulp.dest('_release'));
 });
 


### PR DESCRIPTION
I tested it locally and the resulting `_release` folder does not error on `npm install` or `gulp` for me.

I’ll cherry-pick this commit to `master` once LGTM'd.

r: @sgomes @addyosmani 

cc @Zodiase