### PR TITLE
Fix Switch cursor issue (fixes #1530)

### DIFF
--- a/src/switch/_switch.scss
+++ b/src/switch/_switch.scss
@@ -197,7 +197,6 @@
   }
 
   .mdl-switch.is-checked & {
-    cursor: auto;
     left: $switch-track-length - $switch-ripple-size / 2 -
         $switch-thumb-size / 2;
   }


### PR DESCRIPTION
When switch is on, cursor is no longer pointer. It is set back to default. fixed it by removing the overriding `cursor: auto`