### PR TITLE
Address snackbar MD alignment.

### DIFF
--- a/src/snackbar/_snackbar.scss
+++ b/src/snackbar/_snackbar.scss
@@ -21,11 +21,12 @@
   position: fixed;
   bottom: 0;
   left: 50%;
-  margin-right: -50%;
   cursor: default;
   background-color: $snackbar-background-color;
-  z-index: 10000;
+  z-index: 3;
+  display: block;
   display: flex;
+  justify-content: space-between;
   font-family: $preferred_font;
   will-change: transform;
   transform: translate(-50%, 80px);
@@ -49,17 +50,19 @@
   }
 
   &__text {
-    padding: 14px 24px;
+    padding: 14px 12px 14px 24px;
     vertical-align: middle;
     color: white;
+    float: left;
   }
 
   &__action {
     background: transparent;
     border: none;
     color: $snackbar-action-color;
+    float: right;
     text-transform: uppercase;
-    padding: 14px 24px;
+    padding: 14px 24px 14px 12px;
     @include typo-button();
     overflow: hidden;
     outline: none;
@@ -68,7 +71,7 @@
     cursor: pointer;
     text-decoration: none;
     text-align: center;
-    vertical-align: middle;
+    align-self: center;
 
     &::-moz-focus-inner {
       border: 0;
@@ -79,4 +82,3 @@
     }
   }
 }
-


### PR DESCRIPTION
Fixes #4076 

Adds the float fallback that got lost for older browsers. Uses flex  to space things out  on newer browsers. Fix padding so only a total of 24px is between the action and text instead of 48px.

Removes uneeded right margin due to new translate usage.