### PR TITLE
:new: Add Dialog component - With Dialog Element

### DIFF
--- a/docs/_templates/demo.html
+++ b/docs/_templates/demo.html
@@ -18,6 +18,11 @@
     <link rel="stylesheet" href="{{page.include_prefix}}components/demos.css">
     <script src="{{page.include_prefix}}material.min.js"></script>
 
+    <!-- Dialog polyfill -->
+    <!-- Used for examples to work in non-supporting browsers -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.2/dialog-polyfill.min.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.2/dialog-polyfill.min.css">
+
     {% set demo_css = "../../dist/components/" + page.component + "/demo.css" %}
     <style>
       {% include demo_css ignore missing %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -41,6 +41,11 @@
     <!-- Fonts -->
     <link href='https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en' rel='stylesheet' type='text/css'>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+
+    <!-- Dialog polyfill -->
+    <!-- Used for examples to work in non-supporting browsers -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.2/dialog-polyfill.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.2/dialog-polyfill.min.js"></script>
   </head>
   <body class="{{page.bodyclass}}">
   <!-- Google Analytics: change UA-XXXXX-X to be your site's ID -->

--- a/src/_mixins.scss
+++ b/src/_mixins.scss
@@ -272,3 +272,15 @@
   transition-duration: $duration;
   transition-timing-function: $animation-curve-default;
 }
+
+/* Dialog */
+
+@mixin dialog-width($units:5) {
+  @if(type_of($units) != 'number') {
+    @error "The unit given to dialog-width should be a number.";
+  }
+  // 56dp is the base unit width for Dialogs.
+  // With 5 units being the number of units for a mobile device.
+  // https://goo.gl/sK2O5o
+  width: $units * 56px;
+}

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -555,6 +555,9 @@ $data-table-card-padding: 24px !default;
 $data-table-button-padding-right: 16px !default;
 $data-table-cell-top: $data-table-card-padding / 2;
 
+/* DIALOG */
+$dialog-content-color: $card-supporting-text-text-color;
+
 /* SNACKBAR */
 
 // Hard coded since the color is not present in any palette.

--- a/src/dialog/README.md
+++ b/src/dialog/README.md
@@ -1,0 +1,111 @@
+## Introduction
+
+The Material Design Lite (MDL) **dialog** component allows for verification of
+user actions, simple data input, and alerts to provide extra information to users.
+
+## Basic Usage
+
+To use the dialog component, you must be using a browser that supports the [dialog element](http://www.w3.org/TR/2013/CR-html5-20130806/interactive-elements.html#the-dialog-element).
+Only Chrome and Opera have native support at the time of writing.
+For other browsers you will need to include the [dialog polyfill](https://github.com/GoogleChrome/dialog-polyfill) or create your own.
+
+Once you have dialog support create a dialog element.
+Within that container, add a content element with the class `mdl-dialog__content`.
+Add you content, then create an action container with the class `mdl-dialog__actions`.
+Finally for the markup, add your buttons within this container for triggering dialog functions.
+Keep in mind, the order is automatically reversed for actions.
+The first action you create will appear last on the action bar.
+
+Remember to add the event handlers for your action items.
+After your dialog markup is created, add the event listeners to the page to trigger the dialog to show.
+
+For example:
+
+```js
+  var button = document.querySelector('button');
+  var dialog = document.querySelector('dialog');
+  button.addEventListener('click', function() {
+    dialog.show();
+  });
+```
+
+## Examples
+
+### Simple Dialog
+```html
+<body>
+  <button id="show-dialog" type="button" class="mdl-button">Show Dialog</button>
+  <dialog class="mdl-dialog">
+    <p class="mdl-dialog__title">Allow data collection?</h4>
+    <div class="mdl-dialog__content">
+      <p>
+        Allowing us to collect data will let us get you the information you want faster.
+      <p>
+    </div>
+    <div class="mdl-dialog__actions">
+      <button type="button" class="mdl-button">Agree</button>
+      <button type="button" class="mdl-button close">Disagree</button>
+    </div>
+  </dialog>
+  <script>
+    var dialog = document.querySelector('dialog');
+    var showDialogButton = document.querySelector('#show-dialog');
+    showDialogButton.addEventListener('click', function() {
+      dialog.show();
+    });
+    dialog.querySelector('.close').addEventListener('click', function() {
+      dialog.close();
+    });
+  </script>
+</body>
+```
+
+### Dialog with full width actions
+```html
+<body>
+  <button type="button" class="mdl-button show-modal">Show Modal</button>
+  <dialog class="mdl-dialog">
+    <div class="mdl-dialog__content">
+      <p>
+        Allow this site to collect usage data to improve your experience?
+      <p>
+    </div>
+    <div class="mdl-dialog__actions mdl-dialog__actions--full-width">
+      <button type="button" class="mdl-button">Agree</button>
+      <button type="button" class="mdl-button close">Disagree</button>
+    </div>
+  </dialog>
+  <script>
+    var dialog = document.querySelector('dialog');
+    var showModalButton = document.querySelector('.show-modal');
+    showModalButton.addEventListener('click', function() {
+      dialog.showModal();
+    });
+    dialog.querySelector('.close').addEventListener('click', function() {
+      dialog.close();
+    });
+  </script>
+</body>
+```
+
+## CSS Classes
+
+### Blocks
+
+| MDL Class | Effect | Remarks |
+|-----------|--------|---------|
+| `mdl-dialog` | Defines the container of the dialog component. | Required on dialog container. |
+
+### Elements
+
+| MDL Class | Effect | Remarks |
+|-----------|--------|---------|
+| `mdl-dialog__title` | Defines the title container in the dialog. | Optional on title container. |
+| `mdl-dialog__content` | Defines the content container of the dialog. | Required on content container. |
+| `mdl-dialog__actions` | Defines the actions container in the dialog. | Required on action container. |
+
+### Modifiers
+
+| MDL Class | Effect | Remarks |
+|-----------|--------|---------|
+| `mdl-dialog__actions--full-width` | Modifies the actions to each take the full width of the container. This makes each take their own line. | Optional on action container. |

--- a/src/dialog/_dialog.scss
+++ b/src/dialog/_dialog.scss
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import "../variables";
+@import "../mixins";
+
+.mdl-dialog {
+    border: none;
+    @include shadow-24dp;
+    @include dialog-width;
+
+    &__title {
+        padding: 24px 24px 0;
+        margin: 0;
+        font-size: 2.5rem;
+    }
+    &__actions {
+        padding: 8px 8px 8px 24px;
+        display: flex;
+        flex-direction: row-reverse;
+        flex-wrap: wrap;
+        * {
+            margin-right: 8px;
+            height: 36px;
+            &:last-child {
+                margin-right: 0;
+            }
+        }
+        &--full-width {
+          padding: 0 0 8px 0;
+          * {
+            height: 48px;
+            flex: 0 0 100%;
+            padding-right: 16px;
+            margin-right: 0;
+            text-align: right;
+          }
+        }
+    }
+    &__content {
+        padding: 20px 24px 24px 24px;
+        color: $dialog-content-color;
+    }
+}

--- a/src/dialog/snippets/dialog.html
+++ b/src/dialog/snippets/dialog.html
@@ -1,0 +1,62 @@
+<button class="mdl-button mdl-js-button mdl-button--primary dialog-button">Show Dialog</button>
+<button id="show-modal-example" type="button" class="mdl-button">Show Modal</button>
+
+<dialog id="dialog" class="mdl-dialog">
+  <h3 class="mdl-dialog__title">MDL Dialog</h3>
+  <div class="mdl-dialog__content">
+    <p>
+      This is an example of the Material Design Lite dialog component.
+      Please use responsibly.
+    </p>
+  </div>
+  <div class="mdl-dialog__actions">
+    <button type="button" class="mdl-button">Close</button>
+    <button type="button" class="mdl-button" disabled>Disabled action</button>
+  </div>
+</dialog>
+
+<dialog class="mdl-dialog" id="modal-example">
+  <div class="mdl-dialog__content">
+    <p>
+      This is an example of the MDL Dialog being used as a modal.
+      It is using the full width action design intended for use with buttons
+      that do not fit within the specified <a href="https://www.google.com/design/spec/components/dialogs.html#dialogs-specs">length metrics</a>.
+    </p>
+  </div>
+  <div class="mdl-dialog__actions mdl-dialog__actions--full-width">
+    <button type="button" class="mdl-button">Close</button>
+    <button type="button" class="mdl-button" disabled>Inactive action</button>
+  </div>
+</dialog>
+
+<script>
+  (function() {
+    'use strict';
+    var dialogButton = document.querySelector('.dialog-button');
+    var dialog = document.querySelector('#dialog');
+    dialogButton.addEventListener('click', function() {
+       dialog.show();
+    });
+    dialog.querySelector('button:not([disabled])')
+    .addEventListener('click', function() {
+      dialog.close();
+    });
+  }());
+</script>
+
+<script>
+(function() {
+  'use strict';
+  var dialog = document.querySelector('#modal-example');
+  var closeButton = dialog.querySelector('button');
+  var closeClickHandler = function(event) {
+    dialog.close();
+  };
+  var showButton = document.querySelector('#show-modal-example');
+  var showClickHandler = function(event) {
+    dialog.showModal();
+  };
+  showButton.addEventListener('click', showClickHandler);
+  closeButton.addEventListener('click', closeClickHandler);
+}());
+</script>

--- a/src/material-design-lite.scss
+++ b/src/material-design-lite.scss
@@ -33,6 +33,7 @@
 @import "card/card";
 @import "checkbox/checkbox";
 @import "data-table/data-table";
+@import "dialog/dialog";
 @import "footer/mega_footer";
 @import "footer/mini_footer";
 @import "icon-toggle/icon-toggle";


### PR DESCRIPTION
This implements the dialog component which uses the native dialog element under the hood.

This method reduces the amount of code we are to maintain internally while relying on a high-quality polyfill of the standard for non-supporting browsers. This leads to cleaner code for developers.

@sgomes brought up in the other PR for Dialog that we would be forcing developers into using the dialog without a way to opt-out of some global event handlers the polyfill uses. I went the other way around and made using dialogs at all entirely opt-in. If you don't need dialogs (a good number of sites may never need them) then you simply don't include the polyfill on your site and there is only a minimal amount of extra CSS being added. However, if you do need dialogs then it is up to you to include the polyfill as-needed for your projects workflow.

UPDATE: Having a few issues working out the polyfill. Seems like the JS isn't running like it should be.

Before merge: 
* [ ] Move CDNJS polyfill for demos to local dep