### PR TITLE
More closure fixes

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -6,6 +6,7 @@
   "excludeFiles": ["node_modules/**"],
   "maximumLineLength": 130,
   "validateQuoteMarks": "'",
+  "requireDotNotation": false,
   "requireCamelCaseOrUpperCaseIdentifiers": null,
   "additionalRules": ["utils/jscs-rules/*.js"],
   "closureCamelCase": true,
@@ -13,7 +14,8 @@
     "checkAnnotations": {
       "preset": "closurecompiler",
       "extra": {
-        "type": true
+        "type": true,
+        "suppress": true
       }
     },
     "checkTypes": "strictNativeCase",

--- a/.jshintrc
+++ b/.jshintrc
@@ -11,6 +11,7 @@
   "undef": true,
   "unused": "vars",
   "strict": true,
+  "sub": true,
   "globals": {
     "componentHandler": true
   }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -218,7 +218,7 @@ gulp.task('scripts', ['jscs', 'jshint'], function() {
     'src/ripple/ripple.js'
   ];
   return gulp.src(sources)
-    .pipe(uniffe())
+    .pipe($.if(/mdlComponentHandler\.js/, $.util.noop(), uniffe()))
     .pipe($.sourcemaps.init())
     // Concatenate Scripts
     .pipe($.concat('material.js'))

--- a/src/button/button.js
+++ b/src/button/button.js
@@ -31,7 +31,7 @@
     // Initialize instance.
     this.init();
   };
-  window.MaterialButton = MaterialButton;
+  window['MaterialButton'] = MaterialButton;
 
   /**
    * Store constants in one place so they can be updated easily.
@@ -79,6 +79,7 @@
   MaterialButton.prototype.disable = function() {
     this.element_.disabled = true;
   };
+  MaterialButton.prototype['disable'] = MaterialButton.prototype.disable;
 
   /**
    * Enable button.
@@ -88,6 +89,7 @@
   MaterialButton.prototype.enable = function() {
     this.element_.disabled = false;
   };
+  MaterialButton.prototype['enable'] = MaterialButton.prototype.enable;
 
   /**
    * Initialize element.

--- a/src/checkbox/checkbox.js
+++ b/src/checkbox/checkbox.js
@@ -32,7 +32,7 @@
     // Initialize instance.
     this.init();
   };
-  window.MaterialCheckbox = MaterialCheckbox;
+  window['MaterialCheckbox'] = MaterialCheckbox;
 
   /**
    * Store constants in one place so they can be updated easily.
@@ -145,6 +145,8 @@
       this.element_.classList.remove(this.CssClasses_.IS_CHECKED);
     }
   };
+  MaterialCheckbox.prototype['checkToggleState'] =
+      MaterialCheckbox.prototype.checkToggleState;
 
   /**
    * Check the inputs disabled state and update display.
@@ -158,6 +160,8 @@
       this.element_.classList.remove(this.CssClasses_.IS_DISABLED);
     }
   };
+  MaterialCheckbox.prototype['checkDisabled'] =
+      MaterialCheckbox.prototype.checkDisabled;
 
   /**
    * Disable checkbox.
@@ -168,6 +172,7 @@
     this.inputElement_.disabled = true;
     this.updateClasses_();
   };
+  MaterialCheckbox.prototype['disable'] = MaterialCheckbox.prototype.disable;
 
   /**
    * Enable checkbox.
@@ -178,6 +183,7 @@
     this.inputElement_.disabled = false;
     this.updateClasses_();
   };
+  MaterialCheckbox.prototype['enable'] = MaterialCheckbox.prototype.enable;
 
   /**
    * Check checkbox.
@@ -188,6 +194,7 @@
     this.inputElement_.checked = true;
     this.updateClasses_();
   };
+  MaterialCheckbox.prototype['check'] = MaterialCheckbox.prototype.check;
 
   /**
    * Uncheck checkbox.
@@ -198,6 +205,7 @@
     this.inputElement_.checked = false;
     this.updateClasses_();
   };
+  MaterialCheckbox.prototype['uncheck'] = MaterialCheckbox.prototype.uncheck;
 
   /**
    * Initialize element.

--- a/src/data-table/data-table.js
+++ b/src/data-table/data-table.js
@@ -33,7 +33,7 @@
     this.init();
   };
 
-  window.MaterialDataTable = MaterialDataTable;
+  window['MaterialDataTable'] = MaterialDataTable;
 
   /**
    * Store constants in one place so they can be updated easily.
@@ -87,13 +87,13 @@
         if (checkbox.checked) {
           for (i = 0; i < opt_rows.length; i++) {
             el = opt_rows[i].querySelector('td').querySelector('.mdl-checkbox');
-            el.MaterialCheckbox.check();
+            el['MaterialCheckbox'].check();
             opt_rows[i].classList.add(this.CssClasses_.IS_SELECTED);
           }
         } else {
           for (i = 0; i < opt_rows.length; i++) {
             el = opt_rows[i].querySelector('td').querySelector('.mdl-checkbox');
-            el.MaterialCheckbox.uncheck();
+            el['MaterialCheckbox'].uncheck();
             opt_rows[i].classList.remove(this.CssClasses_.IS_SELECTED);
           }
         }
@@ -106,7 +106,7 @@
    * event handling.
    *
    * @param {HTMLElement} row Row to toggle when checkbox changes.
-   * @param {NodeList=} opt_rows Rows to toggle when checkbox changes.
+   * @param {(Array<Object>|NodeList)=} opt_rows Rows to toggle when checkbox changes.
    * @private
    */
   MaterialDataTable.prototype.createCheckbox_ = function(row, opt_rows) {

--- a/src/data-table/data-table.js
+++ b/src/data-table/data-table.js
@@ -66,7 +66,7 @@
    *
    * @param {Element} checkbox Checkbox that toggles the selection state.
    * @param {HTMLElement} row Row to toggle when checkbox changes.
-   * @param {NodeList=} opt_rows Rows to toggle when checkbox changes.
+   * @param {(Array<Object>|NodeList)=} opt_rows Rows to toggle when checkbox changes.
    * @private
    */
   MaterialDataTable.prototype.selectRow_ = function(checkbox, row, opt_rows) {

--- a/src/icon-toggle/icon-toggle.js
+++ b/src/icon-toggle/icon-toggle.js
@@ -32,7 +32,7 @@
     // Initialize instance.
     this.init();
   };
-  window.MaterialIconToggle = MaterialIconToggle;
+  window['MaterialIconToggle'] = MaterialIconToggle;
 
   /**
    * Store constants in one place so they can be updated easily.
@@ -141,6 +141,8 @@
       this.element_.classList.remove(this.CssClasses_.IS_CHECKED);
     }
   };
+  MaterialIconToggle.prototype['checkToggleState'] =
+      MaterialIconToggle.prototype.checkToggleState;
 
   /**
    * Check the inputs disabled state and update display.
@@ -154,6 +156,8 @@
       this.element_.classList.remove(this.CssClasses_.IS_DISABLED);
     }
   };
+  MaterialIconToggle.prototype['checkDisabled'] =
+      MaterialIconToggle.prototype.checkDisabled;
 
   /**
    * Disable icon toggle.
@@ -164,6 +168,8 @@
     this.inputElement_.disabled = true;
     this.updateClasses_();
   };
+  MaterialIconToggle.prototype['disable'] =
+      MaterialIconToggle.prototype.disable;
 
   /**
    * Enable icon toggle.
@@ -174,6 +180,7 @@
     this.inputElement_.disabled = false;
     this.updateClasses_();
   };
+  MaterialIconToggle.prototype['enable'] = MaterialIconToggle.prototype.enable;
 
   /**
    * Check icon toggle.
@@ -184,6 +191,7 @@
     this.inputElement_.checked = true;
     this.updateClasses_();
   };
+  MaterialIconToggle.prototype['check'] = MaterialIconToggle.prototype.check;
 
   /**
    * Uncheck icon toggle.
@@ -194,6 +202,8 @@
     this.inputElement_.checked = false;
     this.updateClasses_();
   };
+  MaterialIconToggle.prototype['uncheck'] =
+      MaterialIconToggle.prototype.uncheck;
 
   /**
    * Initialize element.

--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -32,7 +32,7 @@
     // Initialize instance.
     this.init();
   };
-  window.MaterialLayout = MaterialLayout;
+  window['MaterialLayout'] = MaterialLayout;
 
   /**
    * Store constants in one place so they can be updated easily.

--- a/src/menu/menu.js
+++ b/src/menu/menu.js
@@ -32,7 +32,7 @@
     // Initialize instance.
     this.init();
   };
-  window.MaterialMenu = MaterialMenu;
+  window['MaterialMenu'] = MaterialMenu;
 
   /**
    * Store constants in one place so they can be updated easily.
@@ -417,6 +417,7 @@
       document.addEventListener('click', callback);
     }
   };
+  MaterialMenu.prototype['show'] = MaterialMenu.prototype.show;
 
   /**
    * Hides the menu.
@@ -446,6 +447,7 @@
       this.addAnimationEndListener_();
     }
   };
+  MaterialMenu.prototype['hide'] = MaterialMenu.prototype.hide;
 
   /**
    * Displays or hides the menu, depending on current state.
@@ -459,6 +461,7 @@
       this.show(evt);
     }
   };
+  MaterialMenu.prototype['toggle'] = MaterialMenu.prototype.toggle;
 
   /**
    * Downgrade the component.

--- a/src/progress/progress.js
+++ b/src/progress/progress.js
@@ -32,7 +32,7 @@
     // Initialize instance.
     this.init();
   };
-  window.MaterialProgress = MaterialProgress;
+  window['MaterialProgress'] = MaterialProgress;
 
   /**
    * Store constants in one place so they can be updated easily.
@@ -68,6 +68,8 @@
 
     this.progressbar_.style.width = p + '%';
   };
+  MaterialProgress.prototype['setProgress'] =
+      MaterialProgress.prototype.setProgress;
 
   /**
    * Set the current progress of the buffer.
@@ -79,6 +81,8 @@
     this.bufferbar_.style.width = p + '%';
     this.auxbar_.style.width = (100 - p) + '%';
   };
+  MaterialProgress.prototype['setBuffer'] =
+      MaterialProgress.prototype.setBuffer;
 
   /**
    * Initialize element.

--- a/src/radio/radio.js
+++ b/src/radio/radio.js
@@ -32,7 +32,7 @@
     // Initialize instance.
     this.init();
   };
-  window.MaterialRadio = MaterialRadio;
+  window['MaterialRadio'] = MaterialRadio;
 
   /**
    * Store constants in one place so they can be updated easily.
@@ -82,7 +82,7 @@
       var button = radios[i].querySelector('.' + this.CssClasses_.RADIO_BTN);
       // Different name == different group, so no point updating those.
       if (button.getAttribute('name') === this.btnElement_.getAttribute('name')) {
-        radios[i].MaterialRadio.updateClasses_();
+        radios[i]['MaterialRadio'].updateClasses_();
       }
     }
   };
@@ -155,6 +155,8 @@
       this.element_.classList.remove(this.CssClasses_.IS_DISABLED);
     }
   };
+  MaterialRadio.prototype['checkDisabled'] =
+      MaterialRadio.prototype.checkDisabled;
 
   /**
    * Check the components toggled state.
@@ -168,6 +170,8 @@
       this.element_.classList.remove(this.CssClasses_.IS_CHECKED);
     }
   };
+  MaterialRadio.prototype['checkToggleState'] =
+      MaterialRadio.prototype.checkToggleState;
 
   /**
    * Disable radio.
@@ -178,6 +182,7 @@
     this.btnElement_.disabled = true;
     this.updateClasses_();
   };
+  MaterialRadio.prototype['disable'] = MaterialRadio.prototype.disable;
 
   /**
    * Enable radio.
@@ -188,6 +193,7 @@
     this.btnElement_.disabled = false;
     this.updateClasses_();
   };
+  MaterialRadio.prototype['enable'] = MaterialRadio.prototype.enable;
 
   /**
    * Check radio.
@@ -198,6 +204,7 @@
     this.btnElement_.checked = true;
     this.updateClasses_();
   };
+  MaterialRadio.prototype['check'] = MaterialRadio.prototype.check;
 
   /**
    * Uncheck radio.
@@ -208,6 +215,7 @@
     this.btnElement_.checked = false;
     this.updateClasses_();
   };
+  MaterialRadio.prototype['uncheck'] = MaterialRadio.prototype.uncheck;
 
   /**
    * Initialize element.

--- a/src/ripple/ripple.js
+++ b/src/ripple/ripple.js
@@ -32,7 +32,7 @@
     // Initialize instance.
     this.init();
   };
-  window.MaterialRipple = MaterialRipple;
+  window['MaterialRipple'] = MaterialRipple;
 
   /**
    * Store constants in one place so they can be updated easily.

--- a/src/slider/slider.js
+++ b/src/slider/slider.js
@@ -33,7 +33,7 @@
     // Initialize instance.
     this.init();
   };
-  window.MaterialSlider = MaterialSlider;
+  window['MaterialSlider'] = MaterialSlider;
 
   /**
    * Store constants in one place so they can be updated easily.
@@ -155,6 +155,7 @@
   MaterialSlider.prototype.disable = function() {
     this.element_.disabled = true;
   };
+  MaterialSlider.prototype['disable'] = MaterialSlider.prototype.disable;
 
   /**
    * Enable slider.
@@ -165,6 +166,7 @@
 
     this.element_.disabled = false;
   };
+  MaterialSlider.prototype['enable'] = MaterialSlider.prototype.enable;
 
   /**
    * Update slider value.
@@ -179,6 +181,7 @@
     }
     this.updateValueStyles_();
   };
+  MaterialSlider.prototype['change'] = MaterialSlider.prototype.change;
 
   /**
    * Initialize element.

--- a/src/slider/slider.js
+++ b/src/slider/slider.js
@@ -101,6 +101,7 @@
    *
    * @param {Event} event The event that fired.
    * @private
+   * @suppress {missingProperties}
    */
   MaterialSlider.prototype.onContainerMouseDown_ = function(event) {
     // If this click is not on the parent element (but rather some child)

--- a/src/spinner/spinner.js
+++ b/src/spinner/spinner.js
@@ -32,7 +32,7 @@
     // Initialize instance.
     this.init();
   };
-  window.MaterialSpinner = MaterialSpinner;
+  window['MaterialSpinner'] = MaterialSpinner;
 
   /**
    * Store constants in one place so they can be updated easily.
@@ -97,6 +97,8 @@
 
     this.element_.appendChild(layer);
   };
+  MaterialSpinner.prototype['createLayer'] =
+      MaterialSpinner.prototype.createLayer;
 
   /**
    * Stops the spinner animation.
@@ -107,6 +109,7 @@
   MaterialSpinner.prototype.stop = function() {
     this.element_.classList.remove('is-active');
   };
+  MaterialSpinner.prototype['stop'] = MaterialSpinner.prototype.stop;
 
   /**
    * Starts the spinner animation.
@@ -118,6 +121,7 @@
   MaterialSpinner.prototype.start = function() {
     this.element_.classList.add('is-active');
   };
+  MaterialSpinner.prototype['start'] = MaterialSpinner.prototype.start;
 
   /**
    * Initialize element.

--- a/src/switch/switch.js
+++ b/src/switch/switch.js
@@ -32,7 +32,7 @@
     // Initialize instance.
     this.init();
   };
-  window.MaterialSwitch = MaterialSwitch;
+  window['MaterialSwitch'] = MaterialSwitch;
 
   /**
    * Store constants in one place so they can be updated easily.
@@ -144,6 +144,8 @@
       this.element_.classList.remove(this.CssClasses_.IS_DISABLED);
     }
   };
+  MaterialSwitch.prototype['checkDisabled'] =
+      MaterialSwitch.prototype.checkDisabled;
 
   /**
    * Check the components toggled state.
@@ -157,6 +159,8 @@
       this.element_.classList.remove(this.CssClasses_.IS_CHECKED);
     }
   };
+  MaterialSwitch.prototype['checkToggleState'] =
+      MaterialSwitch.prototype.checkToggleState;
 
   /**
    * Disable switch.
@@ -167,6 +171,7 @@
     this.inputElement_.disabled = true;
     this.updateClasses_();
   };
+  MaterialSwitch.prototype['disable'] = MaterialSwitch.prototype.disable;
 
   /**
    * Enable switch.
@@ -177,6 +182,7 @@
     this.inputElement_.disabled = false;
     this.updateClasses_();
   };
+  MaterialSwitch.prototype['enable'] = MaterialSwitch.prototype.enable;
 
   /**
    * Activate switch.
@@ -187,6 +193,7 @@
     this.inputElement_.checked = true;
     this.updateClasses_();
   };
+  MaterialSwitch.prototype['on'] = MaterialSwitch.prototype.on;
 
   /**
    * Deactivate switch.
@@ -197,6 +204,7 @@
     this.inputElement_.checked = false;
     this.updateClasses_();
   };
+  MaterialSwitch.prototype['off'] = MaterialSwitch.prototype.off;
 
   /**
    * Initialize element.

--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -33,7 +33,7 @@
     // Initialize instance.
     this.init();
   };
-  window.MaterialTabs = MaterialTabs;
+  window['MaterialTabs'] = MaterialTabs;
 
   /**
    * Store constants in one place so they can be updated easily.

--- a/src/textfield/textfield.js
+++ b/src/textfield/textfield.js
@@ -32,7 +32,7 @@
     // Initialize instance.
     this.init();
   };
-  window.MaterialTextfield = MaterialTextfield;
+  window['MaterialTextfield'] = MaterialTextfield;
 
   /**
    * Store constants in one place so they can be updated easily.
@@ -123,6 +123,8 @@
       this.element_.classList.remove(this.CssClasses_.IS_DISABLED);
     }
   };
+  MaterialTextfield.prototype['checkDisabled'] =
+      MaterialTextfield.prototype.checkDisabled;
 
   /**
    * Check the validity state and update field accordingly.
@@ -136,6 +138,8 @@
       this.element_.classList.add(this.CssClasses_.IS_INVALID);
     }
   };
+  MaterialTextfield.prototype['checkValidity'] =
+      MaterialTextfield.prototype.checkValidity;
 
   /**
    * Check the dirty state and update field accordingly.
@@ -149,6 +153,8 @@
       this.element_.classList.remove(this.CssClasses_.IS_DIRTY);
     }
   };
+  MaterialTextfield.prototype['checkDirty'] =
+      MaterialTextfield.prototype.checkDirty;
 
   /**
    * Disable text field.
@@ -159,6 +165,7 @@
     this.input_.disabled = true;
     this.updateClasses_();
   };
+  MaterialTextfield.prototype['disable'] = MaterialTextfield.prototype.disable;
 
   /**
    * Enable text field.
@@ -169,6 +176,7 @@
     this.input_.disabled = false;
     this.updateClasses_();
   };
+  MaterialTextfield.prototype['enable'] = MaterialTextfield.prototype.enable;
 
   /**
    * Update text field value.
@@ -183,6 +191,7 @@
     }
     this.updateClasses_();
   };
+  MaterialTextfield.prototype['change'] = MaterialTextfield.prototype.change;
 
   /**
    * Initialize element.

--- a/src/third_party/rAF.js
+++ b/src/third_party/rAF.js
@@ -14,9 +14,10 @@
 if (!Date.now) {
   /**
    * Date.now polyfill.
-   * @return {Date} the current Date
+   * @return {number} the current Date
    */
   Date.now = function() { return new Date().getTime(); };
+  Date['now'] = Date.now;
 }
 
 var vendors = ['webkit', 'moz'];
@@ -24,7 +25,9 @@ for (var i = 0; i < vendors.length && !window.requestAnimationFrame; ++i) {
   var vp = vendors[i];
   window.requestAnimationFrame = window[vp + 'RequestAnimationFrame'];
   window.cancelAnimationFrame = (window[vp + 'CancelAnimationFrame'] ||
-  window[vp + 'CancelRequestAnimationFrame']);
+      window[vp + 'CancelRequestAnimationFrame']);
+  window['requestAnimationFrame'] = window.requestAnimationFrame;
+  window['cancelAnimationFrame'] = window.cancelAnimationFrame;
 }
 
 if (/iP(ad|hone|od).*OS 6/.test(window.navigator.userAgent) || !window.requestAnimationFrame || !window.cancelAnimationFrame) {
@@ -40,6 +43,8 @@ if (/iP(ad|hone|od).*OS 6/.test(window.navigator.userAgent) || !window.requestAn
                       nextTime - now);
   };
   window.cancelAnimationFrame = clearTimeout;
+  window['requestAnimationFrame'] = window.requestAnimationFrame;
+  window['cancelAnimationFrame'] = window.cancelAnimationFrame;
 }
 
 })();

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -32,7 +32,7 @@
     // Initialize instance.
     this.init();
   };
-  window.MaterialTooltip = MaterialTooltip;
+  window['MaterialTooltip'] = MaterialTooltip;
 
   /**
    * Store constants in one place so they can be updated easily.

--- a/test/unit/menu.js
+++ b/test/unit/menu.js
@@ -36,10 +36,10 @@ describe('MaterialMenu', function () {
     componentHandler.upgradeElement(el, 'MaterialMenu');
 
     it('should start the showing animation on show()', function(done) {
-      expect($(el.MaterialMenu.container_)).to.not.have.class('is-visible');
+      expect($(el.parentElement)).to.not.have.class('is-visible');
       el.MaterialMenu.show();
       window.setTimeout(function() {
-        expect($(el.MaterialMenu.container_)).to.have.class('is-visible');
+        expect($(el.parentElement)).to.have.class('is-visible');
 
         var ev = document.createEvent('HTMLEvents');
         ev.initEvent('transitionend', true, true)
@@ -49,10 +49,10 @@ describe('MaterialMenu', function () {
     });
 
     it('should start the hiding animation on hide()', function(done) {
-      expect($(el.MaterialMenu.container_)).to.have.class('is-visible');
+      expect($(el.parentElement)).to.have.class('is-visible');
       el.MaterialMenu.hide();
       window.setTimeout(function() {
-        expect($(el.MaterialMenu.container_)).to.not.have.class('is-visible');
+        expect($(el.parentElement)).to.not.have.class('is-visible');
 
         var ev = document.createEvent('HTMLEvents');
         ev.initEvent('transitionend', true, true)
@@ -62,10 +62,10 @@ describe('MaterialMenu', function () {
     });
 
     it('should start the showing animating on toggle() when invisible', function(done) {
-      expect($(el.MaterialMenu.container_)).to.not.have.class('is-visible');
+      expect($(el.parentElement)).to.not.have.class('is-visible');
       el.MaterialMenu.toggle();
       window.setTimeout(function() {
-        expect($(el.MaterialMenu.container_)).to.have.class('is-visible');
+        expect($(el.parentElement)).to.have.class('is-visible');
 
         var ev = document.createEvent('HTMLEvents');
         ev.initEvent('transitionend', true, true)
@@ -75,10 +75,10 @@ describe('MaterialMenu', function () {
     });
 
     it('should start the hiding animating on toggle() when visible', function(done) {
-      expect($(el.MaterialMenu.container_)).to.have.class('is-visible');
+      expect($(el.parentElement)).to.have.class('is-visible');
       el.MaterialMenu.toggle();
       window.setTimeout(function() {
-        expect($(el.MaterialMenu.container_)).to.not.have.class('is-visible');
+        expect($(el.parentElement)).to.not.have.class('is-visible');
 
         var ev = document.createEvent('HTMLEvents');
         ev.initEvent('transitionend', true, true)
@@ -107,7 +107,7 @@ describe('MaterialMenu', function () {
     ev.initEvent('click', true, true);
     ctr.querySelector('#clickable').dispatchEvent(ev);
     window.setTimeout(function() {
-      expect($(el.MaterialMenu.container_)).to.have.class('is-visible');
+      expect($(el.parentElement)).to.have.class('is-visible');
       document.body.removeChild(ctr);
       done();
     }, 100);


### PR DESCRIPTION
This PR contains more fixes to help with Closure compiler support, adding fixes necessary to have it not only compile, but run correctly as well. This includes exporting symbols (using the `foo['bar']` syntax), ensuring private properties aren't accessed by outsiders and typing things a bit more strongly in the componentHandler.

All unit tests pass on both compiled and uncompiled code.

@addyosmani @surma PTAL!