### PR TITLE
Update Cutting-the-mustard test

### DIFF
--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -459,9 +459,11 @@ window.addEventListener('load', function() {
    * tested, adds a mdl-js class to the <html> element. It then upgrades all MDL
    * components requiring JavaScript.
    */
-  if ('classList' in document.createElement('div') &&
+  if (
+      'classList' in document.documentElement &&
       'querySelector' in document &&
-      'addEventListener' in window && Array.prototype.forEach) {
+      'addEventListener' in window &&
+      'forEach' in Array.prototype) {
     document.documentElement.classList.add('mdl-js');
     componentHandler.upgradeAllRegistered();
   } else {


### PR DESCRIPTION
Updates the test conditions so that all of them are checking for Object property using "'propertyName' in Object" pattern. This makes it easier to interpret the individual conditions and what they are checking for, and removes the need for creating an element on the document object simply for testing purposes. Also makes it very clear what the current "cutting-the-mustard" requirements are, eg which properties on which objects need to be present, thus making it easier to unit test and more clear to clients that fail test what is needed to meet minimum requirements.