### PR TITLE
Quick fix to stop new versions of CSSO from breaking the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "gulp-concat": "^2.4.1",
     "gulp-connect": "^2.2.0",
     "gulp-css-inline-images": "^0.1.1",
-    "gulp-csso": "^1.0.0",
+    "gulp-csso": "1.0.0",
     "gulp-file": "^0.2.0",
     "gulp-flatten": "^0.2.0",
     "gulp-front-matter": "^1.2.2",


### PR DESCRIPTION
This fix is only for 1.x, so that we don't break backwards compatibility by changing from `$variables` to `#variables`, in case anyone is relying on our templates. This fix ensures we're locked to a version of CSSO that supports `$variables`.

@surma or @Garbee PTAL