### PR TITLE
Check if the drawer is open before responding to escape keystrokes.

### DIFF
--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -166,7 +166,9 @@
    * @private
    */
   MaterialLayout.prototype.keyboardEventHandler_ = function(evt) {
-    if (evt.keyCode === this.Keycodes_.ESCAPE) {
+    // Only react when the drawer is open.
+    if (evt.keyCode === this.Keycodes_.ESCAPE &&
+        this.drawer_.classList.contains(this.CssClasses_.IS_DRAWER_OPEN)) {
       this.toggleDrawer();
     }
   };


### PR DESCRIPTION
Currently the escape key can not only close but also re-open the drawer, which makes no sense to me.