### PR TITLE
Fix: Autofocused element loses focus when MaterialLayout is upgraded

### DIFF
--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -284,6 +284,11 @@
       this.element_.parentElement.removeChild(this.element_);
       container.appendChild(this.element_);
 
+      var focusedElement = this.element_.querySelector('[autofocus]');
+      if(focusedElement) {
+        focusedElement.focus();
+      }
+
       var directChildren = this.element_.childNodes;
       var numChildren = directChildren.length;
       for (var c = 0; c < numChildren; c++) {

--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -285,7 +285,7 @@
       container.appendChild(this.element_);
 
       var focusedElement = this.element_.querySelector('[autofocus]');
-      if(focusedElement) {
+      if (focusedElement) {
         focusedElement.focus();
       }
 

--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -280,11 +280,13 @@
     if (this.element_) {
       var container = document.createElement('div');
       container.classList.add(this.CssClasses_.CONTAINER);
+
+      var focusedElement = this.element_.querySelector(':focus');
+
       this.element_.parentElement.insertBefore(container, this.element_);
       this.element_.parentElement.removeChild(this.element_);
       container.appendChild(this.element_);
 
-      var focusedElement = this.element_.querySelector('[autofocus]');
       if (focusedElement) {
         focusedElement.focus();
       }

--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -342,7 +342,7 @@ componentHandler = (function() {
    * @param {?componentHandler.Component} component
    */
   function deconstructComponentInternal(component) {
-    var componentIndex = createdComponents_.indexOf(component);
+    var componentIndex = createdComponents_.indexOf(/** @type {componentHandler.Component} */ (component));
     createdComponents_.splice(componentIndex, 1);
 
     var upgrades = component.element_.getAttribute('data-upgraded').split(',');


### PR DESCRIPTION
I noticed a small glitch with an autofocused element, in firefox.

Basically, my html looks like this:

```html
<html>
  <head>
    <link rel="stylesheet" href="https://code.getmdl.io/1.1.1/material.indigo-pink.min.css">
    <script defer src="https://code.getmdl.io/1.1.1/material.min.js"></script>
  </head>
  <body>
    <div class="mdl-layout mdl-js-layout">
      <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
        <input class="mdl-textfield__input" type="text" autofocus="true" />
        <label class="mdl-textfield__label" for="username">Username</label>
    </div>
  </body>
</html>
```

In Chrome, everything is fine, the input has the focus. 

In Firefox, the textfield container has the class **is-focused** as expected, but the input doesn't have the focus.