### PR TITLE
Refocus the :focused element after the layout rendering

### DIFF
--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -281,9 +281,16 @@
     if (this.element_) {
       var container = document.createElement('div');
       container.classList.add(this.CssClasses_.CONTAINER);
+
+      var focusedElement = this.element_.querySelector(':focus');
+
       this.element_.parentElement.insertBefore(container, this.element_);
       this.element_.parentElement.removeChild(this.element_);
       container.appendChild(this.element_);
+
+      if (focusedElement) {
+        focusedElement.focus();
+      }
 
       var directChildren = this.element_.childNodes;
       var numChildren = directChildren.length;


### PR DESCRIPTION
Fix for problem described here #4097 : **Focused element loses focus when MaterialLayout is upgraded**