### PR TITLE
Added link names which make more sense.

### DIFF
--- a/templates/text-only/index.html
+++ b/templates/text-only/index.html
@@ -133,7 +133,7 @@
                 </div>
               </div>
               <div class="mdl-card__actions">
-                <a href="#" class="mdl-button">Read our features</a>
+                <a href="#" class="mdl-button">Read more details</a>
               </div>
             </div>
             <button class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--icon" id="btn2">
@@ -152,7 +152,7 @@
                 Dolore ex deserunt aute fugiat aute nulla ea sunt aliqua nisi cupidatat eu. Nostrud in laboris labore nisi amet do dolor eu fugiat consectetur elit cillum esse. Pariatur occaecat nisi laboris tempor laboris eiusmod qui id Lorem esse commodo in. Exercitation aute dolore deserunt culpa consequat elit labore incididunt elit anim.
               </div>
               <div class="mdl-card__actions">
-                <a href="#" class="mdl-button">Read our features</a>
+                <a href="#" class="mdl-button">Read more about our technology</a>
               </div>
             </div>
             <button class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--icon" id="btn3">


### PR DESCRIPTION
Previously all the links at the bottom of the cards on "Overview" read "Read our features".

I've updated them to reflect the titles of the cards. "Read more details" and "Read about our technology"