### PR TITLE
Menu: fix early-menu-hide bug when click on menu item

### DIFF
--- a/src/menu/menu.js
+++ b/src/menu/menu.js
@@ -406,11 +406,15 @@
 
       // Add a click listener to the document, to close the menu.
       var callback = function(e) {
+        var targetIsMenu = Array.prototype.slice.call(
+          this.container_.querySelectorAll('*')).indexOf(e.target) > -1;
         // Check to see if the document is processing the same event that
         // displayed the menu in the first place. If so, do nothing.
         // Also check to see if the menu is in the process of closing itself, and
         // do nothing in that case.
-        if (e !== evt && !this.closing_) {
+        // Also check if the clicked element is inside of menu container
+        // if so, do nothing.
+        if (e !== evt && !this.closing_ && !targetIsMenu) {
           document.removeEventListener('click', callback);
           this.hide();
         }

--- a/src/menu/menu.js
+++ b/src/menu/menu.js
@@ -406,15 +406,13 @@
 
       // Add a click listener to the document, to close the menu.
       var callback = function(e) {
-        var targetIsMenu = Array.prototype.slice.call(
-          this.container_.querySelectorAll('*')).indexOf(e.target) > -1;
         // Check to see if the document is processing the same event that
         // displayed the menu in the first place. If so, do nothing.
         // Also check to see if the menu is in the process of closing itself, and
         // do nothing in that case.
-        // Also check if the clicked element is inside of menu container
+        // Also check if the clicked element is a menu item
         // if so, do nothing.
-        if (e !== evt && !this.closing_ && !targetIsMenu) {
+        if (e !== evt && !this.closing_ && e.target.parentNode !== this.element_) {
           document.removeEventListener('click', callback);
           this.hide();
         }


### PR DESCRIPTION
I noticed in code [menu.js:306] that when you click on menu item, it should hide with some delay like 100ms. Instead it hides instantly due to ignoring internal menu elements when you click on any document element [menu.js:408]

I added code to check if any clicked element is inside the menu container. 