### PR TITLE
Fix Icon buttons in datatable are misaligned #1402

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -541,6 +541,7 @@ $data-table-card-title-top: 20px;
 $data-table-card-padding: 24px;
 $data-table-button-padding-right: 16px;
 $data-table-cell-top: $data-table-card-padding / 2;
+$data-table-cell-bottom: $data-table-card-padding / 2;
 
 /* TOOLTIP */
 $tooltip-font-size: 10px !default;

--- a/src/data-table/_data-table.scss
+++ b/src/data-table/_data-table.scss
@@ -70,6 +70,7 @@
     border-top: $data-table-dividers;
     border-bottom: $data-table-dividers;
     padding-top: $data-table-cell-top;
+    padding-bottom: $data-table-cell-bottom;
     box-sizing: border-box;
 
     .mdl-data-table__select {


### PR DESCRIPTION
Fixed  #1402 - Icon buttons in datatable are misaligned

<img width="397" alt="screen shot 2015-08-26 at 8 52 24 pm" src="https://cloud.githubusercontent.com/assets/7540669/9512265/68767468-4c34-11e5-8b7e-aa3f5b647e28.png">
