### PR TITLE
Set max-width to 100% in .mdl-progress

### DIFF
--- a/src/progress/_progress.scss
+++ b/src/progress/_progress.scss
@@ -21,6 +21,7 @@
   position: relative;
   height: $bar-height;
   width: 500px;
+  max-width: 100%;
 }
 
 .mdl-progress > .bar {


### PR DESCRIPTION
I was supposed to open an issue first but the fix took 30s to write so I thought submitting directly a PR could be better.

`.mdl-progress` sets the width to 500px. Therefore when including the progress bar into a smaller container, it will not adapt to the container. My suggestion is having a `max-width` attribute set to 100% as a default. The css selector being a class it can be easily overwritten
