### PR TITLE
Multiple tab strips

### DIFF
--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -566,7 +566,6 @@
     });
 
     tab.show = selectTab;
-
   }
   window['MaterialLayoutTab'] = MaterialLayoutTab;
 

--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -230,7 +230,7 @@ componentHandler = (function() {
       var ev;
       if ('CustomEvent' in window && typeof window.CustomEvent === 'function') {
         ev = new Event('mdl-componentupgraded', {
-          'bubbles': true, 'cancelable': false
+          bubbles: true, cancelable: false
         });
       } else {
         ev = document.createEvent('Events');
@@ -364,7 +364,7 @@ componentHandler = (function() {
       var ev;
       if ('CustomEvent' in window && typeof window.CustomEvent === 'function') {
         ev = new Event('mdl-componentdowngraded', {
-          'bubbles': true, 'cancelable': false
+          bubbles: true, cancelable: false
         });
       } else {
         ev = document.createEvent('Events');

--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -76,18 +76,23 @@
       this.element_.classList.add(
         this.CssClasses_.MDL_JS_RIPPLE_EFFECT_IGNORE_EVENTS);
     }
-
-    var thatElement = this.element_;
     // Select element tabs, document panels
-    this.tabs_ = Array.from(this.element_.querySelectorAll('.' + this.CssClasses_.TAB_BAR_CLASS + ' > .' + this.CssClasses_.TAB_CLASS))
-                        .filter(function(element) {
-                          return element.parentElement.parentElement === thatElement;
-                        });
-    this.panels_ =
-        Array.from(this.element_.querySelectorAll('.' + this.CssClasses_.PANEL_CLASS))
-                            .filter(function(element) {
-                              return element.parentElement === thatElement;
-                            });
+    // the mocha tests did not like Array.from or Array.filter
+    this.tabs_ = [];
+    var tabs = this.element_.querySelectorAll('.' + this.CssClasses_.TAB_BAR_CLASS + ' > .' + this.CssClasses_.TAB_CLASS);
+    for (var t = 0; t < tabs.length; t++) {
+      if (tabs[t].parentElement.parentElement === this.element_) {
+        this.tabs_.push(tabs[t]);
+      }
+    }
+
+    this.panels_ = [];
+    var panels = this.element_.querySelectorAll('.' + this.CssClasses_.PANEL_CLASS);
+    for (var p = 0; p < panels.length; p++) {
+      if (panels[p].parentElement === this.element_) {
+        this.panels_.push(panels[p]);
+      }
+    }
 
     // Create new tabs for each tab element
     for (var i = 0; i < this.tabs_.length; i++) {

--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -55,6 +55,7 @@
    */
   MaterialTabs.prototype.CssClasses_ = {
     TAB_CLASS: 'mdl-tabs__tab',
+    TAB_BAR_CLASS: 'mdl-tabs__tab-bar',
     PANEL_CLASS: 'mdl-tabs__panel',
     ACTIVE_CLASS: 'is-active',
     UPGRADED_CLASS: 'is-upgraded',
@@ -71,17 +72,22 @@
    * @private
    */
   MaterialTabs.prototype.initTabs_ = function() {
-    if (this.element_.classList.contains(
-        this.CssClasses_.MDL_JS_RIPPLE_EFFECT)) {
+    if (this.element_.classList.contains(this.CssClasses_.MDL_JS_RIPPLE_EFFECT)) {
       this.element_.classList.add(
         this.CssClasses_.MDL_JS_RIPPLE_EFFECT_IGNORE_EVENTS);
     }
 
+    var thatElement = this.element_;
     // Select element tabs, document panels
-    this.tabs_ =
-        this.element_.querySelectorAll('.' + this.CssClasses_.TAB_CLASS);
+    this.tabs_ = Array.from(this.element_.querySelectorAll('.' + this.CssClasses_.TAB_BAR_CLASS + ' > .' + this.CssClasses_.TAB_CLASS))
+                        .filter(function(element) {
+                          return element.parentElement.parentElement === thatElement;
+                        });
     this.panels_ =
-        this.element_.querySelectorAll('.' + this.CssClasses_.PANEL_CLASS);
+        Array.from(this.element_.querySelectorAll('.' + this.CssClasses_.PANEL_CLASS))
+                            .filter(function(element) {
+                              return element.parentElement === thatElement;
+                            });
 
     // Create new tabs for each tab element
     for (var i = 0; i < this.tabs_.length; i++) {
@@ -131,8 +137,7 @@
    */
   function MaterialTab(tab, ctx) {
     if (tab) {
-      if (ctx.element_.classList.contains(
-          ctx.CssClasses_.MDL_JS_RIPPLE_EFFECT)) {
+      if (ctx.element_.classList.contains(ctx.CssClasses_.MDL_JS_RIPPLE_EFFECT)) {
         var rippleContainer = document.createElement('span');
         rippleContainer.classList.add(ctx.CssClasses_.MDL_RIPPLE_CONTAINER);
         rippleContainer.classList.add(ctx.CssClasses_.MDL_JS_RIPPLE_EFFECT);

--- a/test/unit/tabs.js
+++ b/test/unit/tabs.js
@@ -49,7 +49,18 @@ describe('MaterialTabs', function () {
       '   <a href="#content2" id="tab2" class="mdl-tabs__tab">2</a>' +
       '   <a href="#content3" id="tab3" class="mdl-tabs__tab">3</a>' +
       ' </div>' +
-      ' <div class="mdl-tabs__panel" id="content1"></div>' +
+      ' <div class="mdl-tabs__panel" id="content1">' +
+      '<div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect">' +
+      '  <div class="mdl-tabs__tab-bar">' +
+      '   <a href="#content4" id="tab4" class="mdl-tabs__tab">4</a>' +
+      '   <a href="#content5" id="tab5" class="mdl-tabs__tab">5</a>' +
+      '   <a href="#content6" id="tab6" class="mdl-tabs__tab">6</a>' +
+      ' </div>' +
+      ' <div class="mdl-tabs__panel" id="content4"></div>' +
+      ' <div class="mdl-tabs__panel" id="content5"></div>' +
+      ' <div class="mdl-tabs__panel" id="content6"></div>' +
+      '</div>' +
+      ' </div>' +
       ' <div class="mdl-tabs__panel" id="content2"></div>' +
       ' <div class="mdl-tabs__panel" id="content3"></div>' +
       '</div>';
@@ -57,8 +68,10 @@ describe('MaterialTabs', function () {
 
       tab1 = el.querySelector('#tab1');
       tab2 = el.querySelector('#tab2');
+      tab4 = el.querySelector('#tab4');
       content1 = el.querySelector('#content1');
       content2 = el.querySelector('#content2');
+      content4 = el.querySelector('#content4');
     });
 
     it('Should activate no tab by default', function (done) {
@@ -80,6 +93,20 @@ describe('MaterialTabs', function () {
       }, 100);
     });
 
+    it('Should activate the first tab on the second tab strip on click', function (done) {
+      var el = document.createEvent('MouseEvents');
+      el.initEvent('click', true, true);
+      tab4.dispatchEvent(el);
+
+      window.setTimeout(function () {
+        expect($(tab1)).to.have.class('is-active');
+        expect($(content1)).to.have.class('is-active');
+        expect($(tab4)).to.have.class('is-active');
+        expect($(content4)).to.have.class('is-active');
+        done();
+      }, 100);
+    });
+
     it('Should activate the second tab on click', function (done) {
       var el = document.createEvent('MouseEvents');
       el.initEvent('click', true, true);
@@ -90,6 +117,8 @@ describe('MaterialTabs', function () {
         expect($(content1)).to.not.have.class('is-active');
         expect($(tab2)).to.have.class('is-active');
         expect($(content2)).to.have.class('is-active');
+        expect($(tab4)).to.have.class('is-active');
+        expect($(content4)).to.have.class('is-active');
         done();
       }, 100);
     });

--- a/test/unit/tabs.js
+++ b/test/unit/tabs.js
@@ -37,8 +37,10 @@ describe('MaterialTabs', function () {
     var el;
     var tab1;
     var tab2;
+    var tab4;
     var content1;
     var content2;
+    var content4;
 
     before(function() {
       el = document.createElement('div');
@@ -64,7 +66,7 @@ describe('MaterialTabs', function () {
       ' <div class="mdl-tabs__panel" id="content2"></div>' +
       ' <div class="mdl-tabs__panel" id="content3"></div>' +
       '</div>';
-      componentHandler.upgradeElement(el, 'MaterialTabs');
+      componentHandler.upgradeElements(el);
 
       tab1 = el.querySelector('#tab1');
       tab2 = el.querySelector('#tab2');


### PR DESCRIPTION
The material design spec specifically states no nested tabs.

Currently mdl lite expects no more than 1 set of tabs so it does not discriminate nested tab elements. 

The use case we are having is a set of tabs at the top of a page, like shown [here](http://material-design.storage.googleapis.com/publish/material_v_4/material_ext_publish/0B6Okdz75tqQsRUM1elg3VDRxdTg/components_tabs_usage_desktop5.png) but then having a card which also may have tabs like shown [here](http://material-design.storage.googleapis.com/publish/material_v_4/material_ext_publish/0Bzhp5Z4wHba3cXJ0OTI1MXJUV0U/components_cards_action5.png)

This change does require `mdl-tabs__tab-bar` and the `mdl-tabs__panel` to be children of the `mdl-tabs` element.

