### PR TITLE
Reset button margin

### DIFF
--- a/src/button/_button.scss
+++ b/src/button/_button.scss
@@ -25,6 +25,7 @@
   color: $button-secondary-color;
   position: relative;
   height: $button-height;
+  margin: 0;
   min-width: $button-min-width;
   padding: 0 $button-padding;
   display: inline-block;


### PR DESCRIPTION
Ref #4008 

Buttons in safari have 2px margins by default. normalize.css [resets](https://github.com/necolas/normalize.css/blob/master/normalize.css#L264) that.