### PR TITLE
Use the Event constructor in browsers that support it. Fixes #4188.

### DIFF
--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -227,8 +227,15 @@ componentHandler = (function() {
           'Unable to find a registered component for the given class.');
       }
 
-      var ev = document.createEvent('Events');
-      ev.initEvent('mdl-componentupgraded', true, true);
+      var ev;
+      if ('CustomEvent' in window && typeof window.CustomEvent === 'function') {
+        ev = new Event('mdl-componentupgraded', {
+          "bubbles": true, "cancelable": false
+        });
+      } else {
+        ev = document.createEvent('Events');
+        ev.initEvent('mdl-componentupgraded', true, true);
+      }
       element.dispatchEvent(ev);
     }
   }


### PR DESCRIPTION
For old IE, it falls back to createEvent + initEvent, the latter of
which is deprecated and may be missing from some browsers.

@surma @Garbee PTAL!