### PR TITLE
More fixes for broken sibling selector in iOS

### DIFF
--- a/src/footer/_mega_footer.scss
+++ b/src/footer/_mega_footer.scss
@@ -169,8 +169,8 @@
   z-index: 1;
   opacity: 0;
 
-  &~.mdl-mega-footer--heading:after,
-  &~.mdl-mega-footer__heading:after {
+  & + .mdl-mega-footer--heading:after,
+  & + .mdl-mega-footer__heading:after {
     font-family: 'Material Icons';
     content: '\E5CE'
   }
@@ -178,12 +178,13 @@
 
 .mdl-mega-footer--heading-checkbox:checked,
 .mdl-mega-footer__heading-checkbox:checked {
-  &~ul {
-    display:none;
+  & + .mdl-mega-footer--heading + .mdl-mega-footer--link-list,
+  & + .mdl-mega-footer__heading + .mdl-mega-footer__link-list {
+    display: none;
   }
 
-  &~.mdl-mega-footer--heading:after,
-  &~.mdl-mega-footer__heading:after {
+  & + .mdl-mega-footer--heading:after,
+  & + .mdl-mega-footer__heading:after {
     font-family: 'Material Icons';
     content: '\E5CF'
   }
@@ -260,22 +261,23 @@
   .mdl-mega-footer__heading-checkbox {
     display: none;
 
-    &~.mdl-mega-footer--heading:after,
-    &~.mdl-mega-footer__heading:after {
+    & + .mdl-mega-footer--heading:after,
+    & + .mdl-mega-footer__heading:after {
       background-image: none;
     }
   }
   .mdl-mega-footer--heading-checkbox:checked,
   .mdl-mega-footer__heading-checkbox:checked {
-  &~ul {
-    display: block;
-  }
+    & + .mdl-mega-footer--heading + .mdl-mega-footer__link-list,
+    & + .mdl-mega-footer__heading + .mdl-mega-footer--link-list {
+      display: block;
+    }
 
-  &~.mdl-mega-footer--heading:after,
-  &~.mdl-mega-footer__heading:after {
-    content: '';
+    & + .mdl-mega-footer--heading:after,
+    & + .mdl-mega-footer__heading:after {
+      content: '';
+    }
   }
-}
 }
 
 .mdl-mega-footer--bottom-section,

--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -245,13 +245,6 @@
 
       var mode = this.Mode_.STANDARD;
 
-      // Keep an eye on screen size, and add/remove auxiliary class for styling
-      // of small screens.
-      this.screenSizeMediaQuery_ = window.matchMedia(
-          /** @type {string} */ (this.Constant_.MAX_WIDTH));
-      this.screenSizeMediaQuery_.addListener(this.screenSizeHandler_.bind(this));
-      this.screenSizeHandler_();
-
       if (this.header_) {
         if (this.header_.classList.contains(this.CssClasses_.HEADER_SEAMED)) {
           mode = this.Mode_.SEAMED;
@@ -344,6 +337,13 @@
         obfuscator.addEventListener('mousewheel', eatEvent);
         this.obfuscator_ = obfuscator;
       }
+
+      // Keep an eye on screen size, and add/remove auxiliary class for styling
+      // of small screens.
+      this.screenSizeMediaQuery_ = window.matchMedia(
+          /** @type {string} */ (this.Constant_.MAX_WIDTH));
+      this.screenSizeMediaQuery_.addListener(this.screenSizeHandler_.bind(this));
+      this.screenSizeHandler_();
 
       // Initialize tabs, if any.
       if (this.header_ && this.tabBar_) {

--- a/src/slider/_slider.scss
+++ b/src/slider/_slider.scss
@@ -185,7 +185,7 @@ _:-ms-input-placeholder, :root .mdl-slider.mdl-slider.is-upgraded {
       background: transparent;
     }
 
-    &.is-lowest-value ~
+    &.is-lowest-value +
         .mdl-slider__background-flex > .mdl-slider__background-upper {
       left: 6px;
     }
@@ -205,7 +205,7 @@ _:-ms-input-placeholder, :root .mdl-slider.mdl-slider.is-upgraded {
       transform: scale(1.5);
     }
 
-    &.is-lowest-value:active ~
+    &.is-lowest-value:active +
         .mdl-slider__background-flex > .mdl-slider__background-upper {
       left: 9px;
     }
@@ -271,13 +271,13 @@ _:-ms-input-placeholder, :root .mdl-slider.mdl-slider.is-upgraded {
       background: $range-bg-color;
     }
 
-    &:disabled ~
+    &:disabled +
         .mdl-slider__background-flex > .mdl-slider__background-lower {
       background-color: $range-bg-color;
       left: -6px;
     }
 
-    &:disabled ~
+    &:disabled +
         .mdl-slider__background-flex > .mdl-slider__background-upper {
       left: 6px;
     }
@@ -298,7 +298,7 @@ _:-ms-input-placeholder, :root .mdl-slider.mdl-slider.is-upgraded {
       transform: scale(0.667);
     }
 
-    &.is-lowest-value:disabled:active ~
+    &.is-lowest-value:disabled:active +
         .mdl-slider__background-flex > .mdl-slider__background-upper {
       left: 6px;
     }

--- a/templates/android-dot-com/index.html
+++ b/templates/android-dot-com/index.html
@@ -71,6 +71,9 @@
               <a class="mdl-navigation__link mdl-typography--text-uppercase" href="">Play</a>
             </nav>
           </div>
+          <span class="android-mobile-title mdl-layout-title">
+            <img class="android-logo-image" src="images/android-logo.png">
+          </span>
           <button class="android-more-button mdl-button mdl-js-button mdl-button--icon mdl-js-ripple-effect" id="more-button">
             <i class="material-icons">more_vert</i>
           </button>
@@ -80,9 +83,6 @@
             <li disabled class="mdl-menu__item">4.3 Jelly Bean</li>
             <li class="mdl-menu__item">Android History</li>
           </ul>
-          <span class="android-mobile-title mdl-layout-title">
-            <img class="android-logo-image" src="images/android-logo.png">
-          </span>
         </div>
       </div>
 

--- a/templates/android-dot-com/styles.css
+++ b/templates/android-dot-com/styles.css
@@ -110,7 +110,7 @@ a img{
     width: 800px;
   }
 
-  .android-search-box.is-focused ~ .android-navigation-container {
+  .android-search-box.is-focused + .android-navigation-container {
     opacity: 0;
     width: 100px;
   }
@@ -481,7 +481,8 @@ a img{
     transition: opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
-  .android-search-box.is-focused ~ .android-mobile-title {
+  .android-search-box.is-focused + .android-navigation-container +
+      .android-mobile-title {
     opacity: 0;
   }
 


### PR DESCRIPTION
This PR adds more workarounds for the general sibling selector (`~`) breakage in iOS, replacing it with the adjacent sibling selector (`+`) or a chain thereof.

@surma @addyosmani PTAL!