### PR TITLE
fix textfield `focus` listener on safari

### DIFF
--- a/src/textfield/textfield.js
+++ b/src/textfield/textfield.js
@@ -85,7 +85,7 @@
    * @private
    */
   MaterialTextfield.prototype.onFocus_ = function(event) {
-    this.checkFocus();
+    this.element_.classList.add(this.CssClasses_.IS_FOCUSED);
   };
 
   /**


### PR DESCRIPTION
The textfields are not styled on Safari when clicked to focus most of the times. It seems the `focus` listeners are called before ':focus' could be selected in `checkFocus()`.