### PR TITLE
Add reset event of textfield

### DIFF
--- a/src/textfield/textfield.js
+++ b/src/textfield/textfield.js
@@ -99,6 +99,16 @@
   };
 
   /**
+   * Handle reset event from out side.
+   *
+   * @param {Event} event The event that fired.
+   * @private
+   */
+  MaterialTextfield.prototype.onReset_ = function(event) {
+    this.updateClasses_();
+  };
+
+  /**
    * Handle class updates.
    *
    * @private
@@ -206,9 +216,11 @@
         this.boundUpdateClassesHandler = this.updateClasses_.bind(this);
         this.boundFocusHandler = this.onFocus_.bind(this);
         this.boundBlurHandler = this.onBlur_.bind(this);
+        this.boundResetHandler = this.onReset_.bind(this);
         this.input_.addEventListener('input', this.boundUpdateClassesHandler);
         this.input_.addEventListener('focus', this.boundFocusHandler);
         this.input_.addEventListener('blur', this.boundBlurHandler);
+        this.input_.addEventListener('reset', this.boundResetHandler);
 
         if (this.maxRows !== this.Constant_.NO_MAX_ROWS) {
           // TODO: This should handle pasting multi line text.
@@ -232,6 +244,7 @@
     this.input_.removeEventListener('input', this.boundUpdateClassesHandler);
     this.input_.removeEventListener('focus', this.boundFocusHandler);
     this.input_.removeEventListener('blur', this.boundBlurHandler);
+    this.input_.removeEventListener('reset', this.boundResetHandler);
     if (this.boundKeyDownHandler) {
       this.input_.removeEventListener('keydown', this.boundKeyDownHandler);
     }


### PR DESCRIPTION
For some situation need to handle `onreset` event. Can trigger onreset event from outside

```
let event = new Event('reset');
element.dispatchEvent(event);
```