### PR TITLE
eslint error fixes

### DIFF
--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -566,7 +566,6 @@
     });
 
     tab.show = selectTab;
-
   }
   window['MaterialLayoutTab'] = MaterialLayoutTab;
 

--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -230,7 +230,7 @@ componentHandler = (function() {
       var ev;
       if ('CustomEvent' in window && typeof window.CustomEvent === 'function') {
         ev = new Event('mdl-componentupgraded', {
-          'bubbles': true, 'cancelable': false
+          bubbles: true, cancelable: false
         });
       } else {
         ev = document.createEvent('Events');
@@ -364,7 +364,7 @@ componentHandler = (function() {
       var ev;
       if ('CustomEvent' in window && typeof window.CustomEvent === 'function') {
         ev = new Event('mdl-componentdowngraded', {
-          'bubbles': true, 'cancelable': false
+          bubbles: true, cancelable: false
         });
       } else {
         ev = document.createEvent('Events');


### PR DESCRIPTION
Errors stopped gulp from compiling MDL

**MDL version:** v1.1.2
**Operating system:** OSX
**Operating system version:** v10.11.4
**Node version:** v5.10.1

What steps will reproduce the problem:
While running `gulp all && gulp serve`, gulp errored out due to eslint errors:

```
/material-design-lite/src/mdlComponentHandler.js
  366:51  error  Properties shouldn't be quoted as all quotes are redundant  quote-props

/material-design-lite/src/checkbox/checkbox.js
  123:5  warning  Unexpected 'todo' comment  no-warning-comments

/material-design-lite/src/icon-toggle/icon-toggle.js
  119:5  warning  Unexpected 'todo' comment  no-warning-comments

/material-design-lite/src/radio/radio.js
  133:5  warning  Unexpected 'todo' comment  no-warning-comments

/material-design-lite/src/switch/switch.js
  122:5  warning  Unexpected 'todo' comment  no-warning-comments

/material-design-lite/src/tabs/tabs.js
  88:7  warning  Do not use 'new' for side effects  no-new

/material-design-lite/src/textfield/textfield.js
  273:11  warning  Unexpected 'todo' comment  no-warning-comments

/material-design-lite/src/layout/layout.js
  520:11  warning  Do not use 'new' for side effects  no-new

✖ 8 problems (1 error, 7 warnings)

[12:08:59] 'lint:sources' errored after 811 ms
[12:08:59] ESLintError in plugin 'gulp-eslint'
Message:
    Failed with 1 error
[12:08:59] 'all' errored after 4.11 s
[12:08:59] Error in plugin 'run-sequence'
Message:
    An error occured in task 'lint:sources'.
```

Mocha tests seemed to pass
```
# tests 89
# pass 89
# fail 0
[12:09:31] Finished 'mocha' after 4.86 s
```

But then there was an error in the stream:
```
stream.js:74
      throw er; // Unhandled stream error in pipe.
      ^
Error: src/mdlComponentHandler.js:252: WARNING - invalid cast - must be a subtype or supertype
from: (Element|HTMLCollection|NodeList)
to  : (Array|null)
        elements = Array.prototype.slice.call(/** @type {Array} */ (elements));
                                                                   ^

0 error(s), 1 warning(s), 93.1% typed
```