### PR TITLE
Disallow scrolling if drawer is open (fixes #1348)

### DIFF
--- a/src/layout/_layout.scss
+++ b/src/layout/_layout.scss
@@ -118,6 +118,9 @@
 
     &.is-visible {
       transform: translateX(0);
+      & ~ .mdl-layout__content {
+        overflow: hidden;
+      }
     }
 
     & > * {

--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -286,14 +286,6 @@
         }
       }
 
-      /**
-       * Prevents an event from triggering the default behaviour.
-       * @param  {Event} ev the event to eat.
-       */
-      var eatEvent = function(ev) {
-        ev.preventDefault();
-      };
-
       // Add drawer toggling button to our layout, if we have an openable drawer.
       if (this.drawer_) {
         var drawerButton = this.element_.querySelector('.' +
@@ -337,7 +329,6 @@
         this.element_.appendChild(obfuscator);
         obfuscator.addEventListener('click',
             this.drawerToggleHandler_.bind(this));
-        obfuscator.addEventListener('mousewheel', eatEvent);
       }
 
       // Initialize tabs, if any.


### PR DESCRIPTION
Pure CSS solution to this problem. To my surprise, switching from `overflow: scroll` to `overflow: hidden` after the page has been scrolled doesn’t make it jump back to the top but just locks it wherever it is at that moment.

Put [this](https://gist.github.com/surma/e4475ffeae1ba792a148) file in your `dist` to test locally. Worked for me just fine though. 