### PR TITLE
fix to handle if Tab has no href attribute

### DIFF
--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -559,7 +559,8 @@
     }
 
     tab.addEventListener('click', function(e) {
-      if (tab.getAttribute('href').charAt(0) === '#') {
+      var href = tab.getAttribute('href');
+      if (href && href.charAt(0) === '#') {
         e.preventDefault();
         selectTab();
       }


### PR DESCRIPTION
when tag of Tab has no href attribute, error thrown

`Uncaught TypeError: Cannot read property 'charAt' of null`