### PR TITLE
Consecutive `+` CSS selectors sometimes cause problems in WebKit.

### DIFF
--- a/src/footer/_mega_footer.scss
+++ b/src/footer/_mega_footer.scss
@@ -178,6 +178,11 @@
 
 .mdl-mega-footer--heading-checkbox:checked,
 .mdl-mega-footer__heading-checkbox:checked {
+  // WebViews in iOS 9 break the "~" operator, and WebViews in OS X 10.10
+  // break consecutive "+" operators in some cases. Therefore, we need to use
+  // both here to cover all the bases.
+  & ~ .mdl-mega-footer--link-list,
+  & ~ .mdl-mega-footer__link-list,
   & + .mdl-mega-footer--heading + .mdl-mega-footer--link-list,
   & + .mdl-mega-footer__heading + .mdl-mega-footer__link-list {
     display: none;
@@ -268,8 +273,13 @@
   }
   .mdl-mega-footer--heading-checkbox:checked,
   .mdl-mega-footer__heading-checkbox:checked {
-    & + .mdl-mega-footer--heading + .mdl-mega-footer__link-list,
-    & + .mdl-mega-footer__heading + .mdl-mega-footer--link-list {
+    // WebViews in iOS 9 break the "~" operator, and WebViews in OS X 10.10
+    // break consecutive "+" operators in some cases. Therefore, we need to use
+    // both here to cover all the bases.
+    & ~ .mdl-mega-footer--link-list,
+    & ~ .mdl-mega-footer__link-list,
+    & + .mdl-mega-footer__heading + .mdl-mega-footer__link-list,
+    & + .mdl-mega-footer--heading + .mdl-mega-footer--link-list {
       display: block;
     }
 

--- a/templates/android-dot-com/styles.css
+++ b/templates/android-dot-com/styles.css
@@ -481,8 +481,11 @@ a img{
     transition: opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
-  .android-search-box.is-focused + .android-navigation-container +
-      .android-mobile-title {
+  /* WebViews in iOS 9 break the "~" operator, and WebViews in OS X 10.10 break
+     consecutive "+" operators in some cases. Therefore, we need to use both
+     here to cover all the bases. */
+  .android.android-search-box.is-focused ~ .android-mobile-title,
+  .android-search-box.is-focused + .android-navigation-container + .android-mobile-title {
     opacity: 0;
   }
 


### PR DESCRIPTION
We add `~` as an alternative here. `+` is still needed, though, as `~`
itself has problems in iOS 9 WebViews.

@addyosmani @surma PTAL!