### PR TITLE
Clean up gulp all task.

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -275,11 +275,12 @@ gulp.task('default', ['clean'], cb => {
 // Build production files and microsite
 gulp.task('all', ['clean'], cb => {
   runSequence(
-    ['default', 'styletemplates'],
-    ['styles:gen'],
-    ['lint', 'scripts', 'assets', 'demos', 'pages',
-     'templates', 'images', 'styles-grid', 'metadata'],
+    ['styletemplates'],
+    ['styles-grid', 'styles:gen'],
+    ['scripts'],
     ['mocha'],
+    ['assets', 'pages',
+     'templates', 'images', 'metadata'],
     ['zip'],
     cb);
 });


### PR DESCRIPTION
Helps address #1736

Don't call `default` for all. This calls a bunch of things that most other tasks just re-run.

Styles task is still ran twice. This is because `styles:gen` depends upon it completing, then `mocha` for some reason requires it as well. I'd personally think `mocha` should require `scripts` over `styles`, but that is for another time.

Steps of new `all`:
1. Compile all styles
2. Compile scripts
3. Test Scripts
4. Compile microsite data
5. Zip contents

As far as I can tell, all the needed tasks are still ran as before, we just slim down repetition loads. However, please still test this thoroughly.