### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "author": "Google",
   "repository": "google/material-design-lite",
-  "main": "dist/material.min.js",
+  "main": "dist/material.js",
   "devDependencies": {
     "acorn": "^2.2.0",
     "babel-core": "^5.8.25",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "author": "Google",
   "repository": "google/material-design-lite",
-  "main": "dist/material.js",
+  "main": "dist/material.min.js",
   "devDependencies": {
     "acorn": "^2.2.0",
     "babel-core": "^5.8.25",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "author": "Google",
   "repository": "google/material-design-lite",
+  "main": "dist/material.min.js",
   "devDependencies": {
     "acorn": "^2.2.0",
     "babel-core": "^5.8.25",


### PR DESCRIPTION
I think this issue should be re-opened: https://github.com/google/material-design-lite/issues/1214

The workaround above `require('material-design-lite/material.min.js')` does not work when I use webpack's CommonsChunkPlugin to extract vendor libraries:

```
webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.dist.js')
```

I get the following error at compile time:

```
ERROR in multi vendor
Module not found: Error: Cannot resolve module 'material-design-lite' in /project-path/myproject
 @ multi vendor
```

And my `vendor.dist.js` has this error:

```
...
__webpack_require__(324);
(function webpackMissingModule() { throw new Error("Cannot find module \"material-design-lite\""); }());
...
```

Manually adding `"main": "dist/material.js”` or `"main": "dist/material.min.js”` fixes this issue. Obviously, manual code editing is not an option for when building in Jenkins. 