### PR TITLE
Remove the microsite's usage, and more importantly, our prescription …

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -39,7 +39,7 @@ import pkg from './package.json';
 
 const $ = gulpLoadPlugins();
 const reload = browserSync.reload;
-const hostedLibsUrlPrefix = 'https://storage.googleapis.com/code.getmdl.io';
+const hostedLibsUrlPrefix = 'https://code.getmdl.io';
 const templateArchivePrefix = 'mdl-template-';
 const bucketProd = 'gs://www.getmdl.io';
 const bucketStaging = 'gs://mdl-staging';

--- a/templates/portfolio/Tutorial/step01-initial-HTML-setup.html
+++ b/templates/portfolio/Tutorial/step01-initial-HTML-setup.html
@@ -24,13 +24,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MDL-Static Website</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en">
-    <link rel="stylesheet" href="https://storage.googleapis.com/code.getmdl.io/1.0.6/material.grey-pink.min.css" />
+    <link rel="stylesheet" href="https://code.getmdl.io/1.0.6/material.grey-pink.min.css" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 </head>
 
 <body>
 
-    <script src="https://storage.googleapis.com/code.getmdl.io/1.0.6/material.min.js"></script>
+    <script src="https://code.getmdl.io/1.0.6/material.min.js"></script>
 </body>
 
 </html>

--- a/templates/portfolio/Tutorial/step02-MDL-layout-component.html
+++ b/templates/portfolio/Tutorial/step02-MDL-layout-component.html
@@ -24,7 +24,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MDL-Static Website</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en">
-    <link rel="stylesheet" href="https://storage.googleapis.com/code.getmdl.io/1.0.6/material.grey-pink.min.css" />
+    <link rel="stylesheet" href="https://code.getmdl.io/1.0.6/material.grey-pink.min.css" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 </head>
 
@@ -55,7 +55,7 @@
             <p>Hello world!</p>
         </main>
     </div>
-    <script src="https://storage.googleapis.com/code.getmdl.io/1.0.6/material.min.js"></script>
+    <script src="https://code.getmdl.io/1.0.6/material.min.js"></script>
 </body>
 
 </html>

--- a/templates/portfolio/Tutorial/step03-the-grid-component.html
+++ b/templates/portfolio/Tutorial/step03-the-grid-component.html
@@ -24,7 +24,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MDL-Static Website</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en">
-    <link rel="stylesheet" href="https://storage.googleapis.com/code.getmdl.io/1.0.6/material.grey-pink.min.css" />
+    <link rel="stylesheet" href="https://code.getmdl.io/1.0.6/material.grey-pink.min.css" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 </head>
 
@@ -73,7 +73,7 @@
             </footer>
         </main>
     </div>
-    <script src="https://storage.googleapis.com/code.getmdl.io/1.0.6/material.min.js"></script>
+    <script src="https://code.getmdl.io/1.0.6/material.min.js"></script>
 </body>
 
 </html>

--- a/templates/portfolio/Tutorial/step04-customising-the-layout.html
+++ b/templates/portfolio/Tutorial/step04-customising-the-layout.html
@@ -24,7 +24,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MDL-Static Website</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en">
-    <link rel="stylesheet" href="https://storage.googleapis.com/code.getmdl.io/1.0.6/material.grey-pink.min.css" />
+    <link rel="stylesheet" href="https://code.getmdl.io/1.0.6/material.grey-pink.min.css" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 </head>
@@ -195,7 +195,7 @@
             </footer>
         </main>
     </div>
-    <script src="https://storage.googleapis.com/code.getmdl.io/1.0.6/material.min.js"></script>
+    <script src="https://code.getmdl.io/1.0.6/material.min.js"></script>
 </body>
 
 </html>

--- a/templates/portfolio/Tutorial/step05-individual-pages/about.html
+++ b/templates/portfolio/Tutorial/step05-individual-pages/about.html
@@ -24,7 +24,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MDL-Static Website</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en">
-    <link rel="stylesheet" href="https://storage.googleapis.com/code.getmdl.io/1.0.6/material.grey-pink.min.css" />
+    <link rel="stylesheet" href="https://code.getmdl.io/1.0.6/material.grey-pink.min.css" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 </head>
@@ -100,7 +100,7 @@
             </footer>
         </main>
     </div>
-    <script src="https://storage.googleapis.com/code.getmdl.io/1.0.6/material.min.js"></script>
+    <script src="https://code.getmdl.io/1.0.6/material.min.js"></script>
 </body>
 
 </html>

--- a/templates/portfolio/Tutorial/step05-individual-pages/blog.html
+++ b/templates/portfolio/Tutorial/step05-individual-pages/blog.html
@@ -24,7 +24,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MDL-Static Website</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en">
-    <link rel="stylesheet" href="https://storage.googleapis.com/code.getmdl.io/1.0.6/material.grey-pink.min.css" />
+    <link rel="stylesheet" href="https://code.getmdl.io/1.0.6/material.grey-pink.min.css" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 </head>
@@ -168,7 +168,7 @@
             </footer>
         </main>
     </div>
-    <script src="https://storage.googleapis.com/code.getmdl.io/1.0.6/material.min.js"></script>
+    <script src="https://code.getmdl.io/1.0.6/material.min.js"></script>
 </body>
 
 </html>

--- a/templates/portfolio/Tutorial/step05-individual-pages/contact.html
+++ b/templates/portfolio/Tutorial/step05-individual-pages/contact.html
@@ -24,7 +24,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MDL-Static Website</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en">
-    <link rel="stylesheet" href="https://storage.googleapis.com/code.getmdl.io/1.0.6/material.grey-pink.min.css" />
+    <link rel="stylesheet" href="https://code.getmdl.io/1.0.6/material.grey-pink.min.css" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 </head>
@@ -105,7 +105,7 @@
             </footer>
         </main>
     </div>
-    <script src="https://storage.googleapis.com/code.getmdl.io/1.0.6/material.min.js"></script>
+    <script src="https://code.getmdl.io/1.0.6/material.min.js"></script>
 </body>
 
 </html>

--- a/templates/portfolio/Tutorial/step05-individual-pages/home.html
+++ b/templates/portfolio/Tutorial/step05-individual-pages/home.html
@@ -24,7 +24,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MDL-Static Website</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en">
-    <link rel="stylesheet" href="https://storage.googleapis.com/code.getmdl.io/1.0.6/material.grey-pink.min.css" />
+    <link rel="stylesheet" href="https://code.getmdl.io/1.0.6/material.grey-pink.min.css" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 </head>
@@ -195,7 +195,7 @@
             </footer>
         </main>
     </div>
-    <script src="https://storage.googleapis.com/code.getmdl.io/1.0.6/material.min.js"></script>
+    <script src="https://code.getmdl.io/1.0.6/material.min.js"></script>
 </body>
 
 </html>

--- a/templates/portfolio/Tutorial/step05-individual-pages/portfolio-example01.html
+++ b/templates/portfolio/Tutorial/step05-individual-pages/portfolio-example01.html
@@ -24,7 +24,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MDL-Static Website</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en">
-    <link rel="stylesheet" href="https://storage.googleapis.com/code.getmdl.io/1.0.6/material.grey-pink.min.css" />
+    <link rel="stylesheet" href="https://code.getmdl.io/1.0.6/material.grey-pink.min.css" />
     <link rel="stylesheet" href="../styles.css" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 </head>
@@ -113,7 +113,7 @@
             </footer>
         </main>
     </div>
-    <script src="https://storage.googleapis.com/code.getmdl.io/1.0.6/material.min.js"></script>
+    <script src="https://code.getmdl.io/1.0.6/material.min.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
…that users import our resource  via the storage.googleapis.com domain, and rather suggest they access our resources via the simpler https://code.getmdl.io/thing.

Nothing has changed about where the content lives, it's still stored in the same GCS buckets as before so the old links keep working as before indefinitely.