### PR TITLE
Make gulp tasks work in CI context

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,18 +10,17 @@ build:
     - WEBDRIVER=http://chromedriver.storage.googleapis.com/2.16/chromedriver_linux64.zip
     - DISPLAY=:99
   commands:
-    - Xvfb $DISPLAY &
-    # gulp mocha:closure inexplicably throws an error w/o without -g phantomjs
-    - npm install -g phantomjs
     - npm install
     # build and unit test
     - gulp all
     - gulp mocha:closure
     # additional browser tests
     # do this after the build and unit tests to fail fast
+    - Xvfb $DISPLAY &
     - curl -sSLo chrome.deb $CHROME && dpkg -i chrome.deb
     - curl -sSLo driver.zip $WEBDRIVER && unzip -q driver.zip -d /usr/bin
-    - node test/memory/test.js
+    - npm install babel-cli
+    - ./node_modules/.bin/babel-node test/memory/test.js
 #deploy:
 #  bash:
 #    when:

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,5 +1,6 @@
 {
   "preset": "google",
+  "esnext": true,
   "disallowSpacesInAnonymousFunctionExpression": null,
   "validateLineBreaks": "LF",
   "validateIndentation": 2,

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -17,6 +17,8 @@
  *
  */
 
+// jscs:disable jsDoc
+
 'use strict';
 
 // Include Gulp & Tools We'll Use

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "jshint-stylish": "^2.0.1",
     "merge-stream": "^1.0.0",
     "mocha": "^2.1.0",
-    "phantomjs": "^1.9.17",
     "prismjs": "0.0.1",
     "run-sequence": "^1.0.2",
     "swig": "^1.4.2",


### PR DESCRIPTION
@surma these seem to be the last changes needed to make gulp tasks run in the CI context.

However, test/memory/test.js still fails with:

```
$ ./node_modules/.bin/babel-node test/memory/test.js
undefined:1190
   vlog(2, () => this + ' scheduling notifications', this);
            ^
SyntaxError: Unexpected token )
```