### PR TITLE
Remove double header background color in dashboard

### DIFF
--- a/templates/dashboard/index.html
+++ b/templates/dashboard/index.html
@@ -62,7 +62,7 @@
   </head>
   <body>
     <div class="demo-layout mdl-layout mdl-js-layout mdl-layout--fixed-drawer mdl-layout--fixed-header">
-      <header class="demo-header mdl-layout__header mdl-color--white mdl-color--grey-100 mdl-color-text--grey-600">
+      <header class="demo-header mdl-layout__header mdl-color--grey-100 mdl-color-text--grey-600">
         <div class="mdl-layout__header-row">
           <span class="mdl-layout-title">Home</span>
           <div class="mdl-layout-spacer"></div>


### PR DESCRIPTION
It seems commit 9e4503591bb93d0a40661d50e55d038d4c50ab8d intended the background to be `grey-100` but `white` was still left in. I removed white to keep the original intent. The resulting color displayed in the browser was white, so maybe it should be `white` instead of `grey-100`.