### PR TITLE
Address spec alignment with snackbar action.

### DIFF
--- a/src/snackbar/_snackbar.scss
+++ b/src/snackbar/_snackbar.scss
@@ -25,7 +25,9 @@
   cursor: default;
   background-color: $snackbar-background-color;
   z-index: 10000;
+  display: block;
   display: flex;
+  justify-content: space-between;
   font-family: $preferred_font;
   will-change: transform;
   transform: translate(0, 80px);
@@ -49,9 +51,9 @@
   }
 
   &__text {
-    padding: 14px 24px;
-    vertical-align: middle;
+    padding: 14px 12px 14px 24px;
     color: white;
+    float: left;
   }
 
   &__action {
@@ -59,7 +61,7 @@
     border: none;
     color: $snackbar-action-color;
     text-transform: uppercase;
-    padding: 14px 24px;
+    padding: 14px 24px 14px 12px;
     @include typo-button();
     overflow: hidden;
     outline: none;
@@ -69,6 +71,8 @@
     text-decoration: none;
     text-align: center;
     vertical-align: middle;
+    float: right;
+    align-self: center;
 
     &::-moz-focus-inner {
       border: 0;


### PR DESCRIPTION
Fixes #4076 

Adds the float fallback that got lost for older browsers. Uses flex  to space things out  on newer browsers. Fix padding so only a total of 24px is between the action and text instead of 48px.