### PR TITLE
Textfields can initialize as invalid.

### DIFF
--- a/src/textfield/README.md
+++ b/src/textfield/README.md
@@ -253,6 +253,7 @@ The MDL CSS classes apply various predefined visual and behavioral enhancements 
 | `mdl-js-button` | Assigns basic behavior to icon container | For expandable input fields, required on "outer" div's label element |
 | `mdl-button--icon` | Defines label as an MDL icon container | For expandable input fields, required on "outer" div's label element |
 | `mdl-input__expandable-holder` | Defines a container as an MDL component | For expandable input fields, required on "inner" div element |
+| `is-invalid` | Defines the textfield as invalid on initial load. | Optional on `mdl-textfield` element |
 
 (1) The "search" icon is used here as an example. Other icons can be used by modifying the text. For a list of available icons, see [this page](https://www.google.com/design/icons).
 

--- a/src/textfield/textfield.js
+++ b/src/textfield/textfield.js
@@ -225,9 +225,13 @@
           this.boundKeyDownHandler = this.onKeyDown_.bind(this);
           this.input_.addEventListener('keydown', this.boundKeyDownHandler);
         }
-
+        var invalid = this.element_.classList
+          .contains(this.CssClasses_.IS_INVALID);
         this.updateClasses_();
         this.element_.classList.add(this.CssClasses_.IS_UPGRADED);
+        if (invalid) {
+          this.element_.classList.add(this.CssClasses_.IS_INVALID);
+        }
       }
     }
   };

--- a/test/unit/textfield.js
+++ b/test/unit/textfield.js
@@ -68,4 +68,11 @@ describe('MaterialTextfield', function () {
     });
   });
 
+  it('should be invalid after upgrade if invalid previously', function () {
+    var el = createSingleLineTextfield()
+    el.classList.add('is-invalid');
+    componentHandler.upgradeElement(el);
+    expect(el.classList.contains('is-invalid')).to.equal(true);
+  });
+
 });


### PR DESCRIPTION
Fixes #1463 

This allows textfields to be upgraded and keep their invalid status even if HTML5 validation succeeds. As far as I can tell no other form components have invalid states so they are unaffected in this PR to address the issue.