### PR TITLE
Add full bleed modifier for menu items.

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -280,6 +280,7 @@ $default-item-outline-color: unquote("rgb(#{$palette-grey-400})") !default;
 $default-item-hover-bg-color: unquote("rgb(#{$palette-grey-200})") !default;
 $default-item-focus-bg-color: unquote("rgb(#{$palette-grey-200})") !default;
 $default-item-active-bg-color: unquote("rgb(#{$palette-grey-300})") !default;
+$default-item-divider-color: unquote("rgba(#{$color-black}, 0.12)") !default;
 
 // Disabled Button Colors
 $disabled-item-text-color: unquote("rgb(#{$palette-grey-400})") !default;

--- a/src/menu/README.md
+++ b/src/menu/README.md
@@ -91,6 +91,7 @@ The MDL CSS classes apply various predefined visual and behavioral enhancements 
 | `mdl-menu` | Defines an unordered list container as an MDL component | Required on ul element |
 | `mdl-js-menu` | Assigns basic MDL behavior to menu | Required on ul element |
 | `mdl-menu__item` | Defines buttons as MDL menu options and assigns basic MDL behavior | Required on list item elements |
+| `mdl-menu__item--full-bleed-divider` | Modifies an item to have a full bleed divider between it and the next list item. | Optional on list item elements |
 | `mdl-js-ripple-effect` | Applies *ripple* click effect to option links | Optional; goes on unordered list element |
 | `mdl-menu--top-left` | Positions menu above button, aligns left edge of menu with button  | Optional; goes on unordered list element |
 | (none) | Positions menu below button, aligns left edge of menu with button | Default |

--- a/src/menu/_menu.scss
+++ b/src/menu/_menu.scss
@@ -151,6 +151,10 @@
     border: 0;
   }
 
+  &--full-bleed-divider {
+    border-bottom: 1px solid $default-item-divider-color;
+  }
+
   &[disabled], &[data-mdl-disabled] {
     color: $disabled-item-text-color;
     background-color: transparent;

--- a/src/menu/snippets/lower-left.html
+++ b/src/menu/snippets/lower-left.html
@@ -7,7 +7,7 @@
 <ul class="mdl-menu mdl-menu--bottom-left mdl-js-menu mdl-js-ripple-effect"
     for="demo-menu-lower-left">
   <li class="mdl-menu__item">Some Action</li>
-  <li class="mdl-menu__item">Another Action</li>
+  <li class="mdl-menu__item mdl-menu__item--full-bleed-divider">Another Action</li>
   <li disabled class="mdl-menu__item">Disabled Action</li>
   <li class="mdl-menu__item">Yet Another Action</li>
 </ul>


### PR DESCRIPTION
Fixes #1546 

Doing partial-bleeds is infeasible in CSS, so we either need to do more work for that using new elements and fussing with the layout or opt to not include partial-bleeds in MDL. For now, I'm chosing the latter to keep things simple. Plus partial bleeds don't make much sense in this menu context.