### PR TITLE
Fixed ribbon breaking on iOS.

### DIFF
--- a/templates/article/styles.css
+++ b/templates/article/styles.css
@@ -15,6 +15,7 @@
  */
 
 .demo-ribbon {
+  position: absolute;
   width: 100%;
   height: 40vh;
   background-color: #3F51B5;
@@ -22,7 +23,7 @@
 }
 
 .demo-main {
-  margin-top: -35vh;
+  margin-top: 5vh;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
On iOS the article gets pushed above the top of the screen because the ribbons height is not recognized. Does not work appear in chrome dev tools but, on an actual device it does

What appears now (before the commit):
![12366599_676057222536304_1102258209_n](https://cloud.githubusercontent.com/assets/5288805/11768693/7b2d7fac-a1a2-11e5-9305-f849ed91b896.jpg)

What will appear (how it should look, after the commit):
![12388307_1700551126844830_576241090_n](https://cloud.githubusercontent.com/assets/5288805/11768697/816fbbc8-a1a2-11e5-9da8-e2dc091113ba.jpg)

These are screenshots from my own website which uses the article MDL template: https://github.com/braeden123/braeden123.github.io


Here is the commit before the fix, if you want to test it:

https://github.com/braeden123/braeden123.github.io/commit/12ddb89037eda3e1eb76743226d81de31f34b0ea