### PR TITLE
Adding reordering classes to the grid

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -519,6 +519,7 @@ $grid-phone-gutter: $grid-desktop-gutter !default;
 $grid-phone-margin: $grid-desktop-margin !default;
 
 $grid-cell-default-columns: $grid-phone-columns !default;
+$grid-max-columns: $grid-desktop-columns !default;
 
 /* DATA TABLE */
 

--- a/src/grid/README.md
+++ b/src/grid/README.md
@@ -110,6 +110,10 @@ The MDL CSS classes apply various predefined visual enhancements and behavioral 
 | `mdl-cell--N-offset-desktop` | Adds N columns of whitespace before the cell in desktop mode | N is 1-11 inclusive; optional on "inner" div elements|
 | `mdl-cell--N-offset-tablet` | Adds N columns of whitespace before the cell in tablet mode | N is 1-7 inclusive; optional on "inner" div elements|
 | `mdl-cell--N-offset-phone` | Adds N columns of whitespace before the cell in phone mode | N is 1-3 inclusive; optional on "inner" div elements|
+| `mdl-cell--order-N` | Reorders cell to position N | N is 1-12 inclusive; optional on "inner" div elements|
+| `mdl-cell--order-N-desktop` | Reorders cell to position N when in desktop mode | N is 1-12 inclusive; optional on "inner" div elements|
+| `mdl-cell--order-N-tablet` | Reorders cell to position N when in tablet mode | N is 1-12 inclusive; optional on "inner" div elements|
+| `mdl-cell--order-N-phone` | Reorders cell to position N when in phone mode | N is 1-12 inclusive; optional on "inner" div elements|
 | `mdl-cell--hide-desktop` | Hides the cell when in desktop mode | Optional on "inner" div elements |
 | `mdl-cell--hide-tablet` | Hides the cell when in tablet mode | Optional on "inner" div elements |
 | `mdl-cell--hide-phone` | Hides the cell when in phone mode | Optional on "inner" div elements |

--- a/src/grid/_grid.scss
+++ b/src/grid/_grid.scss
@@ -58,6 +58,13 @@
   margin: 0;
 }
 
+// Define order override classes.
+@for $i from 1 through $grid-max-columns {
+  .mdl-cell--order-#{$i} {
+    order: $i;
+  }
+}
+
 
 // Mixins for width calculation.
 @mixin partial-size($size, $columns, $gutter) {
@@ -97,6 +104,13 @@
 
   .mdl-cell--hide-phone {
     display: none !important;
+  }
+
+  // Define order override classes.
+  @for $i from 1 through $grid-max-columns {
+    .mdl-cell--order-#{$i}-phone.mdl-cell--order-#{$i}-phone {
+      order: $i;
+    }
   }
 
   // Define partial sizes for columnNumber < totalColumns.
@@ -142,6 +156,13 @@
     display: none !important;
   }
 
+  // Define order override classes.
+  @for $i from 1 through $grid-max-columns {
+    .mdl-cell--order-#{$i}-tablet.mdl-cell--order-#{$i}-tablet {
+      order: $i;
+    }
+  }
+
   // Define partial sizes for columnNumber < totalColumns.
   @for $i from 1 through ($grid-tablet-columns - 1) {
     .mdl-cell--#{$i}-col,
@@ -183,6 +204,13 @@
 
   .mdl-cell--hide-desktop {
     display: none !important;
+  }
+
+  // Define order override classes.
+  @for $i from 1 through $grid-max-columns {
+    .mdl-cell--order-#{$i}-desktop.mdl-cell--order-#{$i}-desktop {
+      order: $i;
+    }
   }
 
   // Define partial sizes for all numbers of columns.


### PR DESCRIPTION
This PR adds reordering classes to the grid, numbered 1 to 12 for the maximum number of columns on our grid. These are convenience classes that provide autoprefixed `order` attributes.

@surma @Garbee PTAL!