### PR TITLE
Removed unnecessary css to remove bug from IE

### DIFF
--- a/src/data-table/_data-table.scss
+++ b/src/data-table/_data-table.scss
@@ -71,12 +71,6 @@
     border-bottom: $data-table-dividers;
     padding-top: $data-table-cell-top;
     box-sizing: border-box;
-
-    .mdl-data-table__select {
-      vertical-align: top;
-      position: absolute;
-      left: 24px;
-    }
   }
 
   th {


### PR DESCRIPTION
Code not needed and causes the checkbox on the header of a table to get out of its container in IE 11 (see attached picture from official documentation)
![checkbox-ie-table](https://cloud.githubusercontent.com/assets/6192131/9757583/dbca162e-56e1-11e5-8db0-b9d04a0f7561.PNG)
