### PR TITLE
Remove automatic name and value for data table checkboxes.

### DIFF
--- a/src/data-table/README.md
+++ b/src/data-table/README.md
@@ -189,4 +189,3 @@ The MDL CSS classes apply various predefined visual and behavioral enhancements 
 | `mdl-data-table__cell--non-numeric` | Applies text formatting to data cell | Optional; goes on both table header and table data cells |
 | (none) | Applies numeric formatting to header or data cell (default) |  |
 
-You may add `data-mdl-data-table-selectable-name` and `data-mdl-data-table-selectable-value` attributes to the *rows* of the table. If the table is selectable, these values will be added to the name and value of the created checkboxes.

--- a/src/data-table/data-table.js
+++ b/src/data-table/data-table.js
@@ -122,12 +122,6 @@
     if (row) {
       checkbox.checked = row.classList.contains(this.CssClasses_.IS_SELECTED);
       checkbox.addEventListener('change', this.selectRow_(checkbox, row));
-      if (row.hasAttribute('data-mdl-data-table-selectable-name')) {
-        checkbox.name = row.getAttribute('data-mdl-data-table-selectable-name');
-      }
-      if (row.hasAttribute('data-mdl-data-table-selectable-value')) {
-        checkbox.value = row.getAttribute('data-mdl-data-table-selectable-value');
-      }
     } else if (opt_rows) {
       checkbox.addEventListener('change', this.selectRow_(checkbox, null, opt_rows));
     }

--- a/test/unit/data-table.js
+++ b/test/unit/data-table.js
@@ -58,18 +58,4 @@ describe('MaterialDataTable', function () {
     document.body.removeChild(table);
   });
 
-  it('should assign a name and value to checkboxes when provided on rows', function() {
-    var table = createTable();
-    table.classList.add('mdl-data-table--selectable');
-    var row = table.insertRow();
-    row.dataset.mdlDataTableSelectableName = 'test';
-    row.dataset.mdlDataTableSelectableValue = 'awesome';
-    row.insertCell();
-
-    document.body.appendChild(table);
-
-    componentHandler.upgradeElement(table);
-    expect(table.querySelector('input[name="test"][value="awesome"]').nodeName).to.equal('INPUT');
-  });
-
 });


### PR DESCRIPTION
Since we are officially deprecating the automatic creation of checkboxes and such, we should not push this new feature. Instead we encourage developers to follow the [deprecation help](https://github.com/google/material-design-lite/wiki/Deprecations#automatic-selection-checkboxes) for this functionality which will give them absolute control over what is provided to the checkboxes.