### PR TITLE
📐 Align search icon with menu icon in Firefox

### DIFF
--- a/templates/dashboard/styles.css
+++ b/templates/dashboard/styles.css
@@ -23,7 +23,11 @@ html, body {
   border-radius: 24px;
 }
 .demo-layout .demo-header .mdl-textfield {
-  padding-top: 27px;
+  padding: 0px;
+  margin-top: 41px;
+}
+.demo-layout .demo-header .mdl-textfield .mdl-textfield__expandable-holder {
+  bottom: 19px;
 }
 .demo-layout .mdl-layout__header .mdl-layout__drawer-button {
   color: rgba(0, 0, 0, 0.54);


### PR DESCRIPTION
The search icon was not aligned with the menu icon, in Firefox.

**Before**
![Image before fix]
(https://www.dropbox.com/s/s10ue7uru25573k/Captura%20de%20pantalla%202015-10-28%20a%20las%2010.35.31%20p.m..png?dl=1)

**After**
![Image of after fix]
(https://www.dropbox.com/s/0g5o7n0ggybeend/Captura%20de%20pantalla%202015-10-28%20a%20las%2010.38.07%20p.m..png?dl=1)

Tested with Firefox, Chrome, and Safari.

