### PR TITLE
Fix margin-right when using .mdl-badge--overlap

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -503,6 +503,7 @@ $badge-background: unquote("rgb(#{$color-accent})") !default;
 $badge-background-inverse: unquote("rgba(#{$color-accent-contrast},0.2)") !default;
 $badge-size : 22px !default;
 $badge-padding: 2px !default;
+$badge-overlap: 12px !default;
 
 /* SHADOWS */
 

--- a/src/badge/_badge.scss
+++ b/src/badge/_badge.scss
@@ -63,7 +63,10 @@
       box-shadow: 0 0 1px gray;
     }
   }
-  &.mdl-badge--overlap:after {
-    right: -10px;
+  &.mdl-badge--overlap {
+    margin-right: ($badge-size - $badge-overlap);
+    &:after {
+      right: -($badge-size - $badge-overlap);
+    }
   }
 }


### PR DESCRIPTION
Hi, I realised that the `margin-right` in badges is not adapted when using the `overlap` modifier:

<img width="455" alt="screen shot 2015-12-06 at 11 56 01" src="https://cloud.githubusercontent.com/assets/664177/11612969/60f0981e-9c10-11e5-8516-36fefa9141f5.png">

I therefore added an overlap variable and adapted the margin when the `overlap` modifier is present:

<img width="450" alt="screen shot 2015-12-06 at 11 47 00" src="https://cloud.githubusercontent.com/assets/664177/11612972/83378586-9c10-11e5-9446-91023452a454.png">

The overlap can be modified by changing the `$badge-overlap` variable. It correspond to the actual overlap.

I set it to 12px because that's its current value. The padding variable is ignored on purpose because it makes the overlapping easier: if we use the padding we have to take it into account when defining the overlapping. Having a padding of 2px means that we need an overlapping of 14px to actually overlap 12px.

By ignoringn the padding variable, setting the overlap variable to 0 (and modifying some variables to make it more visible), leads to this result:

<img width="240" alt="screen shot 2015-12-06 at 12 07 13" src="https://cloud.githubusercontent.com/assets/664177/11613028/58fb238e-9c12-11e5-9abb-7f17521ad1e1.png">

Which is, in my opinion, what is expected by the developper