### PR TITLE
Decouple tabs from panels.  When a tab is clicked, if a matching pane…

### DIFF
--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -140,13 +140,15 @@
       }
 
       tab.addEventListener('click', function(e) {
-        e.preventDefault();
         var href = tab.href.split('#')[1];
         var panel = ctx.element_.querySelector('#' + href);
         ctx.resetTabState_();
         ctx.resetPanelState_();
         tab.classList.add(ctx.CssClasses_.ACTIVE_CLASS);
-        panel.classList.add(ctx.CssClasses_.ACTIVE_CLASS);
+        if (panel) {
+          panel.classList.add(ctx.CssClasses_.ACTIVE_CLASS);
+          e.preventDefault();
+        }
       });
 
     }


### PR DESCRIPTION
…l isn't found, set is-active on the tab, skip panel logic, and fire the event as normal.