### PR TITLE
Simplify a css selector with duplicate classes

### DIFF
--- a/src/layout/_layout.scss
+++ b/src/layout/_layout.scss
@@ -314,7 +314,7 @@
     }
   }
 
-    .mdl-layout__header--transparent.mdl-layout__header--transparent {
+    .mdl-layout__header--transparent {
       background-color: transparent;
       box-shadow: none;
     }


### PR DESCRIPTION
This was caused by a previous rename.