### PR TITLE
Hide number spinners for textfields.

### DIFF
--- a/src/textfield/_textfield.scss
+++ b/src/textfield/_textfield.scss
@@ -68,6 +68,16 @@
   text-align: left;
   color: inherit;
 
+  &[type="number"] {
+    -moz-appearance: textfield;
+  }
+
+  &[type="number"]::-webkit-inner-spin-button,
+  &[type="number"]::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
   .mdl-textfield.is-focused & {
     outline: none;
   }


### PR DESCRIPTION
Fixes #889 

Hides number spinners so the textfield can function with `type="number"` and still align to Material Design.