### PR TITLE
Remove import of partials from components

### DIFF
--- a/src/animation/_animation.scss
+++ b/src/animation/_animation.scss
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-@import "../variables";
-
-
 .mdl-animation--default {
   transition-timing-function: $animation-curve-default;
 }

--- a/src/badge/_badge.scss
+++ b/src/badge/_badge.scss
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@import "../variables";
-
 .mdl-badge {
   position : relative;
   white-space: nowrap;

--- a/src/button/_button.scss
+++ b/src/button/_button.scss
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-@import "../variables";
-@import "../mixins";
-
 // The button component. Defaults to a flat button.
 .mdl-button {
   background: transparent;

--- a/src/card/_card.scss
+++ b/src/card/_card.scss
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@import "../variables";
-
 .mdl-card {
   display: flex;
   flex-direction: column;

--- a/src/checkbox/_checkbox.scss
+++ b/src/checkbox/_checkbox.scss
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-@import "../variables";
-@import "../mixins";
-
 .mdl-checkbox {
   position: relative;
 

--- a/src/data-table/_data-table.scss
+++ b/src/data-table/_data-table.scss
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-@import "../variables";
-@import "../mixins";
-
 .mdl-data-table {
   position: relative;
   border: $data-table-dividers;

--- a/src/footer/_mega_footer.scss
+++ b/src/footer/_mega_footer.scss
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-@import "../variables";
-@import "../mixins";
-
 .mdl-mega-footer {
   padding: $footer-min-padding $footer-padding-sides;
 

--- a/src/footer/_mini_footer.scss
+++ b/src/footer/_mini_footer.scss
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@import "../variables";
-
 .mdl-mini-footer {
   display: flex;
   flex-flow: row wrap;

--- a/src/grid/_grid.scss
+++ b/src/grid/_grid.scss
@@ -20,8 +20,6 @@
 * For example: `.mdl-cell--1-col-phone.mdl-cell--1-col-phone`
 */
 
-@import "../variables";
-
 .mdl-grid {
   display: flex;
   flex-flow: row wrap;

--- a/src/icon-toggle/_icon-toggle.scss
+++ b/src/icon-toggle/_icon-toggle.scss
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@import "../variables";
-
 .mdl-icon-toggle {
   position: relative;
 

--- a/src/layout/_layout.scss
+++ b/src/layout/_layout.scss
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-@import "../variables";
-@import "../mixins";
-
 // Navigation classes. Only used here for now, but we may at some point move
 // this to its own component.
 .mdl-navigation {

--- a/src/menu/_menu.scss
+++ b/src/menu/_menu.scss
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-@import "../variables";
-@import "../mixins";
-
 .mdl-menu__container {
   display: block;
   margin: 0;

--- a/src/palette/_palette.scss
+++ b/src/palette/_palette.scss
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@import "../variables";
-
 @if $trim-color-classes == false {
   // Red
 

--- a/src/progress/_progress.scss
+++ b/src/progress/_progress.scss
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@import "../variables";
-
 .mdl-progress {
   display: block;
   position: relative;

--- a/src/radio/_radio.scss
+++ b/src/radio/_radio.scss
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-@import "../variables";
-@import "../mixins";
-
 .mdl-radio {
   position: relative;
 

--- a/src/resets/_h5bp.scss
+++ b/src/resets/_h5bp.scss
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@import "../variables";
-
 /*
  * What follows is the result of much research on cross-browser styling.
  * Credit left inline and big thanks to Nicolas Gallagher, Jonathan Neal,

--- a/src/ripple/_ripple.scss
+++ b/src/ripple/_ripple.scss
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@import "../variables";
-
 .mdl-ripple {
   background       : $ripple-bg-color;
   border-radius    : 50%;

--- a/src/shadow/_shadow.scss
+++ b/src/shadow/_shadow.scss
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-@import "../variables";
-@import "../mixins";
-
 .mdl-shadow--2dp {
   @include shadow-2dp();
 }

--- a/src/slider/_slider.scss
+++ b/src/slider/_slider.scss
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@import "../variables";
-
 // Some CSS magic to target only IE.
 _:-ms-input-placeholder, :root .mdl-slider.mdl-slider.is-upgraded {
   -ms-appearance: none;

--- a/src/spinner/_spinner.scss
+++ b/src/spinner/_spinner.scss
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-@import "../variables";
-
-
 .mdl-spinner {
   display: inline-block;
   position: relative;

--- a/src/switch/_switch.scss
+++ b/src/switch/_switch.scss
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-
-@import "../variables";
-@import "../mixins";
-
 .mdl-switch {
   position: relative;
 

--- a/src/tabs/_tabs.scss
+++ b/src/tabs/_tabs.scss
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-@import "../variables";
-
-
 .mdl-tabs {
   display: block;
   width: 100%;

--- a/src/textfield/_textfield.scss
+++ b/src/textfield/_textfield.scss
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-@import "../variables";
-@import "../mixins";
-
 // The container for the whole component.
 .mdl-textfield {
   position: relative;

--- a/src/tooltip/_tooltip.scss
+++ b/src/tooltip/_tooltip.scss
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@import "../variables";
-
 .mdl-tooltip {
   transform: scale(0);
   transform-origin: top center;

--- a/src/typography/_typography.scss
+++ b/src/typography/_typography.scss
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-@import "../variables";
-@import "../mixins";
-
 @if $target-elements-directly == true {
   html, body {
     font-family: $performance_font;


### PR DESCRIPTION
per #1474 import of _variables and _mixins directly into component's prevents customisation outside the framework.

There's probably still some things to look at, (functions and color definitions), but the tests all pass.

Can add !default to variables where it is missing too, if this gets the green-light.