### PR TITLE
New method to remove internal references to elements.

### DIFF
--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -402,6 +402,27 @@ componentHandler = (function() {
     }
   }
 
+  /**
+  * Remove the element from the internal createdComponents_ array.
+  *
+  * @param {!Element} element
+  */
+  function removeComponentInternal(element) {
+    var foundComponents = [];
+    for (var n = 0; n < createdComponents_.length; n++) {
+      var component = createdComponents_[n];
+      if (component.element_ === element) {
+        foundComponents.push(component);
+      }
+    }
+    for (var i = 0, length = foundComponents.length; i < length; i++) {
+      createdComponents_.splice(createdComponents_.indexOf(foundComponents[i]), 1);
+    }
+    var ev = document.createEvent('Events');
+    ev.initEvent('mdl-componentremoved', true, false);
+    element.dispatchEvent(ev);
+  }
+
   // Now return the functions that should be made public with their publicly
   // facing names...
   return {
@@ -411,7 +432,8 @@ componentHandler = (function() {
     upgradeAllRegistered: upgradeAllRegisteredInternal,
     registerUpgradedCallback: registerUpgradedCallbackInternal,
     register: registerInternal,
-    downgradeElements: downgradeNodesInternal
+    downgradeElements: downgradeNodesInternal,
+    removeComponent: removeComponentInternal
   };
 })();
 
@@ -467,6 +489,7 @@ componentHandler['registerUpgradedCallback'] =
     componentHandler.registerUpgradedCallback;
 componentHandler['register'] = componentHandler.register;
 componentHandler['downgradeElements'] = componentHandler.downgradeElements;
+componentHandler['removeComponent'] = componentHandler.removeComponent;
 window.componentHandler = componentHandler;
 window['componentHandler'] = componentHandler;
 

--- a/test/unit/componentHandler.js
+++ b/test/unit/componentHandler.js
@@ -61,12 +61,18 @@ describe('componentHandler', function() {
   });
 
   it('should reveal public methods', function() {
-    expect(componentHandler.upgradeDom).to.be.a('function');
-    expect(componentHandler.upgradeElement).to.be.a('function');
-    expect(componentHandler.upgradeAllRegistered).to.be.a('function');
-    expect(componentHandler.registerUpgradedCallback).to.be.a('function');
-    expect(componentHandler.register).to.be.a('function');
-    expect(componentHandler.downgradeElements).to.be.a('function');
+    var methods = [
+      'upgradeDom',
+      'upgradeElement',
+      'upgradeAllRegistered',
+      'registerUpgradedCallback',
+      'register',
+      'downgradeElements',
+      'removeComponent'
+    ];
+    methods.forEach(function(method) {
+      expect(componentHandler[method]).to.be.a('function');
+    });
   });
 
   it('should throw an error if a duplicate classAsString is provided for registration', function() {
@@ -112,7 +118,7 @@ describe('componentHandler', function() {
     componentHandler.upgradeElement(el, 'MaterialButton');
     componentHandler.upgradeElement(el, 'MaterialRipple');
     expect($(el)).to.have.data('upgraded', ',MaterialButton,MaterialRipple');
-  });  
+  });
 
   it('should upgrade a single component to an element by using its CSS classes', function() {
     var el = document.createElement('button');
@@ -147,8 +153,8 @@ describe('componentHandler', function() {
     var checkbox = createCheckbox();
 
     componentHandler.upgradeElements(checkbox);
-    
-    var child = checkbox.lastChild;    
+
+    var child = checkbox.lastChild;
     expect($(child)).to.have.data('upgraded', ',MaterialRipple');
   });
 


### PR DESCRIPTION
This adds a method to the component handler to remove all internal references to elements. It only takes a single node at a time to keep the method simple and clean.

> Side note: While I was in the unit test, I cleaned up the method test function to be much easier to keep updated.

## Usage

When a component can't be downgraded this provides a way to remove the internal reference. For example: `componentHandler.removeComponent(document.querySelector('mdl-js-button'))` will remove the internal reference for the first button found.

## Before merge

We need proper testing. I'm not sure of the best method to continually test this using mocha. cc @samccone to take a peek at how to handle that.