### PR TITLE
Fix tooltip to behave more correctly on mobile

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -63,7 +63,6 @@
    * @private
    */
   MaterialTooltip.prototype.handleMouseEnter_ = function(event) {
-    event.stopPropagation();
     var props = event.target.getBoundingClientRect();
     var left = props.left + (props.width / 2);
     var marginLeft = -1 * (this.element_.offsetWidth / 2);
@@ -78,21 +77,15 @@
 
     this.element_.style.top = props.top + props.height + 10 + 'px';
     this.element_.classList.add(this.CssClasses_.IS_ACTIVE);
-    window.addEventListener('scroll', this.boundMouseLeaveHandler, false);
-    window.addEventListener('touchmove', this.boundMouseLeaveHandler, false);
   };
 
   /**
    * Handle mouseleave for tooltip.
    *
-   * @param {Event} event The event that fired.
    * @private
    */
-  MaterialTooltip.prototype.handleMouseLeave_ = function(event) {
-    event.stopPropagation();
+  MaterialTooltip.prototype.handleMouseLeave_ = function() {
     this.element_.classList.remove(this.CssClasses_.IS_ACTIVE);
-    window.removeEventListener('scroll', this.boundMouseLeaveHandler);
-    window.removeEventListener('touchmove', this.boundMouseLeaveHandler, false);
   };
 
   /**
@@ -108,21 +101,17 @@
       }
 
       if (this.forElement_) {
-        // Tabindex needs to be set for `blur` events to be emitted
+        // It's left here because it prevents accidental text selection on Android
         if (!this.forElement_.getAttribute('tabindex')) {
           this.forElement_.setAttribute('tabindex', '0');
         }
 
         this.boundMouseEnterHandler = this.handleMouseEnter_.bind(this);
         this.boundMouseLeaveHandler = this.handleMouseLeave_.bind(this);
-        this.forElement_.addEventListener('mouseenter', this.boundMouseEnterHandler,
-            false);
-        this.forElement_.addEventListener('click', this.boundMouseEnterHandler,
-            false);
-        this.forElement_.addEventListener('blur', this.boundMouseLeaveHandler);
-        this.forElement_.addEventListener('touchstart', this.boundMouseEnterHandler,
-            false);
-        this.forElement_.addEventListener('mouseleave', this.boundMouseLeaveHandler);
+        this.forElement_.addEventListener('mouseenter', this.boundMouseEnterHandler, false);
+        this.forElement_.addEventListener('touchend', this.boundMouseEnterHandler, false);
+        this.forElement_.addEventListener('mouseleave', this.boundMouseLeaveHandler, false);
+        window.addEventListener('touchstart', this.boundMouseLeaveHandler);
       }
     }
   };
@@ -135,9 +124,9 @@
   MaterialTooltip.prototype.mdlDowngrade_ = function() {
     if (this.forElement_) {
       this.forElement_.removeEventListener('mouseenter', this.boundMouseEnterHandler, false);
-      this.forElement_.removeEventListener('click', this.boundMouseEnterHandler, false);
-      this.forElement_.removeEventListener('touchstart', this.boundMouseEnterHandler, false);
-      this.forElement_.removeEventListener('mouseleave', this.boundMouseLeaveHandler);
+      this.forElement_.removeEventListener('touchend', this.boundMouseEnterHandler, false);
+      this.forElement_.removeEventListener('mouseleave', this.boundMouseLeaveHandler, false);
+      window.removeEventListener('touchstart', this.boundMouseLeaveHandler);
     }
   };
 


### PR DESCRIPTION
Discussion started at https://github.com/google/material-design-lite/issues/1461#issuecomment-148042964

It fixes tooltip behavior on mobile (works fine on latest iOS Simulator and latest Android, probably needs wider testing on a real iOS device and wider testing on Android versions/browsers, not sure about needed browser support).

Also `stopPropagation` is not needed anymore.

A few notes:

1. `touchmove` and `scroll` removed as hide triggers because I'm pretty sure there's no way to scroll without touch on mobile. So `touchstart` is used instead.

2. `touchstart` listener for `window` is bound/unbound on upgrade/downgrade respectively.

3. `blur` is actually fired on Android, but not on iOS so it doesn't help here.
Actually Android just fires `mouseenter`/`mouseleave` so no need to fix anything.

4. `tabindex` left here because without it icon selected as text on Android. Probably it's not needed at all.

5. `click` is not handled anymore because it doesn't make sense to handle it instead of or together with `touchstart`.

6. On capturing: capture phase used on `touchstart` on `window` to hide previously shown tooltip on and then if another tooltip is touched by the same event it's shown. Works like magic :-)

Pretty sure that it's enough and should not break backwards compatibility, plus it won't break event delegation.