### PR TITLE
Add material-icons to typography

### DIFF
--- a/src/typography/_typography.scss
+++ b/src/typography/_typography.scss
@@ -295,3 +295,18 @@
 .mdl-typography--font-black {
   font-weight: 900 !important;
 }
+
+.material-icons {
+  font-family: 'Material Icons';
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  word-wrap: normal;
+  font-feature-settings: 'liga';
+  -webkit-font-feature-settings: 'liga';
+  -webkit-font-smoothing: antialiased;
+}


### PR DESCRIPTION
Originally added by Surma in commit e2d090e58d14877d9ccf5c7c067ab4dfe29a3c49. Was never pulled into master from mdl-1.0 as needed. This adds it into master for the 1.1 release.