### PR TITLE
Check for snippets and demos before processing (fixes #1447)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -367,6 +367,17 @@ gulp.task('demos', ['demoresources'], function() {
     return fs.readdirSync('./src/')
       .filter(function(file) {
         return fs.statSync(path.join('./src/', file)).isDirectory();
+      })
+      .filter(function(file) {
+        var demoFile = false;
+        var snippetDir = false;
+        try {
+          demoFile = fs.statSync(path.join('./src/', file, 'demo.html')).isFile();
+        } catch (e) {}
+        try {
+          snippetDir = fs.statSync(path.join('./src/', file, 'snippets')).isDirectory();
+        } catch (e) {}
+        return demoFile || snippetDir;
       });
   }
 


### PR DESCRIPTION
Apparently, `gulp-header` lost the capability to handle empty streams. When generating our demos, some of the :file_folder: folders (like `utils`) don’t have a `demo.html` or a `snippet` folder, which made the process break :wheelchair: 

I added something to filter these kind of folders, but I don’t even know how to node :cry: If there’s a more elegant way, please let me know about it :dancer: 

r: @addyosmani @samccone @sgomes 

cc @tkisme @kelsmj @janzelc