### PR TITLE
Dialog popups

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -202,6 +202,7 @@ gulp.task('scripts', ['jscs', 'jshint'], function() {
     // Base components
     'src/button/button.js',
     'src/checkbox/checkbox.js',
+    'src/dialog/dialog.js',
     'src/icon-toggle/icon-toggle.js',
     'src/menu/menu.js',
     'src/progress/progress.js',

--- a/src/dialog/demo.html
+++ b/src/dialog/demo.html
@@ -1,0 +1,87 @@
+<button type="button" id="show" class="mdl-button mdl-js-button">Show dialog</button>
+<button type="button" id="show-modal" class="mdl-button mdl-js-button">Show as modal</button>
+
+<div id="normal-dialog" class="mdl-dialog mdl-shadow--4dp mdl-js-dialog">
+  <h3 class="mdl-dialog__title">
+    Title Text
+  </h3>
+  <div class="mdl-dialog__content">
+    Dialog Content
+  </div>
+  <div class="mdl-dialog__actions">
+    <button class="mdl-button mdl-js-button">Something else</button>
+    <button class="mdl-button mdl-js-button" id="close">Close</button>
+  </div>
+</div>
+
+<hr>
+<button type="button" id="show-dt" class="mdl-button mdl-js-button">Show dialog with Data Table</button>
+<button type="button" id="show-dt-modal" class="mdl-button mdl-js-button">Show as modal with Data Table</button>
+
+<div id="data-table-dialog" class="mdl-dialog mdl-shadow--4dp mdl-js-dialog">
+  <h3 class="mdl-dialog__title">
+    Products
+  </h3>
+  <div class="mdl-dialog__content">
+  <table class="mdl-data-table mdl-js-data-table mdl-data-table--selectable mdl-shadow--2dp">
+    <thead>
+      <tr>
+        <th class="mdl-data-table__cell--non-numeric">Material</th>
+        <th>Quantity</th>
+        <th>Unit price</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Acrylic (Transparent)</td>
+        <td>25</td>
+        <td>$2.90</td>
+      </tr>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Plywood (Birch)</td>
+        <td>50</td>
+        <td>$1.25</td>
+      </tr>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Laminate (Gold on Blue)</td>
+        <td>10</td>
+        <td>$2.35</td>
+      </tr>
+    </tbody>
+  </table>
+  </div>
+  <div class="mdl-dialog__actions mdl-dialog__actions--full-width">
+    <button class="mdl-button mdl-js-button" id="close-dt">Close</button>
+  </div>
+</div>
+
+<script>
+(function() {
+    'use strict';
+    var dialog = document.querySelector('#normal-dialog');
+    document.querySelector('#show').addEventListener('click', function(event) {
+        dialog.MaterialDialog.show();
+    });
+    document.querySelector('#show-modal').addEventListener('click', function(event) {
+        dialog.MaterialDialog.showModal();
+    });
+    document.querySelector('#close').addEventListener('click', function(event) {
+        dialog.MaterialDialog.close();
+    });
+}());
+
+(function() {
+    'use strict';
+    var dialog = document.querySelector('#data-table-dialog');
+    document.querySelector('#show-dt').addEventListener('click', function(event) {
+        dialog.MaterialDialog.show();
+    });
+    document.querySelector('#show-dt-modal').addEventListener('click', function(event) {
+        dialog.MaterialDialog.showModal();
+    });
+    document.querySelector('#close-dt').addEventListener('click', function(event) {
+        dialog.MaterialDialog.close();
+    });
+}());
+
+</script>

--- a/src/dialog/demo.html
+++ b/src/dialog/demo.html
@@ -4,6 +4,28 @@
 
 <button type="button" data-toggle="dialog" for="data-table-dialog" class="mdl-button mdl-js-button">Show dialog with Data Table</button>
 
+<hr>
+
+<button id="open-dialog" class="mdl-button mdl-js-button">Manually bound dialog</button>
+<script>
+(function() {
+    'use strict';
+    document.querySelector('#open-dialog').addEventListener('click', function(event) {
+        document.querySelector('#normal-dialog').MaterialDialog.show();
+    });
+}());
+</script>
+
+<button id="open-modal-dialog" class="mdl-button mdl-js-button">Manually bound modal dialog</button>
+<script>
+(function() {
+    'use strict';
+    document.querySelector('#open-modal-dialog').addEventListener('click', function(event) {
+        document.querySelector('#normal-dialog').MaterialDialog.showModal();
+    });
+}());
+</script>
+
 <div id="normal-dialog" class="mdl-card mdl-dialog mdl-dialog--modal mdl-shadow--4dp mdl-js-dialog">
   <h3 class="mdl-dialog__title">
     Title Text

--- a/src/dialog/demo.html
+++ b/src/dialog/demo.html
@@ -1,24 +1,23 @@
-<button type="button" id="show" class="mdl-button mdl-js-button">Show dialog</button>
-<button type="button" id="show-modal" class="mdl-button mdl-js-button">Show as modal</button>
+<button type="button" data-toggle="dialog" for="normal-dialog" class="mdl-button mdl-js-button">Show modal dialog</button>
 
-<div id="normal-dialog" class="mdl-dialog mdl-shadow--4dp mdl-js-dialog">
+<hr>
+
+<button type="button" data-toggle="dialog" for="data-table-dialog" class="mdl-button mdl-js-button">Show dialog with Data Table</button>
+
+<div id="normal-dialog" class="mdl-card mdl-dialog mdl-dialog--modal mdl-shadow--4dp mdl-js-dialog">
   <h3 class="mdl-dialog__title">
     Title Text
   </h3>
   <div class="mdl-dialog__content">
-    Dialog Content
+    Sugar plum cupcake candy biscuit bear claw wafer. Gingerbread sesame snaps candy oat cake chocolate tiramisu. Caramels sesame snaps lollipop wafer gummi bears ice cream donut. Marshmallow toffee cheesecake danish candy apple pie bear claw. Gingerbread lemon drops sesame snaps dragée dragée icing wafer apple pie dessert. Marshmallow bonbon tiramisu donut powder cotton candy sweet sweet soufflé. Jelly pudding bonbon. Icing jelly-o lemon drops oat cake ice cream caramels jelly beans gummies. Halvah gummies gummi bears gummies jujubes tiramisu cotton candy tiramisu tart. Pie jelly beans croissant caramels toffee icing lollipop toffee. Bonbon caramels oat cake halvah donut soufflé sweet fruitcake bear claw. Oat cake chupa chups liquorice caramels bear claw bonbon powder macaroon. Icing marzipan cookie sesame snaps pastry chocolate cake lollipop liquorice.
   </div>
   <div class="mdl-dialog__actions">
     <button class="mdl-button mdl-js-button">Something else</button>
-    <button class="mdl-button mdl-js-button" id="close">Close</button>
+    <button class="mdl-button mdl-js-button" data-dismiss="dialog">Close</button>
   </div>
 </div>
 
-<hr>
-<button type="button" id="show-dt" class="mdl-button mdl-js-button">Show dialog with Data Table</button>
-<button type="button" id="show-dt-modal" class="mdl-button mdl-js-button">Show as modal with Data Table</button>
-
-<div id="data-table-dialog" class="mdl-dialog mdl-shadow--4dp mdl-js-dialog">
+<div id="data-table-dialog" class="mdl-card mdl-dialog mdl-shadow--4dp mdl-js-dialog">
   <h3 class="mdl-dialog__title">
     Products
   </h3>
@@ -51,11 +50,14 @@
   </table>
   </div>
   <div class="mdl-dialog__actions mdl-dialog__actions--full-width">
-    <button class="mdl-button mdl-js-button" id="close-dt">Close</button>
+    <button class="mdl-button mdl-js-button" data-dismiss="dialog">Close</button>
   </div>
 </div>
 
 <script>
+
+/*
+
 (function() {
     'use strict';
     var dialog = document.querySelector('#normal-dialog');
@@ -83,5 +85,7 @@
         dialog.MaterialDialog.close();
     });
 }());
+
+*/
 
 </script>

--- a/src/dialog/dialog.js
+++ b/src/dialog/dialog.js
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ function MaterialDialog(element) {
+  'use strict';
+  this.element_ = element;
+  this.returnValue = '';
+}
+
+MaterialDialog.prototype.showInternal_ = function(backdrop) {
+  'use strict';
+  if (backdrop === undefined) {
+    throw Error('You must provide whether or not to show the backdrop.');
+  }
+  if (this.element_.getAttribute('open') === 'true') {
+    return;
+  }
+  if (backdrop) {
+    this.createBackdrop_();
+  }
+  this.element_.setAttribute('open', true);
+};
+
+MaterialDialog.prototype.createBackdrop_ = function() {
+  'use strict';
+  this.backdropElement_ = document.createElement('div');
+  this.backdropElement_.classList.add('mdl-dialog-backdrop');
+  document.body.appendChild(this.backdropElement_);
+};
+
+MaterialDialog.prototype.show = function() {
+  'use strict';
+  this.showInternal_(false);
+};
+
+MaterialDialog.prototype.showModal = function() {
+  'use strict';
+  this.showInternal_(true);
+};
+
+MaterialDialog.prototype.close = function(returnValue) {
+  'use strict';
+  this.element_.removeAttribute('open');
+  if (this.backdropElement_) {
+    document.body.removeChild(this.backdropElement_);
+    this.backdropElement_ = undefined;
+  }
+};
+
+componentHandler.register({
+  constructor: MaterialDialog,
+  classAsString: 'MaterialDialog',
+  cssClass: 'mdl-js-dialog',
+  widget: true
+});

--- a/src/dialog/dialog.js
+++ b/src/dialog/dialog.js
@@ -15,10 +15,13 @@
  * limitations under the License.
  */
 
- function MaterialDialog(element) {
+function MaterialDialog(element) {
   'use strict';
+
   this.element_ = element;
   this.returnValue = '';
+
+  this.init();
 }
 
 MaterialDialog.prototype.showInternal_ = function(backdrop) {
@@ -59,6 +62,46 @@ MaterialDialog.prototype.close = function(returnValue) {
     document.body.removeChild(this.backdropElement_);
     this.backdropElement_ = undefined;
   }
+};
+
+MaterialDialog.prototype.init = function() {
+  'use strict';
+
+  if (this.element_) {
+    var id = this.element_.getAttribute('id');
+
+    if (id && document.querySelector('[data-toggle="dialog"][for="' + id + '"]')) {
+      var toggleEls = document.querySelectorAll('[data-toggle="dialog"][for="' + id + '"]');
+      for (var i = 0; i < toggleEls.length; i++) {
+        toggleEls[i].addEventListener('click', this.handleOpen_.bind(this));
+      }
+    }
+
+    // bind close buttons
+    if (id && document.querySelector('#' + id + '.mdl-dialog [data-dismiss="dialog"]')) {
+      var dismissEls = document.querySelectorAll('#' + id + '.mdl-dialog [data-dismiss="dialog"]');
+      for (var j = 0; j < dismissEls.length; j++) {
+        dismissEls[j].addEventListener('click', this.handleClose_.bind(this));
+      }
+    }
+
+  }
+};
+
+MaterialDialog.prototype.handleOpen_ = function(event) {
+  'use strict';
+
+  if (this.element_.className.indexOf('mdl-dialog--modal') !== -1) {
+    this.element_.MaterialDialog.showModal();
+  } else {
+    this.element_.MaterialDialog.show();
+  }
+};
+
+MaterialDialog.prototype.handleClose_ = function(event) {
+  'use strict';
+
+  this.element_.MaterialDialog.close();
 };
 
 componentHandler.register({

--- a/src/dialog/dialog.scss
+++ b/src/dialog/dialog.scss
@@ -20,6 +20,7 @@ $dialog-backdrop-color: rgba(0, 0, 0, .55);
 
 .mdl-dialog {
     display: block;
+    width: 100%;
     min-width: 280px;
     max-width: 500px;
     margin: auto;
@@ -28,6 +29,12 @@ $dialog-backdrop-color: rgba(0, 0, 0, .55);
     left: 0;
     right: 0;
     z-index: 11;
+    
+    top: 50%;                     // kinda hacky way to vertically center
+    transform: translate(0,-50%); //
+
+    max-height: 100%; // fix for content that goes past the height of the screen
+    overflow-y: auto; //
 
     &:not([open]) {
         display:none;
@@ -49,6 +56,7 @@ $dialog-backdrop-color: rgba(0, 0, 0, .55);
 
     &__title {
         color: black;
+        margin: 0;
         padding-left: 24px;
         padding-right: 24px;
         padding-top: 24px;

--- a/src/dialog/dialog.scss
+++ b/src/dialog/dialog.scss
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import "../variables";
+
+$dialog-backdrop-color: rgba(0, 0, 0, .55);
+
+.mdl-dialog {
+    display: block;
+    min-width: 280px;
+    max-width: 500px;
+    margin: auto;
+    background: white;
+    position: fixed;
+    left: 0;
+    right: 0;
+    z-index: 11;
+
+    &:not([open]) {
+        display:none;
+    }
+
+    &::backdrop{
+        background-color: $dialog-backdrop-color;
+    }
+
+    &-backdrop {
+        background-color: $dialog-backdrop-color;
+        position:absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        z-index: 10;
+    }
+
+    &__title {
+        color: black;
+        padding-left: 24px;
+        padding-right: 24px;
+        padding-top: 24px;
+    }
+    &__actions {
+        padding: 8px 8px 8px 24px;
+        float: right;
+        * {
+            margin-right: 8px;
+            &:last-child {
+                margin-right: 0;
+            }
+        }
+    }
+    &__content {
+        color: grey;
+        padding-top: 20px;
+        padding-left: 24px;
+        padding-right: 24px;
+        padding-bottom: 24px;
+    }
+}

--- a/src/material-design-lite.scss
+++ b/src/material-design-lite.scss
@@ -31,6 +31,7 @@
 @import "badge/badge";
 @import "button/button";
 @import "card/card";
+@import "dialog/dialog";
 @import "checkbox/checkbox";
 @import "data-table/data-table";
 @import "footer/mega_footer";


### PR DESCRIPTION
I know there's a dialog branch, but some things appear to be fixable and/or improvable, so I've what I can to speed things along, using the existing dialog branch. I just took the files pertaining to dialogs from that branch, so as not to lose the updates that have since occurred in the master branch.

- Fixes Internet Explorer alignment. The width is still fixed at 500px, but it centers vertically and horizontally. (Requires `transform` support.)
- Created event listeners for MaterialDialog so that dialogs can be created and dismissed without needing to add extra js.
- Demo page includes examples of modal and non-modal dialogs, opening a dialog using the event listeners and manually.