### PR TITLE
:new: Textfield checkfocus

### DIFF
--- a/src/textfield/textfield.js
+++ b/src/textfield/textfield.js
@@ -117,6 +117,7 @@
     this.checkDisabled();
     this.checkValidity();
     this.checkDirty();
+    this.checkFocus();
   };
 
   // Public methods.
@@ -167,6 +168,21 @@
   };
   MaterialTextfield.prototype['checkDirty'] =
       MaterialTextfield.prototype.checkDirty;
+
+  /**
+  * Check the focus state and update field accordingly.
+  *
+  * @public
+  */
+  MaterialTextfield.prototype.checkFocus = function() {
+    if (Boolean(this.element_.querySelector(':focus'))) {
+      this.element_.classList.add(this.CssClasses_.IS_FOCUSED);
+    } else {
+      this.element_.classList.remove(this.CssClasses_.IS_FOCUSED);
+    }
+  };
+  MaterialTextfield.prototype['checkFocus'] =
+      MaterialTextfield.prototype.checkFocus;
 
   /**
    * Disable text field.

--- a/test/unit/textfield.js
+++ b/test/unit/textfield.js
@@ -59,6 +59,7 @@ describe('MaterialTextfield', function () {
       'checkDisabled',
       'checkValidity',
       'checkDirty',
+      'checkFocus',
       'disable',
       'enable',
       'change'


### PR DESCRIPTION
Fixes #1125 

No unit test since nothing I tried to test this functionality would work. Looks like the `focus()` method on inputs in a test focusing seems to be an issue. I manually tested by opening a snippet and adding `autofocus` to one, then going to http://localhost:5000/components/textfield/demo.html and seeing if it were focused or not. Works as expected.