### PR TITLE
Use string properties for box style values

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -77,15 +77,15 @@
         this.element_.classList.contains(this.CssClasses_.RIGHT)) {
       left = (props.width / 2);
       if (top + marginTop < 0) {
-        this.element_.style.top = 0;
-        this.element_.style.marginTop = 0;
+        this.element_.style.top = '0';
+        this.element_.style.marginTop = '0';
       } else {
         this.element_.style.top = top + 'px';
         this.element_.style.marginTop = marginTop + 'px';
       }
     } else if (left + marginLeft < 0) {
-      this.element_.style.left = 0;
-      this.element_.style.marginLeft = 0;
+      this.element_.style.left = '0';
+      this.element_.style.marginLeft = '0';
     } else {
       this.element_.style.left = left + 'px';
       this.element_.style.marginLeft = marginLeft + 'px';


### PR DESCRIPTION
According to https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSS2Properties, these properties should be strings, not numbers.