### PR TITLE
Fix links at bottom being too close to each other

### DIFF
--- a/docs/_assets/main.css
+++ b/docs/_assets/main.css
@@ -1319,3 +1319,6 @@ code[class*=language-], pre[class*=language-] {
   max-width: 640px;
   margin: 60px 0 40px 0;
 }
+footer > ul:last-child > li:first-child {
+  margin-right: 10px;
+}


### PR DESCRIPTION
Two links at the bottom of the [MDL home page](http://getmdl.io) have the text `Web Starter Kit`
and `Help` and are touching. My fix was to apply a `margin-right` of `10px` on the first `li`. I was not sure what the class name of the `ul` containing the links should be, so I used the CSS path.
![Screenshot of issue](http://i.imgur.com/gvsH6XI.png)
Running Chrome 41.0.2272.89 on Ubuntu 14.04. 