### PR TITLE
#1421 - Remove background color for current navigation link

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -541,6 +541,7 @@ $data-table-card-title-top: 20px;
 $data-table-card-padding: 24px;
 $data-table-button-padding-right: 16px;
 $data-table-cell-top: $data-table-card-padding / 2;
+$data-table-cell-bottom: $data-table-card-padding / 2;
 
 /* TOOLTIP */
 $tooltip-font-size: 10px !default;

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -179,7 +179,6 @@ $layout-drawer-bg-color: unquote("rgb(#{$palette-grey-50})") !default;
 $layout-drawer-border-color: unquote("rgb(#{$palette-grey-300})") !default;
 $layout-text-color: unquote("rgb(#{$palette-grey-800})") !default;
 $layout-drawer-navigation-color: #757575 !default;
-$layout-drawer-navigation-link-active-background: unquote("rgb(#{$color-light-contrast})") !default;
 $layout-drawer-navigation-link-active-color: unquote("rgb(#{$color-primary})") !default;
 
 // Header

--- a/src/data-table/_data-table.scss
+++ b/src/data-table/_data-table.scss
@@ -70,6 +70,7 @@
     border-top: $data-table-dividers;
     border-bottom: $data-table-dividers;
     padding-top: $data-table-cell-top;
+    padding-bottom: $data-table-cell-bottom;
     box-sizing: border-box;
 
     .mdl-data-table__select {

--- a/src/layout/_layout.scss
+++ b/src/layout/_layout.scss
@@ -155,7 +155,6 @@
         }
 
         &--current {
-            background-color: $layout-drawer-navigation-link-active-background;
             color: $layout-drawer-navigation-link-active-color;
         }
       }


### PR DESCRIPTION
Remove the background color for current navigation link of side menu seems to be appropriate according to a few Google current websites. Fixes #1421 