### PR TITLE
Fixed issue #2581

### DIFF
--- a/src/ripple/ripple.js
+++ b/src/ripple/ripple.js
@@ -101,9 +101,14 @@
       if (event.clientX === 0 && event.clientY === 0) {
         x = Math.round(bound.width / 2);
         y = Math.round(bound.height / 2);
+      } else if (event.touches) {
+        var clientX = event.touches[0].clientX;
+        var clientY = event.touches[0].clientY;
+        x = Math.round(clientX - bound.left);
+        y = Math.round(clientY - bound.top);
       } else {
-        var clientX = event.clientX ? event.clientX : event.touches[0].clientX;
-        var clientY = event.clientY ? event.clientY : event.touches[0].clientY;
+        var clientX = event.clientX ? event.clientX : 0;
+        var clientY = event.clientY ? event.clientY : 0;
         x = Math.round(clientX - bound.left);
         y = Math.round(clientY - bound.top);
       }


### PR DESCRIPTION
When the users clicks a button on the edge of the page like in the image below (client x = 0, the problem only happens on the white button on the image), the ripple effect stops working.

The error happens in line 105 of ripple.js, where it tries to set a variable "clientX" as "event.touches[0].clientX", but "event.touches" is undefined (it's a mouse click at x = 0!).

Tested on Google Chrome.

![problem](https://cloud.githubusercontent.com/assets/6368056/12105086/826624b6-b338-11e5-836f-e592d7fe4f42.png)

----

Garbee pulled content in from issue to straighten things up. No need for doing an issue just to turn around and do a PR as well.