### PR TITLE
Utilize event deduping optmization with addEventListener

### DIFF
--- a/src/menu/menu.js
+++ b/src/menu/menu.js
@@ -339,20 +339,24 @@
   };
 
   /**
+   * cleanup function to remove animation listeners.
+   *
+   * @param {Event} evt
+   * @private
+   */
+
+  MaterialMenu.prototype.removeAnimationEndListener_ = function(evt) {
+    evt.target.classList.remove(MaterialMenu.prototype.CssClasses_.IS_ANIMATING);
+  };
+
+  /**
    * Adds an event listener to clean up after the animation ends.
    *
    * @private
    */
   MaterialMenu.prototype.addAnimationEndListener_ = function() {
-    var cleanup = function() {
-      this.element_.removeEventListener('transitionend', cleanup);
-      this.element_.removeEventListener('webkitTransitionEnd', cleanup);
-      this.element_.classList.remove(this.CssClasses_.IS_ANIMATING);
-    }.bind(this);
-
-    // Remove animation class once the transition is done.
-    this.element_.addEventListener('transitionend', cleanup);
-    this.element_.addEventListener('webkitTransitionEnd', cleanup);
+    this.element_.addEventListener('transitionend', this.removeAnimationEndListener_);
+    this.element_.addEventListener('webkitTransitionEnd', this.removeAnimationEndListener_);
   };
 
   /**


### PR DESCRIPTION
**TLDR;** :sparkles: :heart: 

The old fix for the leak, did accomplish removing the event listener leak, however it was fixed in a way that caused object thrashing due to the non-uniqueness of each event-listener bound fn (due to the use of native bind)

--------

 
The initial leak found here https://github.com/google/material-design-lite/issues/761

And then patched here https://github.com/google/material-design-lite/commit/957656d2beaab2d990b7758c8f13f44f9d0dfaf3

Was never the "correct" fix. Yes the patch in
957656d2beaab2d990b7758c8f13f44f9d0dfaf3 caused us to no longer leak
however we were still paying the cost of registering and unregistering
for the same event over and over, as well as allocating a new bound
scope each time (thus generating more garbage and thus eventually
causing more time to be spent int GC)

<img width="1219" alt="screen shot 2015-12-08 at 7 10 24 pm" src="https://cloud.githubusercontent.com/assets/883126/11675562/9b1a61b6-9ddf-11e5-895c-0e5d7bdc3c34.png">

--------------

Instead I opted here to take advantage of addEventListener and its
ability to automatically discard duplicate listeners. (1)

Resulting in a much more efficient use of runtime memory heap allocations (and thus less time to be spent in GC land)

<img width="1277" alt="screen shot 2015-12-08 at 7 12 02 pm" src="https://cloud.githubusercontent.com/assets/883126/11675585/d23c00dc-9ddf-11e5-9697-91cf1f7c0ed1.png">


:yellow_heart: 


Because there is no outside pointers into this eventListener (such as `.bind` or a parent self reference), there is no need to remove the listener anymore, because once the node reference becomes
unreachable the events will be automatically GCd for us. :game_die: 

-------------

(1)
> If multiple identical EventListeners are registered on the same
> EventTarget with the same parameters, the duplicate instances are
> discarded. They do not cause the EventListener to be called twice, and
> they do not need to be removed manually with the removeEventListener
> method.
https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Multiple_identical_event_listeners