### PR TITLE
Required input fields should not be marked invalid (red) automatically

### DIFF
--- a/src/textfield/textfield.js
+++ b/src/textfield/textfield.js
@@ -132,7 +132,9 @@
     if (this.input_.validity.valid) {
       this.element_.classList.remove(this.CssClasses_.IS_INVALID);
     } else {
-      this.element_.classList.add(this.CssClasses_.IS_INVALID);
+      if (this.element_.getElementsByTagName('input')[0].value.length > 0) {
+        this.element_.classList.add(this.CssClasses_.IS_INVALID);
+      }
     }
   };
 

--- a/src/textfield/textfield.js
+++ b/src/textfield/textfield.js
@@ -132,7 +132,7 @@
     if (this.input_.validity.valid) {
       this.element_.classList.remove(this.CssClasses_.IS_INVALID);
     } else {
-      if (this.element_.getElementsByTagName('input')[0].value.length > 0) {
+      if (this.input_.value && this.input_.value.length > 0) {
         this.element_.classList.add(this.CssClasses_.IS_INVALID);
       }
     }

--- a/src/textfield/textfield.js
+++ b/src/textfield/textfield.js
@@ -132,9 +132,7 @@
     if (this.input_.validity.valid) {
       this.element_.classList.remove(this.CssClasses_.IS_INVALID);
     } else {
-      if (this.input_.value && this.input_.value.length > 0) {
-        this.element_.classList.add(this.CssClasses_.IS_INVALID);
-      }
+      this.element_.classList.add(this.CssClasses_.IS_INVALID);
     }
   };
 
@@ -218,6 +216,10 @@
         }
 
         this.updateClasses_();
+        
+        // remove IS_INVALID upon itializing this element so that it first appears without errors
+        this.element_.classList.remove(this.CssClasses_.IS_INVALID);
+        
         this.element_.classList.add(this.CssClasses_.IS_UPGRADED);
       }
     }


### PR DESCRIPTION
If an input field is required then it will automatically be marked as invalid. This should not happen on a page load, but once a user interacts with it. 

See issue #1502