### PR TITLE
Fix ripple effect on menubtn in templates/blog/index.html

### DIFF
--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -89,11 +89,11 @@
               <div>
                 <strong>The Newist</strong>
               </div>
-              <ul class="mdl-menu mdl-js-menu mdl-menu--bottom-right" for="menubtn">
-                <li class="mdl-menu__item mdl-js-ripple-effect">About</li>
-                <li class="mdl-menu__item mdl-js-ripple-effect">Message</li>
-                <li class="mdl-menu__item mdl-js-ripple-effect">Favorite</li>
-                <li class="mdl-menu__item mdl-js-ripple-effect">Search</li>
+              <ul class="mdl-menu mdl-js-menu mdl-menu--bottom-right mdl-js-ripple-effect" for="menubtn">
+                <li class="mdl-menu__item">About</li>
+                <li class="mdl-menu__item">Message</li>
+                <li class="mdl-menu__item">Favorite</li>
+                <li class="mdl-menu__item">Search</li>
               </ul>
               <button id="menubtn" class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--icon">
                 <i class="material-icons" role="presentation">more_vert</i>


### PR DESCRIPTION
The **mdl-js-ripple-effect** class applied to the wrong element, and cause JS error. The code change complies with the guide on http://www.getmdl.io/components/index.html#menus-section.