### PR TITLE
Align icons with text in navigation link

### DIFF
--- a/src/layout/_layout.scss
+++ b/src/layout/_layout.scss
@@ -31,6 +31,11 @@
   font-weight: 500;
   font-size: $layout-nav-link-font-size;
   margin: 0;
+
+  // Align icons inside link with text
+  & .material-icons {
+    vertical-align: middle;
+  }
 }
 
 // Main layout class.


### PR DESCRIPTION
This allows the icon to be vertically aligned with a text inside a navigation link.