### PR TITLE
Fix the obfuscator in iOS9. Fixes #1696.

### DIFF
--- a/src/layout/_layout.scss
+++ b/src/layout/_layout.scss
@@ -382,7 +382,7 @@
     transition-property: background-color;
     @include material-animation-default();
 
-    .mdl-layout__drawer.is-visible ~ & {
+    &.is-visible {
       background-color: rgba(0, 0, 0, 0.5);
       visibility: visible;
     }

--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -151,6 +151,7 @@
       // Collapse drawer (if any) when moving to a large screen size.
       if (this.drawer_) {
         this.drawer_.classList.remove(this.CssClasses_.IS_DRAWER_OPEN);
+        this.obfuscator_.classList.remove(this.CssClasses_.IS_DRAWER_OPEN);
       }
     }
   };
@@ -162,6 +163,7 @@
    */
   MaterialLayout.prototype.drawerToggleHandler_ = function() {
     this.drawer_.classList.toggle(this.CssClasses_.IS_DRAWER_OPEN);
+    this.obfuscator_.classList.toggle(this.CssClasses_.IS_DRAWER_OPEN);
   };
 
   /**
@@ -340,6 +342,7 @@
         obfuscator.addEventListener('click',
             this.drawerToggleHandler_.bind(this));
         obfuscator.addEventListener('mousewheel', eatEvent);
+        this.obfuscator_ = obfuscator;
       }
 
       // Initialize tabs, if any.

--- a/templates/android-dot-com/index.html
+++ b/templates/android-dot-com/index.html
@@ -27,7 +27,7 @@
     <!-- Page styles -->
     <link href="https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-    <link rel="stylesheet" href="https://storage.googleapis.com/code.getmdl.io/1.0.0/material.min.css">
+    <link rel="stylesheet" href="material.min.css">
     <link rel="stylesheet" href="styles.css">
     <style>
     #view-source {

--- a/templates/android-dot-com/material.scss
+++ b/templates/android-dot-com/material.scss
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import '../../src/material-design-lite';


### PR DESCRIPTION
iOS9 seems to have broken the general sibling selector (~) in WebViews. :bomb:

This means we can't use it anymore. Yay. This code works around the issue by applying the class directly to the obfuscator element.

In addition, this fixes the android.com template to always use the latest version of MDL (since this was the test case for the bug).

@surma PTAL!