### PR TITLE
Fix card text width. Potentially breaking change for styling.

### DIFF
--- a/src/card/_card.scss
+++ b/src/card/_card.scss
@@ -83,7 +83,7 @@
   line-height: $card-supporting-text-line-height;
   overflow: hidden;
   padding: $card-vertical-padding $card-horizontal-padding;
-  width: 90%;
+  box-sizing: border-box;
 }
 
 .mdl-card__actions {


### PR DESCRIPTION
We may end up reimplementing cards, but merging this small fix
now gives us a nice baseline anyway.

Fixes #1396.

@Garbee PTAL!