### PR TITLE
#516 - Display color name on the wheel with tooltip 

### DIFF
--- a/docs/_assets/customizer.js
+++ b/docs/_assets/customizer.js
@@ -203,6 +203,7 @@ MaterialCustomizer = (function() {
   MaterialCustomizer.prototype.buildWheel_ = function() {
     var config = this.config;
     var mainG = this.wheel.querySelector('g.wheel--maing');
+    var wheelContainer = this.wheel.parentNode;
 
     this.wheel.setAttribute('viewBox', '0 0 ' +
       this.config.width + ' ' +  this.config.height);
@@ -215,6 +216,7 @@ MaterialCustomizer = (function() {
     var svgNS = 'http://www.w3.org/2000/svg';
     config.colors.forEach(function(color, idx) {
       var field = fieldTpl.cloneNode(true);
+      var tooltip = document.createElement('div');
 
       for (var i = 1; i <= 2; i++) {
         var g = document.createElementNS(svgNS, 'g');
@@ -230,6 +232,7 @@ MaterialCustomizer = (function() {
         field.appendChild(g);
       }
       field.setAttribute('data-color', color);
+      field.id = color;
       field.querySelector('.polygons > *:nth-child(1)').style.fill =
         'rgb(' + this.getColor(color, '500') + ')';
       field.querySelector('.polygons > *:nth-child(2)').style.fill =
@@ -238,10 +241,16 @@ MaterialCustomizer = (function() {
         addEventListener('click', this.fieldClicked_.bind(this));
       field.setAttribute('transform', 'rotate(' + config.alphaDeg * idx + ')');
       mainG.appendChild(field);
+
+      tooltip.setAttribute('for', color);
+      tooltip.className = 'mdl-tooltip mdl-tooltip--large';
+      tooltip.innerText = color;
+      wheelContainer.appendChild(tooltip);
     }.bind(this));
 
     mainG.setAttribute('transform',
       'translate(' + config.width / 2 + ',' + config.height / 2 + ')');
+
   };
 
   MaterialCustomizer.prototype.generateFieldTemplate_ = function() {

--- a/docs/_assets/customizer.js
+++ b/docs/_assets/customizer.js
@@ -244,7 +244,7 @@ MaterialCustomizer = (function() {
 
       tooltip.setAttribute('for', color);
       tooltip.className = 'mdl-tooltip mdl-tooltip--large';
-      tooltip.innerText = color;
+      tooltip.innerHTML = color;
       wheelContainer.appendChild(tooltip);
     }.bind(this));
 

--- a/docs/_assets/main.js
+++ b/docs/_assets/main.js
@@ -75,27 +75,3 @@
     });
   });
 })();
-
-// Display color name on the wheel with tooltip
-(function () {
-  'use strict';
-
-  document.addEventListener('DOMContentLoaded', function(event) {
-    var colors = document.querySelectorAll('[data-color]');
-    var wheel = document.getElementById('wheel');
-
-    Array.prototype.forEach.call(colors, function(color) {
-      var colorText = color.dataset.color;
-      var tooltip = document.createElement('div');
-
-      color.id = colorText;
-
-      tooltip.setAttribute('for', colorText);
-      tooltip.className = 'mdl-tooltip mdl-tooltip--large';
-      tooltip.innerText = colorText;
-
-      componentHandler.upgradeElement(tooltip);
-      wheel.appendChild(tooltip);
-    });
-  });
-})();

--- a/docs/_assets/main.js
+++ b/docs/_assets/main.js
@@ -75,3 +75,27 @@
     });
   });
 })();
+
+// Display color name on the wheel with tooltip
+(function () {
+  'use strict';
+
+  document.addEventListener('DOMContentLoaded', function(event) {
+    var colors = document.querySelectorAll('[data-color]');
+    var wheel = document.getElementById('wheel');
+
+    Array.prototype.forEach.call(colors, function(color) {
+      var colorText = color.dataset.color;
+      var tooltip = document.createElement('div');
+
+      color.id = colorText;
+
+      tooltip.setAttribute('for', colorText);
+      tooltip.className = 'mdl-tooltip mdl-tooltip--large';
+      tooltip.innerText = colorText;
+
+      componentHandler.upgradeElement(tooltip);
+      wheel.appendChild(tooltip);
+    });
+  });
+})();


### PR DESCRIPTION
Added tooltip for the color wheel in the Customize page (fixes #516). 

<img width="435" alt="screen shot 2015-08-27 at 3 22 36 am" src="https://cloud.githubusercontent.com/assets/7540669/9518338/e4b921e8-4c6a-11e5-9213-8101657cc70a.png">
