### PR TITLE
Remove unnecessary line

### DIFF
--- a/src/tabs/_tabs.scss
+++ b/src/tabs/_tabs.scss
@@ -44,7 +44,6 @@
   position: relative;
   display: block;
 
-  color: red;
   text-decoration: none;
   height: 48px;
   line-height: 48px;


### PR DESCRIPTION
Thre property color: red; is unnecessary since it is also being set with the variable $tab-text-color in line 56.