### PR TITLE
Don't call private component methods from the component handler.

### DIFF
--- a/src/button/button.js
+++ b/src/button/button.js
@@ -125,6 +125,17 @@
     this.element_.removeEventListener('mouseleave', this.boundButtonBlurHandler);
   };
 
+  /**
+   * Public alias for the downgrade method.
+   *
+   * @public
+   */
+  MaterialButton.prototype.mdlDowngrade =
+      MaterialButton.prototype.mdlDowngrade_;
+
+  MaterialButton.prototype['mdlDowngrade'] =
+      MaterialButton.prototype.mdlDowngrade;
+
   // The component registers itself. It can assume componentHandler is available
   // in the global scope.
   componentHandler.register({

--- a/src/checkbox/checkbox.js
+++ b/src/checkbox/checkbox.js
@@ -273,6 +273,17 @@
     this.element_.removeEventListener('mouseup', this.boundElementMouseUp);
   };
 
+  /**
+   * Public alias for the downgrade method.
+   *
+   * @public
+   */
+  MaterialCheckbox.prototype.mdlDowngrade =
+      MaterialCheckbox.prototype.mdlDowngrade_;
+
+  MaterialCheckbox.prototype['mdlDowngrade'] =
+      MaterialCheckbox.prototype.mdlDowngrade;
+
   // The component registers itself. It can assume componentHandler is available
   // in the global scope.
   componentHandler.register({

--- a/src/icon-toggle/icon-toggle.js
+++ b/src/icon-toggle/icon-toggle.js
@@ -259,6 +259,17 @@
     this.element_.removeEventListener('mouseup', this.boundElementOnMouseUp);
   };
 
+  /**
+   * Public alias for the downgrade method.
+   *
+   * @public
+   */
+  MaterialIconToggle.prototype.mdlDowngrade =
+      MaterialIconToggle.prototype.mdlDowngrade_;
+
+  MaterialIconToggle.prototype['mdlDowngrade'] =
+      MaterialIconToggle.prototype.mdlDowngrade;
+
   // The component registers itself. It can assume componentHandler is available
   // in the global scope.
   componentHandler.register({

--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -91,7 +91,7 @@ componentHandler = (function() {
   /** @type {!Array<componentHandler.Component>} */
   var createdComponents_ = [];
 
-  var downgradeMethod_ = 'mdlDowngrade_';
+  var downgradeMethod_ = 'mdlDowngrade';
   var componentConfigProperty_ = 'mdlComponentConfigInternal_';
 
   /**

--- a/src/menu/menu.js
+++ b/src/menu/menu.js
@@ -480,6 +480,17 @@
     }
   };
 
+  /**
+   * Public alias for the downgrade method.
+   *
+   * @public
+   */
+  MaterialMenu.prototype.mdlDowngrade =
+      MaterialMenu.prototype.mdlDowngrade_;
+
+  MaterialMenu.prototype['mdlDowngrade'] =
+      MaterialMenu.prototype.mdlDowngrade;
+
   // The component registers itself. It can assume componentHandler is available
   // in the global scope.
   componentHandler.register({

--- a/src/progress/progress.js
+++ b/src/progress/progress.js
@@ -123,6 +123,17 @@
     }
   };
 
+  /**
+   * Public alias for the downgrade method.
+   *
+   * @public
+   */
+  MaterialProgress.prototype.mdlDowngrade =
+      MaterialProgress.prototype.mdlDowngrade_;
+
+  MaterialProgress.prototype['mdlDowngrade'] =
+      MaterialProgress.prototype.mdlDowngrade;
+
   // The component registers itself. It can assume componentHandler is available
   // in the global scope.
   componentHandler.register({

--- a/src/ripple/ripple.js
+++ b/src/ripple/ripple.js
@@ -267,6 +267,17 @@
     this.element_.removeEventListener('blur', this.boundUpHandler);
   };
 
+  /**
+   * Public alias for the downgrade method.
+   *
+   * @public
+   */
+  MaterialRipple.prototype.mdlDowngrade =
+      MaterialRipple.prototype.mdlDowngrade_;
+
+  MaterialRipple.prototype['mdlDowngrade'] =
+      MaterialRipple.prototype.mdlDowngrade;
+
   // The component registers itself. It can assume componentHandler is available
   // in the global scope.
   componentHandler.register({

--- a/src/slider/slider.js
+++ b/src/slider/slider.js
@@ -245,6 +245,17 @@
     this.element_.parentElement.removeEventListener('mousedown', this.boundContainerMouseDownHandler);
   };
 
+  /**
+   * Public alias for the downgrade method.
+   *
+   * @public
+   */
+  MaterialSlider.prototype.mdlDowngrade =
+      MaterialSlider.prototype.mdlDowngrade_;
+
+  MaterialSlider.prototype['mdlDowngrade'] =
+      MaterialSlider.prototype.mdlDowngrade;
+
   // The component registers itself. It can assume componentHandler is available
   // in the global scope.
   componentHandler.register({

--- a/src/switch/switch.js
+++ b/src/switch/switch.js
@@ -277,6 +277,17 @@
     this.element_.removeEventListener('mouseup', this.boundMouseUpHandler);
   };
 
+  /**
+   * Public alias for the downgrade method.
+   *
+   * @public
+   */
+  MaterialSwitch.prototype.mdlDowngrade =
+      MaterialSwitch.prototype.mdlDowngrade_;
+
+  MaterialSwitch.prototype['mdlDowngrade'] =
+      MaterialSwitch.prototype.mdlDowngrade;
+
   // The component registers itself. It can assume componentHandler is available
   // in the global scope.
   componentHandler.register({

--- a/src/textfield/textfield.js
+++ b/src/textfield/textfield.js
@@ -250,6 +250,17 @@
     }
   };
 
+  /**
+   * Public alias for the downgrade method.
+   *
+   * @public
+   */
+  MaterialTextfield.prototype.mdlDowngrade =
+      MaterialTextfield.prototype.mdlDowngrade_;
+
+  MaterialTextfield.prototype['mdlDowngrade'] =
+      MaterialTextfield.prototype.mdlDowngrade;
+
   // The component registers itself. It can assume componentHandler is available
   // in the global scope.
   componentHandler.register({

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -141,6 +141,17 @@
     }
   };
 
+  /**
+   * Public alias for the downgrade method.
+   *
+   * @public
+   */
+  MaterialTooltip.prototype.mdlDowngrade =
+      MaterialTooltip.prototype.mdlDowngrade_;
+
+  MaterialTooltip.prototype['mdlDowngrade'] =
+      MaterialTooltip.prototype.mdlDowngrade;
+
   // The component registers itself. It can assume componentHandler is available
   // in the global scope.
   componentHandler.register({


### PR DESCRIPTION
This creates a public alias for every private downgrade method,
and switches the component handler to using the aliases instead.

@Garbee, @surma PTAL!