### PR TITLE
Shadow root compatibility feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "run-sequence": "^1.0.2",
     "swig": "^1.4.2",
     "through2": "^2.0.0",
-    "vinyl-paths": "^2.0.0"
+    "vinyl-paths": "^2.0.0",
+    "webcomponents.js": "^0.7.22"
   },
   "engines": {
     "node": ">=4.0.0"

--- a/src/button/button.js
+++ b/src/button/button.js
@@ -101,9 +101,9 @@
   MaterialButton.prototype.init = function() {
     if (this.element_) {
       if (this.element_.classList.contains(this.CssClasses_.RIPPLE_EFFECT)) {
-        var rippleContainer = this.document_.createElement('span');
+        var rippleContainer = document.createElement('span');
         rippleContainer.classList.add(this.CssClasses_.RIPPLE_CONTAINER);
-        this.rippleElement_ = this.document_.createElement('span');
+        this.rippleElement_ = document.createElement('span');
         this.rippleElement_.classList.add(this.CssClasses_.RIPPLE);
         rippleContainer.appendChild(this.rippleElement_);
         this.boundRippleBlurHandler = this.blurHandler_.bind(this);

--- a/src/button/button.js
+++ b/src/button/button.js
@@ -24,8 +24,12 @@
    * https://github.com/jasonmayes/mdl-component-design-pattern
    *
    * @param {HTMLElement} element The element that will be upgraded.
+   * @param {HTMLDocument|ShadowRoot=} optDom Optional DOM that will
+   * be upgraded.
    */
-  var MaterialButton = function MaterialButton(element) {
+  var MaterialButton = function MaterialButton(element, optDom) {
+    var optDom_ = optDom || document;
+    this.document_ = optDom_;
     this.element_ = element;
 
     // Initialize instance.
@@ -97,9 +101,9 @@
   MaterialButton.prototype.init = function() {
     if (this.element_) {
       if (this.element_.classList.contains(this.CssClasses_.RIPPLE_EFFECT)) {
-        var rippleContainer = document.createElement('span');
+        var rippleContainer = this.document_.createElement('span');
         rippleContainer.classList.add(this.CssClasses_.RIPPLE_CONTAINER);
-        this.rippleElement_ = document.createElement('span');
+        this.rippleElement_ = this.document_.createElement('span');
         this.rippleElement_.classList.add(this.CssClasses_.RIPPLE);
         rippleContainer.appendChild(this.rippleElement_);
         this.boundRippleBlurHandler = this.blurHandler_.bind(this);

--- a/src/checkbox/checkbox.js
+++ b/src/checkbox/checkbox.js
@@ -25,8 +25,12 @@
    *
    * @constructor
    * @param {HTMLElement} element The element that will be upgraded.
+   * @param {HTMLDocument|ShadowRoot=} optDom Optional DOM that will
+   * be upgraded.
    */
-  var MaterialCheckbox = function MaterialCheckbox(element) {
+  var MaterialCheckbox = function MaterialCheckbox(element, optDom) {
+    var optDom_ = optDom || document;
+    this.document_ = optDom_;
     this.element_ = element;
 
     // Initialize instance.
@@ -211,13 +215,13 @@
       this.inputElement_ = this.element_.querySelector('.' +
           this.CssClasses_.INPUT);
 
-      var boxOutline = document.createElement('span');
+      var boxOutline = this.document_.createElement('span');
       boxOutline.classList.add(this.CssClasses_.BOX_OUTLINE);
 
-      var tickContainer = document.createElement('span');
+      var tickContainer = this.document_.createElement('span');
       tickContainer.classList.add(this.CssClasses_.FOCUS_HELPER);
 
-      var tickOutline = document.createElement('span');
+      var tickOutline = this.document_.createElement('span');
       tickOutline.classList.add(this.CssClasses_.TICK_OUTLINE);
 
       boxOutline.appendChild(tickOutline);
@@ -227,7 +231,7 @@
 
       if (this.element_.classList.contains(this.CssClasses_.RIPPLE_EFFECT)) {
         this.element_.classList.add(this.CssClasses_.RIPPLE_IGNORE_EVENTS);
-        this.rippleContainerElement_ = document.createElement('span');
+        this.rippleContainerElement_ = this.document_.createElement('span');
         this.rippleContainerElement_.classList.add(
             this.CssClasses_.RIPPLE_CONTAINER);
         this.rippleContainerElement_.classList.add(
@@ -238,7 +242,7 @@
         this.rippleContainerElement_.addEventListener(
             'mouseup', this.boundRippleMouseUp);
 
-        var ripple = document.createElement('span');
+        var ripple = this.document_.createElement('span');
         ripple.classList.add(this.CssClasses_.RIPPLE);
 
         this.rippleContainerElement_.appendChild(ripple);

--- a/src/checkbox/checkbox.js
+++ b/src/checkbox/checkbox.js
@@ -215,13 +215,13 @@
       this.inputElement_ = this.element_.querySelector('.' +
           this.CssClasses_.INPUT);
 
-      var boxOutline = this.document_.createElement('span');
+      var boxOutline = document.createElement('span');
       boxOutline.classList.add(this.CssClasses_.BOX_OUTLINE);
 
-      var tickContainer = this.document_.createElement('span');
+      var tickContainer = document.createElement('span');
       tickContainer.classList.add(this.CssClasses_.FOCUS_HELPER);
 
-      var tickOutline = this.document_.createElement('span');
+      var tickOutline = document.createElement('span');
       tickOutline.classList.add(this.CssClasses_.TICK_OUTLINE);
 
       boxOutline.appendChild(tickOutline);
@@ -231,7 +231,7 @@
 
       if (this.element_.classList.contains(this.CssClasses_.RIPPLE_EFFECT)) {
         this.element_.classList.add(this.CssClasses_.RIPPLE_IGNORE_EVENTS);
-        this.rippleContainerElement_ = this.document_.createElement('span');
+        this.rippleContainerElement_ = document.createElement('span');
         this.rippleContainerElement_.classList.add(
             this.CssClasses_.RIPPLE_CONTAINER);
         this.rippleContainerElement_.classList.add(
@@ -242,7 +242,7 @@
         this.rippleContainerElement_.addEventListener(
             'mouseup', this.boundRippleMouseUp);
 
-        var ripple = this.document_.createElement('span');
+        var ripple = document.createElement('span');
         ripple.classList.add(this.CssClasses_.RIPPLE);
 
         this.rippleContainerElement_.appendChild(ripple);

--- a/src/data-table/data-table.js
+++ b/src/data-table/data-table.js
@@ -119,7 +119,7 @@
    * @private
    */
   MaterialDataTable.prototype.createCheckbox_ = function(row, optRows) {
-    var label = this.document_.createElement('label');
+    var label = document.createElement('label');
     var labelClasses = [
       'mdl-checkbox',
       'mdl-js-checkbox',
@@ -127,7 +127,7 @@
       this.CssClasses_.SELECT_ELEMENT
     ];
     label.className = labelClasses.join(' ');
-    var checkbox = this.document_.createElement('input');
+    var checkbox = document.createElement('input');
     checkbox.type = 'checkbox';
     checkbox.classList.add('mdl-checkbox__input');
 
@@ -157,7 +157,7 @@
       var rows = bodyRows.concat(footRows);
 
       if (this.element_.classList.contains(this.CssClasses_.SELECTABLE)) {
-        var th = this.document_.createElement('th');
+        var th = document.createElement('th');
         var headerCheckbox = this.createCheckbox_(null, rows);
         th.appendChild(headerCheckbox);
         firstHeader.parentElement.insertBefore(th, firstHeader);
@@ -165,7 +165,7 @@
         for (var i = 0; i < rows.length; i++) {
           var firstCell = rows[i].querySelector('td');
           if (firstCell) {
-            var td = this.document_.createElement('td');
+            var td = document.createElement('td');
             if (rows[i].parentNode.nodeName.toUpperCase() === 'TBODY') {
               var rowCheckbox = this.createCheckbox_(rows[i]);
               td.appendChild(rowCheckbox);

--- a/src/data-table/data-table.js
+++ b/src/data-table/data-table.js
@@ -25,8 +25,12 @@
    *
    * @constructor
    * @param {Element} element The element that will be upgraded.
+   * @param {HTMLDocument|ShadowRoot=} optDom Optional DOM that will
+   * be upgraded.
    */
-  var MaterialDataTable = function MaterialDataTable(element) {
+  var MaterialDataTable = function MaterialDataTable(element, optDom) {
+    var optDom_ = optDom || document;
+    this.document_ = optDom_;
     this.element_ = element;
 
     // Initialize instance.
@@ -115,7 +119,7 @@
    * @private
    */
   MaterialDataTable.prototype.createCheckbox_ = function(row, optRows) {
-    var label = document.createElement('label');
+    var label = this.document_.createElement('label');
     var labelClasses = [
       'mdl-checkbox',
       'mdl-js-checkbox',
@@ -123,7 +127,7 @@
       this.CssClasses_.SELECT_ELEMENT
     ];
     label.className = labelClasses.join(' ');
-    var checkbox = document.createElement('input');
+    var checkbox = this.document_.createElement('input');
     checkbox.type = 'checkbox';
     checkbox.classList.add('mdl-checkbox__input');
 
@@ -153,7 +157,7 @@
       var rows = bodyRows.concat(footRows);
 
       if (this.element_.classList.contains(this.CssClasses_.SELECTABLE)) {
-        var th = document.createElement('th');
+        var th = this.document_.createElement('th');
         var headerCheckbox = this.createCheckbox_(null, rows);
         th.appendChild(headerCheckbox);
         firstHeader.parentElement.insertBefore(th, firstHeader);
@@ -161,7 +165,7 @@
         for (var i = 0; i < rows.length; i++) {
           var firstCell = rows[i].querySelector('td');
           if (firstCell) {
-            var td = document.createElement('td');
+            var td = this.document_.createElement('td');
             if (rows[i].parentNode.nodeName.toUpperCase() === 'TBODY') {
               var rowCheckbox = this.createCheckbox_(rows[i]);
               td.appendChild(rowCheckbox);

--- a/src/icon-toggle/icon-toggle.js
+++ b/src/icon-toggle/icon-toggle.js
@@ -215,7 +215,7 @@
 
       if (this.element_.classList.contains(this.CssClasses_.JS_RIPPLE_EFFECT)) {
         this.element_.classList.add(this.CssClasses_.RIPPLE_IGNORE_EVENTS);
-        this.rippleContainerElement_ = this.document_.createElement('span');
+        this.rippleContainerElement_ = document.createElement('span');
         this.rippleContainerElement_.classList.add(
             this.CssClasses_.RIPPLE_CONTAINER);
         this.rippleContainerElement_.classList.add(
@@ -226,7 +226,7 @@
         this.rippleContainerElement_.addEventListener(
             'mouseup', this.boundRippleMouseUp);
 
-        var ripple = this.document_.createElement('span');
+        var ripple = document.createElement('span');
         ripple.classList.add(this.CssClasses_.RIPPLE);
 
         this.rippleContainerElement_.appendChild(ripple);

--- a/src/icon-toggle/icon-toggle.js
+++ b/src/icon-toggle/icon-toggle.js
@@ -25,8 +25,12 @@
    *
    * @constructor
    * @param {HTMLElement} element The element that will be upgraded.
+   * @param {HTMLDocument|ShadowRoot=} optDom Optional DOM that will
+   * be upgraded.
    */
-  var MaterialIconToggle = function MaterialIconToggle(element) {
+  var MaterialIconToggle = function MaterialIconToggle(element, optDom) {
+    var optDom_ = optDom || document;
+    this.document_ = optDom_;
     this.element_ = element;
 
     // Initialize instance.
@@ -211,7 +215,7 @@
 
       if (this.element_.classList.contains(this.CssClasses_.JS_RIPPLE_EFFECT)) {
         this.element_.classList.add(this.CssClasses_.RIPPLE_IGNORE_EVENTS);
-        this.rippleContainerElement_ = document.createElement('span');
+        this.rippleContainerElement_ = this.document_.createElement('span');
         this.rippleContainerElement_.classList.add(
             this.CssClasses_.RIPPLE_CONTAINER);
         this.rippleContainerElement_.classList.add(
@@ -222,7 +226,7 @@
         this.rippleContainerElement_.addEventListener(
             'mouseup', this.boundRippleMouseUp);
 
-        var ripple = document.createElement('span');
+        var ripple = this.document_.createElement('span');
         ripple.classList.add(this.CssClasses_.RIPPLE);
 
         this.rippleContainerElement_.appendChild(ripple);

--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -566,7 +566,6 @@
     });
 
     tab.show = selectTab;
-
   }
   window['MaterialLayoutTab'] = MaterialLayoutTab;
 

--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -246,7 +246,7 @@ componentHandler = (function() {
   /**
    * Upgrades a specific list of elements rather than all in the DOM.
    *
-   * @param {!Element|!Array<!Element>|!NodeList|!HTMLCollection} elements
+   * @param {!Element|!Array<!Element>|!NodeList|!HTMLCollection|ShadowRoot} elements
    * The elements we wish to upgrade.
    */
   function upgradeElementsInternal(elements) {

--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -59,7 +59,7 @@ var componentHandler = {
    * @param {!HTMLDocument|!ShadowRoot=} element Optional element we want to
    * upgrade. If not indicated by default it equals to document
    */
-  upgradeAllRegistered: function(element) {},
+  upgradeAllRegistered: function(element) {}, // eslint-disable-line
   /**
    * Allows user to be alerted to any upgrades that are performed for a given
    * component type

--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -55,8 +55,11 @@ var componentHandler = {
   /**
    * Upgrades all registered components found in the current DOM. This is
    * automatically called on window load.
+   *
+   * @param {!HTMLDocument|!ShadowRoot=} element Optional element we want to
+   * upgrade. If not indicated by default it equals to document
    */
-  upgradeAllRegistered: function() {},
+  upgradeAllRegistered: function(element) {},
   /**
    * Allows user to be alerted to any upgrades that are performed for a given
    * component type
@@ -246,7 +249,7 @@ componentHandler = (function() {
   /**
    * Upgrades a specific list of elements rather than all in the DOM.
    *
-   * @param {!Element|!Array<!Element>|!NodeList|!HTMLCollection|ShadowRoot} elements
+   * @param {!Element|!Array<!Element>|!NodeList|!HTMLCollection|!ShadowRoot} elements
    * The elements we wish to upgrade.
    */
   function upgradeElementsInternal(elements) {
@@ -338,8 +341,9 @@ componentHandler = (function() {
   /**
    * Upgrades all registered components found in the current DOM. This is
    * automatically called on window load.
-   * @param {string=} optDom the element which can be document or shadowRoot
-   * instance
+   *
+   * @param {!HTMLDocument|!ShadowRoot=} optDom Optional element we want to
+   * upgrade. If not indicated by default it equals to document
    */
   function upgradeAllRegisteredInternal(optDom) {
     for (var n = 0; n < registeredComponents_.length; n++) {

--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -149,13 +149,15 @@ componentHandler = (function() {
    * need to create a new instance of.
    * @param {string=} optCssClass the name of the CSS class elements of this
    * type will have.
+   * @param {string=} optDom the element which can be document or shadowRoot
+   * instance
    */
-  function upgradeDomInternal(optJsClass, optCssClass) {
+  function upgradeDomInternal(optJsClass, optCssClass, optDom) {
     if (typeof optJsClass === 'undefined' &&
         typeof optCssClass === 'undefined') {
       for (var i = 0; i < registeredComponents_.length; i++) {
         upgradeDomInternal(registeredComponents_[i].className,
-            registeredComponents_[i].cssClass);
+            registeredComponents_[i].cssClass, optDom);
       }
     } else {
       var jsClass = /** @type {string} */ (optJsClass);
@@ -166,7 +168,8 @@ componentHandler = (function() {
         }
       }
 
-      var elements = document.querySelectorAll('.' + optCssClass);
+      var _document = optDom || document;
+      var elements = _document.querySelectorAll('.' + optCssClass);
       for (var n = 0; n < elements.length; n++) {
         upgradeElementInternal(elements[n], jsClass);
       }
@@ -335,10 +338,12 @@ componentHandler = (function() {
   /**
    * Upgrades all registered components found in the current DOM. This is
    * automatically called on window load.
+   * @param {string=} optDom the element which can be document or shadowRoot
+   * instance
    */
-  function upgradeAllRegisteredInternal() {
+  function upgradeAllRegisteredInternal(optDom) {
     for (var n = 0; n < registeredComponents_.length; n++) {
-      upgradeDomInternal(registeredComponents_[n].className);
+      upgradeDomInternal(registeredComponents_[n].className, undefined, optDom);
     }
   }
 

--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -261,7 +261,7 @@ componentHandler = (function() {
   function upgradeElementsInternal(elements, optDom) {
     if (!Array.isArray(elements)) {
       if (typeof elements.item === 'function') {
-        elements = Array.prototype.slice.call(/** @type {Array} */ (elements));
+        elements = Array.prototype.slice.call(/** @type {Array<!Element>|!NodeList|!HTMLCollection} */ (elements));
       } else {
         elements = [elements];
       }
@@ -269,7 +269,7 @@ componentHandler = (function() {
     for (var i = 0, n = elements.length, element; i < n; i++) {
       element = elements[i];
       if (element instanceof HTMLElement) {
-        upgradeElementInternal(element, optDom);
+        upgradeElementInternal(element, undefined, optDom);
         if (element.children.length > 0) {
           upgradeElementsInternal(element.children, optDom);
         }
@@ -483,6 +483,16 @@ componentHandler['register'] = componentHandler.register;
 componentHandler['downgradeElements'] = componentHandler.downgradeElements;
 window.componentHandler = componentHandler;
 window['componentHandler'] = componentHandler;
+
+document.currentScript.addEventListener('load', function() {
+  if (
+      'ShadowRoot' in window &&
+      this.parentNode &&
+      this.parentNode instanceof window.ShadowRoot) {
+    this.parentNode.host.classList.add('mdl-js');
+    componentHandler.upgradeAllRegistered(this.parentNode);
+  }
+});
 
 window.addEventListener('load', function() {
   'use strict';

--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -230,7 +230,7 @@ componentHandler = (function() {
       var ev;
       if ('CustomEvent' in window && typeof window.CustomEvent === 'function') {
         ev = new Event('mdl-componentupgraded', {
-          'bubbles': true, 'cancelable': false
+          bubbles: true, cancelable: false
         });
       } else {
         ev = document.createEvent('Events');
@@ -364,7 +364,7 @@ componentHandler = (function() {
       var ev;
       if ('CustomEvent' in window && typeof window.CustomEvent === 'function') {
         ev = new Event('mdl-componentdowngraded', {
-          'bubbles': true, 'cancelable': false
+          bubbles: true, cancelable: false
         });
       } else {
         ev = document.createEvent('Events');

--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -35,8 +35,9 @@ var componentHandler = {
    * need to create a new instance of.
    * @param {string=} optCssClass the name of the CSS class elements of this
    * type will have.
+   * @param {!HTMLDocument|!ShadowRoot=} optDom the element we want to upgrade
    */
-  upgradeDom: function(optJsClass, optCssClass) {}, // eslint-disable-line
+  upgradeDom: function(optJsClass, optCssClass, optDom) {}, // eslint-disable-line
   /**
    * Upgrades a specific element rather than all in the DOM.
    *
@@ -152,7 +153,7 @@ componentHandler = (function() {
    * need to create a new instance of.
    * @param {string=} optCssClass the name of the CSS class elements of this
    * type will have.
-   * @param {string=} optDom the element which can be document or shadowRoot
+   * @param {!HTMLDocument|!ShadowRoot=} optDom the element which can be document or shadowRoot
    * instance
    */
   function upgradeDomInternal(optJsClass, optCssClass, optDom) {

--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -35,7 +35,8 @@ var componentHandler = {
    * need to create a new instance of.
    * @param {string=} optCssClass the name of the CSS class elements of this
    * type will have.
-   * @param {!HTMLDocument|!ShadowRoot=} optDom the element we want to upgrade
+   * @param {!HTMLDocument|!ShadowRoot=} optDom the DOM we want to upgrade.
+   * If not indicated by default it equals to document.
    */
   upgradeDom: function(optJsClass, optCssClass, optDom) {}, // eslint-disable-line
   /**
@@ -57,10 +58,10 @@ var componentHandler = {
    * Upgrades all registered components found in the current DOM. This is
    * automatically called on window load.
    *
-   * @param {!HTMLDocument|!ShadowRoot=} element Optional element we want to
-   * upgrade. If not indicated by default it equals to document
+   * @param {!HTMLDocument|!ShadowRoot=} optDom Optional DOM we want to
+   * upgrade. If not indicated by default it equals to document.
    */
-  upgradeAllRegistered: function(element) {}, // eslint-disable-line
+  upgradeAllRegistered: function(optDom) {}, // eslint-disable-line
   /**
    * Allows user to be alerted to any upgrades that are performed for a given
    * component type
@@ -175,7 +176,7 @@ componentHandler = (function() {
       var _document = optDom || document;
       var elements = _document.querySelectorAll('.' + optCssClass);
       for (var n = 0; n < elements.length; n++) {
-        upgradeElementInternal(elements[n], jsClass);
+        upgradeElementInternal(elements[n], jsClass, _document);
       }
     }
   }
@@ -186,8 +187,11 @@ componentHandler = (function() {
    * @param {!Element} element The element we wish to upgrade.
    * @param {string=} optJsClass Optional name of the class we want to upgrade
    * the element to.
+   * @param {!HTMLDocument|!ShadowRoot=} optDom Optional DOM element we want
+   * to upgrade.
    */
-  function upgradeElementInternal(element, optJsClass) {
+  function upgradeElementInternal(element, optJsClass, optDom) {
+    var _optDom = optDom || document;
     // Verify argument type.
     if (!(typeof element === 'object' && element instanceof Element)) {
       throw new Error('Invalid argument provided to upgrade MDL element.');
@@ -217,7 +221,7 @@ componentHandler = (function() {
         // Mark element as upgraded.
         upgradedList.push(registeredClass.className);
         element.setAttribute('data-upgraded', upgradedList.join(','));
-        var instance = new registeredClass.classConstructor(element); // eslint-disable-line
+        var instance = new registeredClass.classConstructor(element, _optDom); // eslint-disable-line
         instance[componentConfigProperty_] = registeredClass;
         createdComponents_.push(instance);
         // Call any callbacks the user has registered with this component type.
@@ -252,8 +256,9 @@ componentHandler = (function() {
    *
    * @param {!Element|!Array<!Element>|!NodeList|!HTMLCollection} elements
    * The elements we wish to upgrade.
+   * @param {!HTMLDocument|!ShadowRoot} optDom The DOM we wish to upgrade.
    */
-  function upgradeElementsInternal(elements) {
+  function upgradeElementsInternal(elements, optDom) {
     if (!Array.isArray(elements)) {
       if (typeof elements.item === 'function') {
         elements = Array.prototype.slice.call(/** @type {Array} */ (elements));
@@ -264,9 +269,9 @@ componentHandler = (function() {
     for (var i = 0, n = elements.length, element; i < n; i++) {
       element = elements[i];
       if (element instanceof HTMLElement) {
-        upgradeElementInternal(element);
+        upgradeElementInternal(element, optDom);
         if (element.children.length > 0) {
-          upgradeElementsInternal(element.children);
+          upgradeElementsInternal(element.children, optDom);
         }
       }
     }
@@ -343,13 +348,14 @@ componentHandler = (function() {
    * Upgrades all registered components found in the current DOM. This is
    * automatically called on window load.
    *
-   * @param {!HTMLDocument|!ShadowRoot=} optDom Optional element we want to
+   * @param {!HTMLDocument|!ShadowRoot=} optDom Optional DOM we want to
    * upgrade. If not indicated by default it equals to document
    */
   function upgradeAllRegisteredInternal(optDom) {
     var _optDom = optDom || document;
     for (var n = 0; n < registeredComponents_.length; n++) {
-      upgradeDomInternal(registeredComponents_[n].className, undefined, _optDom);
+      upgradeDomInternal(registeredComponents_[n].className,
+          undefined, _optDom);
     }
   }
 

--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -346,8 +346,9 @@ componentHandler = (function() {
    * upgrade. If not indicated by default it equals to document
    */
   function upgradeAllRegisteredInternal(optDom) {
+    var _optDom = optDom || document;
     for (var n = 0; n < registeredComponents_.length; n++) {
-      upgradeDomInternal(registeredComponents_[n].className, undefined, optDom);
+      upgradeDomInternal(registeredComponents_[n].className, undefined, _optDom);
     }
   }
 

--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -249,7 +249,7 @@ componentHandler = (function() {
   /**
    * Upgrades a specific list of elements rather than all in the DOM.
    *
-   * @param {!Element|!Array<!Element>|!NodeList|!HTMLCollection|!ShadowRoot} elements
+   * @param {!Element|!Array<!Element>|!NodeList|!HTMLCollection} elements
    * The elements we wish to upgrade.
    */
   function upgradeElementsInternal(elements) {

--- a/src/menu/menu.js
+++ b/src/menu/menu.js
@@ -25,8 +25,12 @@
    *
    * @constructor
    * @param {HTMLElement} element The element that will be upgraded.
+   * @param {HTMLDocument|ShadowRoot=} optDom Optional DOM that will
+   * be upgraded.
    */
-  var MaterialMenu = function MaterialMenu(element) {
+  var MaterialMenu = function MaterialMenu(element, optDom) {
+    var optDom_ = optDom || document;
+    this.document_ = optDom_;
     this.element_ = element;
 
     // Initialize instance.
@@ -98,7 +102,7 @@
   MaterialMenu.prototype.init = function() {
     if (this.element_) {
       // Create container for the menu.
-      var container = document.createElement('div');
+      var container = this.document_.createElement('div');
       container.classList.add(this.CssClasses_.CONTAINER);
       this.element_.parentElement.insertBefore(container, this.element_);
       this.element_.parentElement.removeChild(this.element_);
@@ -106,7 +110,7 @@
       this.container_ = container;
 
       // Create outline for the menu (shadow and background).
-      var outline = document.createElement('div');
+      var outline = this.document_.createElement('div');
       outline.classList.add(this.CssClasses_.OUTLINE);
       this.outline_ = outline;
       container.insertBefore(outline, this.element_);
@@ -116,7 +120,7 @@
                       this.element_.getAttribute('data-mdl-for');
       var forEl = null;
       if (forElId) {
-        forEl = document.getElementById(forElId);
+        forEl = this.document_.getElementById(forElId);
         if (forEl) {
           this.forElement_ = forEl;
           forEl.addEventListener('click', this.handleForClick_.bind(this));
@@ -144,10 +148,10 @@
         for (var j = 0; j < items.length; j++) {
           var item = items[j];
 
-          var rippleContainer = document.createElement('span');
+          var rippleContainer = this.document_.createElement('span');
           rippleContainer.classList.add(this.CssClasses_.ITEM_RIPPLE_CONTAINER);
 
-          var ripple = document.createElement('span');
+          var ripple = this.document_.createElement('span');
           ripple.classList.add(this.CssClasses_.RIPPLE);
           rippleContainer.appendChild(ripple);
 
@@ -424,11 +428,11 @@
         // if so, do nothing.
         if (e !== evt && !this.closing_ &&
             e.target.parentNode !== this.element_) {
-          document.removeEventListener('click', callback);
+          this.document_.removeEventListener('click', callback);
           this.hide();
         }
       }.bind(this);
-      document.addEventListener('click', callback);
+      this.document_.addEventListener('click', callback);
     }
   };
   MaterialMenu.prototype['show'] = MaterialMenu.prototype.show;

--- a/src/menu/menu.js
+++ b/src/menu/menu.js
@@ -102,7 +102,7 @@
   MaterialMenu.prototype.init = function() {
     if (this.element_) {
       // Create container for the menu.
-      var container = this.document_.createElement('div');
+      var container = document.createElement('div');
       container.classList.add(this.CssClasses_.CONTAINER);
       this.element_.parentElement.insertBefore(container, this.element_);
       this.element_.parentElement.removeChild(this.element_);
@@ -110,7 +110,7 @@
       this.container_ = container;
 
       // Create outline for the menu (shadow and background).
-      var outline = this.document_.createElement('div');
+      var outline = document.createElement('div');
       outline.classList.add(this.CssClasses_.OUTLINE);
       this.outline_ = outline;
       container.insertBefore(outline, this.element_);
@@ -148,10 +148,10 @@
         for (var j = 0; j < items.length; j++) {
           var item = items[j];
 
-          var rippleContainer = this.document_.createElement('span');
+          var rippleContainer = document.createElement('span');
           rippleContainer.classList.add(this.CssClasses_.ITEM_RIPPLE_CONTAINER);
 
-          var ripple = this.document_.createElement('span');
+          var ripple = document.createElement('span');
           ripple.classList.add(this.CssClasses_.RIPPLE);
           rippleContainer.appendChild(ripple);
 

--- a/src/progress/progress.js
+++ b/src/progress/progress.js
@@ -94,17 +94,17 @@
    */
   MaterialProgress.prototype.init = function() {
     if (this.element_) {
-      var el = this.document_.createElement('div');
+      var el = document.createElement('div');
       el.className = 'progressbar bar bar1';
       this.element_.appendChild(el);
       this.progressbar_ = el;
 
-      el = this.document_.createElement('div');
+      el = document.createElement('div');
       el.className = 'bufferbar bar bar2';
       this.element_.appendChild(el);
       this.bufferbar_ = el;
 
-      el = this.document_.createElement('div');
+      el = document.createElement('div');
       el.className = 'auxbar bar bar3';
       this.element_.appendChild(el);
       this.auxbar_ = el;

--- a/src/progress/progress.js
+++ b/src/progress/progress.js
@@ -25,8 +25,12 @@
    *
    * @constructor
    * @param {HTMLElement} element The element that will be upgraded.
+   * @param {HTMLDocument|ShadowRoot=} optDom Optional DOM that will
+   * be upgraded.
    */
-  var MaterialProgress = function MaterialProgress(element) {
+  var MaterialProgress = function MaterialProgress(element, optDom) {
+    var optDom_ = optDom || document;
+    this.document_ = optDom_;
     this.element_ = element;
 
     // Initialize instance.
@@ -90,17 +94,17 @@
    */
   MaterialProgress.prototype.init = function() {
     if (this.element_) {
-      var el = document.createElement('div');
+      var el = this.document_.createElement('div');
       el.className = 'progressbar bar bar1';
       this.element_.appendChild(el);
       this.progressbar_ = el;
 
-      el = document.createElement('div');
+      el = this.document_.createElement('div');
       el.className = 'bufferbar bar bar2';
       this.element_.appendChild(el);
       this.bufferbar_ = el;
 
-      el = document.createElement('div');
+      el = this.document_.createElement('div');
       el.className = 'auxbar bar bar3';
       this.element_.appendChild(el);
       this.auxbar_ = el;

--- a/src/radio/radio.js
+++ b/src/radio/radio.js
@@ -25,8 +25,12 @@
    *
    * @constructor
    * @param {HTMLElement} element The element that will be upgraded.
+   * @param {HTMLDocument|ShadowRoot=} optDom Optional DOM that will
+   * be upgraded.
    */
-  var MaterialRadio = function MaterialRadio(element) {
+  var MaterialRadio = function MaterialRadio(element, optDom) {
+    var optDom_ = optDom || document;
+    this.document_ = optDom_;
     this.element_ = element;
 
     // Initialize instance.
@@ -76,7 +80,7 @@
   MaterialRadio.prototype.onChange_ = function() {
     // Since other radio buttons don't get change events, we need to look for
     // them to update their classes.
-    var radios = document.getElementsByClassName(this.CssClasses_.JS_RADIO);
+    var radios = this.document_.getElementsByClassName(this.CssClasses_.JS_RADIO);
     for (var i = 0; i < radios.length; i++) {
       var button = radios[i].querySelector('.' + this.CssClasses_.RADIO_BTN);
       // Different name == different group, so no point updating those.
@@ -226,10 +230,10 @@
       this.boundBlurHandler_ = this.onBlur_.bind(this);
       this.boundMouseUpHandler_ = this.onMouseup_.bind(this);
 
-      var outerCircle = document.createElement('span');
+      var outerCircle = this.document_.createElement('span');
       outerCircle.classList.add(this.CssClasses_.RADIO_OUTER_CIRCLE);
 
-      var innerCircle = document.createElement('span');
+      var innerCircle = this.document_.createElement('span');
       innerCircle.classList.add(this.CssClasses_.RADIO_INNER_CIRCLE);
 
       this.element_.appendChild(outerCircle);
@@ -240,14 +244,14 @@
           this.CssClasses_.RIPPLE_EFFECT)) {
         this.element_.classList.add(
             this.CssClasses_.RIPPLE_IGNORE_EVENTS);
-        rippleContainer = document.createElement('span');
+        rippleContainer = this.document_.createElement('span');
         rippleContainer.classList.add(
             this.CssClasses_.RIPPLE_CONTAINER);
         rippleContainer.classList.add(this.CssClasses_.RIPPLE_EFFECT);
         rippleContainer.classList.add(this.CssClasses_.RIPPLE_CENTER);
         rippleContainer.addEventListener('mouseup', this.boundMouseUpHandler_);
 
-        var ripple = document.createElement('span');
+        var ripple = this.document_.createElement('span');
         ripple.classList.add(this.CssClasses_.RIPPLE);
 
         rippleContainer.appendChild(ripple);

--- a/src/radio/radio.js
+++ b/src/radio/radio.js
@@ -230,10 +230,10 @@
       this.boundBlurHandler_ = this.onBlur_.bind(this);
       this.boundMouseUpHandler_ = this.onMouseup_.bind(this);
 
-      var outerCircle = this.document_.createElement('span');
+      var outerCircle = document.createElement('span');
       outerCircle.classList.add(this.CssClasses_.RADIO_OUTER_CIRCLE);
 
-      var innerCircle = this.document_.createElement('span');
+      var innerCircle = document.createElement('span');
       innerCircle.classList.add(this.CssClasses_.RADIO_INNER_CIRCLE);
 
       this.element_.appendChild(outerCircle);
@@ -244,14 +244,14 @@
           this.CssClasses_.RIPPLE_EFFECT)) {
         this.element_.classList.add(
             this.CssClasses_.RIPPLE_IGNORE_EVENTS);
-        rippleContainer = this.document_.createElement('span');
+        rippleContainer = document.createElement('span');
         rippleContainer.classList.add(
             this.CssClasses_.RIPPLE_CONTAINER);
         rippleContainer.classList.add(this.CssClasses_.RIPPLE_EFFECT);
         rippleContainer.classList.add(this.CssClasses_.RIPPLE_CENTER);
         rippleContainer.addEventListener('mouseup', this.boundMouseUpHandler_);
 
-        var ripple = this.document_.createElement('span');
+        var ripple = document.createElement('span');
         ripple.classList.add(this.CssClasses_.RIPPLE);
 
         rippleContainer.appendChild(ripple);

--- a/src/slider/slider.js
+++ b/src/slider/slider.js
@@ -25,8 +25,12 @@
    *
    * @constructor
    * @param {HTMLElement} element The element that will be upgraded.
+   * @param {HTMLDocument|ShadowRoot=} optDom Optional DOM that will
+   * be upgraded.
    */
-  var MaterialSlider = function MaterialSlider(element) {
+  var MaterialSlider = function MaterialSlider(element, optDom) {
+    var optDom_ = optDom || document;
+    this.document_ = optDom_;
     this.element_ = element;
     // Browser feature detection.
     this.isIE_ = window.navigator.msPointerEnabled;
@@ -189,7 +193,7 @@
         // Since we need to specify a very large height in IE due to
         // implementation limitations, we add a parent here that trims it down to
         // a reasonable size.
-        var containerIE = document.createElement('div');
+        var containerIE = this.document_.createElement('div');
         containerIE.classList.add(this.CssClasses_.IE_CONTAINER);
         this.element_.parentElement.insertBefore(containerIE, this.element_);
         this.element_.parentElement.removeChild(this.element_);
@@ -198,18 +202,18 @@
         // For non-IE browsers, we need a div structure that sits behind the
         // slider and allows us to style the left and right sides of it with
         // different colors.
-        var container = document.createElement('div');
+        var container = this.document_.createElement('div');
         container.classList.add(this.CssClasses_.SLIDER_CONTAINER);
         this.element_.parentElement.insertBefore(container, this.element_);
         this.element_.parentElement.removeChild(this.element_);
         container.appendChild(this.element_);
-        var backgroundFlex = document.createElement('div');
+        var backgroundFlex = this.document_.createElement('div');
         backgroundFlex.classList.add(this.CssClasses_.BACKGROUND_FLEX);
         container.appendChild(backgroundFlex);
-        this.backgroundLower_ = document.createElement('div');
+        this.backgroundLower_ = this.document_.createElement('div');
         this.backgroundLower_.classList.add(this.CssClasses_.BACKGROUND_LOWER);
         backgroundFlex.appendChild(this.backgroundLower_);
-        this.backgroundUpper_ = document.createElement('div');
+        this.backgroundUpper_ = this.document_.createElement('div');
         this.backgroundUpper_.classList.add(this.CssClasses_.BACKGROUND_UPPER);
         backgroundFlex.appendChild(this.backgroundUpper_);
       }

--- a/src/slider/slider.js
+++ b/src/slider/slider.js
@@ -193,7 +193,7 @@
         // Since we need to specify a very large height in IE due to
         // implementation limitations, we add a parent here that trims it down to
         // a reasonable size.
-        var containerIE = this.document_.createElement('div');
+        var containerIE = document.createElement('div');
         containerIE.classList.add(this.CssClasses_.IE_CONTAINER);
         this.element_.parentElement.insertBefore(containerIE, this.element_);
         this.element_.parentElement.removeChild(this.element_);
@@ -202,18 +202,18 @@
         // For non-IE browsers, we need a div structure that sits behind the
         // slider and allows us to style the left and right sides of it with
         // different colors.
-        var container = this.document_.createElement('div');
+        var container = document.createElement('div');
         container.classList.add(this.CssClasses_.SLIDER_CONTAINER);
         this.element_.parentElement.insertBefore(container, this.element_);
         this.element_.parentElement.removeChild(this.element_);
         container.appendChild(this.element_);
-        var backgroundFlex = this.document_.createElement('div');
+        var backgroundFlex = document.createElement('div');
         backgroundFlex.classList.add(this.CssClasses_.BACKGROUND_FLEX);
         container.appendChild(backgroundFlex);
-        this.backgroundLower_ = this.document_.createElement('div');
+        this.backgroundLower_ = document.createElement('div');
         this.backgroundLower_.classList.add(this.CssClasses_.BACKGROUND_LOWER);
         backgroundFlex.appendChild(this.backgroundLower_);
-        this.backgroundUpper_ = this.document_.createElement('div');
+        this.backgroundUpper_ = document.createElement('div');
         this.backgroundUpper_.classList.add(this.CssClasses_.BACKGROUND_UPPER);
         backgroundFlex.appendChild(this.backgroundUpper_);
       }

--- a/src/spinner/spinner.js
+++ b/src/spinner/spinner.js
@@ -23,10 +23,14 @@
    * Implements MDL component design pattern defined at:
    * https://github.com/jasonmayes/mdl-component-design-pattern
    *
-   * @param {HTMLElement} element The element that will be upgraded.
    * @constructor
+   * @param {HTMLElement} element The element that will be upgraded.
+   * @param {HTMLDocument|ShadowRoot=} optDom Optional DOM that will
+   * be upgraded.
    */
-  var MaterialSpinner = function MaterialSpinner(element) {
+  var MaterialSpinner = function MaterialSpinner(element, optDom) {
+    var optDom_ = optDom || document;
+    this.document_ = optDom_;
     this.element_ = element;
 
     // Initialize instance.
@@ -68,25 +72,25 @@
    * @public
    */
   MaterialSpinner.prototype.createLayer = function(index) {
-    var layer = document.createElement('div');
+    var layer = this.document_.createElement('div');
     layer.classList.add(this.CssClasses_.MDL_SPINNER_LAYER);
     layer.classList.add(this.CssClasses_.MDL_SPINNER_LAYER + '-' + index);
 
-    var leftClipper = document.createElement('div');
+    var leftClipper = this.document_.createElement('div');
     leftClipper.classList.add(this.CssClasses_.MDL_SPINNER_CIRCLE_CLIPPER);
     leftClipper.classList.add(this.CssClasses_.MDL_SPINNER_LEFT);
 
-    var gapPatch = document.createElement('div');
+    var gapPatch = this.document_.createElement('div');
     gapPatch.classList.add(this.CssClasses_.MDL_SPINNER_GAP_PATCH);
 
-    var rightClipper = document.createElement('div');
+    var rightClipper = this.document_.createElement('div');
     rightClipper.classList.add(this.CssClasses_.MDL_SPINNER_CIRCLE_CLIPPER);
     rightClipper.classList.add(this.CssClasses_.MDL_SPINNER_RIGHT);
 
     var circleOwners = [leftClipper, gapPatch, rightClipper];
 
     for (var i = 0; i < circleOwners.length; i++) {
-      var circle = document.createElement('div');
+      var circle = this.document_.createElement('div');
       circle.classList.add(this.CssClasses_.MDL_SPINNER_CIRCLE);
       circleOwners[i].appendChild(circle);
     }

--- a/src/spinner/spinner.js
+++ b/src/spinner/spinner.js
@@ -72,25 +72,25 @@
    * @public
    */
   MaterialSpinner.prototype.createLayer = function(index) {
-    var layer = this.document_.createElement('div');
+    var layer = document.createElement('div');
     layer.classList.add(this.CssClasses_.MDL_SPINNER_LAYER);
     layer.classList.add(this.CssClasses_.MDL_SPINNER_LAYER + '-' + index);
 
-    var leftClipper = this.document_.createElement('div');
+    var leftClipper = document.createElement('div');
     leftClipper.classList.add(this.CssClasses_.MDL_SPINNER_CIRCLE_CLIPPER);
     leftClipper.classList.add(this.CssClasses_.MDL_SPINNER_LEFT);
 
-    var gapPatch = this.document_.createElement('div');
+    var gapPatch = document.createElement('div');
     gapPatch.classList.add(this.CssClasses_.MDL_SPINNER_GAP_PATCH);
 
-    var rightClipper = this.document_.createElement('div');
+    var rightClipper = document.createElement('div');
     rightClipper.classList.add(this.CssClasses_.MDL_SPINNER_CIRCLE_CLIPPER);
     rightClipper.classList.add(this.CssClasses_.MDL_SPINNER_RIGHT);
 
     var circleOwners = [leftClipper, gapPatch, rightClipper];
 
     for (var i = 0; i < circleOwners.length; i++) {
-      var circle = this.document_.createElement('div');
+      var circle = document.createElement('div');
       circle.classList.add(this.CssClasses_.MDL_SPINNER_CIRCLE);
       circleOwners[i].appendChild(circle);
     }

--- a/src/switch/switch.js
+++ b/src/switch/switch.js
@@ -25,8 +25,12 @@
    *
    * @constructor
    * @param {HTMLElement} element The element that will be upgraded.
+   * @param {HTMLDocument|ShadowRoot=} optDom Optional DOM that will
+   * be upgraded.
    */
-  var MaterialSwitch = function MaterialSwitch(element) {
+  var MaterialSwitch = function MaterialSwitch(element, optDom) {
+    var optDom_ = optDom || document;
+    this.document_ = optDom_;
     this.element_ = element;
 
     // Initialize instance.
@@ -210,13 +214,13 @@
       this.inputElement_ = this.element_.querySelector('.' +
           this.CssClasses_.INPUT);
 
-      var track = document.createElement('div');
+      var track = this.document_.createElement('div');
       track.classList.add(this.CssClasses_.TRACK);
 
-      var thumb = document.createElement('div');
+      var thumb = this.document_.createElement('div');
       thumb.classList.add(this.CssClasses_.THUMB);
 
-      var focusHelper = document.createElement('span');
+      var focusHelper = this.document_.createElement('span');
       focusHelper.classList.add(this.CssClasses_.FOCUS_HELPER);
 
       thumb.appendChild(focusHelper);
@@ -230,7 +234,7 @@
           this.CssClasses_.RIPPLE_EFFECT)) {
         this.element_.classList.add(
             this.CssClasses_.RIPPLE_IGNORE_EVENTS);
-        this.rippleContainerElement_ = document.createElement('span');
+        this.rippleContainerElement_ = this.document_.createElement('span');
         this.rippleContainerElement_.classList.add(
             this.CssClasses_.RIPPLE_CONTAINER);
         this.rippleContainerElement_.classList.add(
@@ -240,7 +244,7 @@
         this.rippleContainerElement_.addEventListener('mouseup',
             this.boundMouseUpHandler);
 
-        var ripple = document.createElement('span');
+        var ripple = this.document_.createElement('span');
         ripple.classList.add(this.CssClasses_.RIPPLE);
 
         this.rippleContainerElement_.appendChild(ripple);

--- a/src/switch/switch.js
+++ b/src/switch/switch.js
@@ -214,13 +214,13 @@
       this.inputElement_ = this.element_.querySelector('.' +
           this.CssClasses_.INPUT);
 
-      var track = this.document_.createElement('div');
+      var track = document.createElement('div');
       track.classList.add(this.CssClasses_.TRACK);
 
-      var thumb = this.document_.createElement('div');
+      var thumb = document.createElement('div');
       thumb.classList.add(this.CssClasses_.THUMB);
 
-      var focusHelper = this.document_.createElement('span');
+      var focusHelper = document.createElement('span');
       focusHelper.classList.add(this.CssClasses_.FOCUS_HELPER);
 
       thumb.appendChild(focusHelper);
@@ -234,7 +234,7 @@
           this.CssClasses_.RIPPLE_EFFECT)) {
         this.element_.classList.add(
             this.CssClasses_.RIPPLE_IGNORE_EVENTS);
-        this.rippleContainerElement_ = this.document_.createElement('span');
+        this.rippleContainerElement_ = document.createElement('span');
         this.rippleContainerElement_.classList.add(
             this.CssClasses_.RIPPLE_CONTAINER);
         this.rippleContainerElement_.classList.add(
@@ -244,7 +244,7 @@
         this.rippleContainerElement_.addEventListener('mouseup',
             this.boundMouseUpHandler);
 
-        var ripple = this.document_.createElement('span');
+        var ripple = document.createElement('span');
         ripple.classList.add(this.CssClasses_.RIPPLE);
 
         this.rippleContainerElement_.appendChild(ripple);

--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -25,9 +25,13 @@
    *
    * @constructor
    * @param {Element} element The element that will be upgraded.
+   * @param {HTMLDocument|ShadowRoot=} optDom Optional DOM that will
+   * be upgraded.
    */
-  var MaterialTabs = function MaterialTabs(element) {
+  var MaterialTabs = function MaterialTabs(element, optDom) {
     // Stores the HTML element.
+    var optDom_ = optDom || document;
+    this.document_ = optDom_;
     this.element_ = element;
 
     // Initialize instance.
@@ -133,10 +137,10 @@
     if (tab) {
       if (ctx.element_.classList.contains(
           ctx.CssClasses_.MDL_JS_RIPPLE_EFFECT)) {
-        var rippleContainer = document.createElement('span');
+        var rippleContainer = this.document_.createElement('span');
         rippleContainer.classList.add(ctx.CssClasses_.MDL_RIPPLE_CONTAINER);
         rippleContainer.classList.add(ctx.CssClasses_.MDL_JS_RIPPLE_EFFECT);
-        var ripple = document.createElement('span');
+        var ripple = this.document_.createElement('span');
         ripple.classList.add(ctx.CssClasses_.MDL_RIPPLE);
         rippleContainer.appendChild(ripple);
         tab.appendChild(rippleContainer);

--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -137,10 +137,10 @@
     if (tab) {
       if (ctx.element_.classList.contains(
           ctx.CssClasses_.MDL_JS_RIPPLE_EFFECT)) {
-        var rippleContainer = this.document_.createElement('span');
+        var rippleContainer = document.createElement('span');
         rippleContainer.classList.add(ctx.CssClasses_.MDL_RIPPLE_CONTAINER);
         rippleContainer.classList.add(ctx.CssClasses_.MDL_JS_RIPPLE_EFFECT);
-        var ripple = this.document_.createElement('span');
+        var ripple = document.createElement('span');
         ripple.classList.add(ctx.CssClasses_.MDL_RIPPLE);
         rippleContainer.appendChild(ripple);
         tab.appendChild(rippleContainer);

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -30,8 +30,8 @@
    */
   var MaterialTooltip = function MaterialTooltip(element, optDom) {
     var optDom_ = optDom || document;
-    this.element_ = element;
     this.document_ = optDom_;
+    this.element_ = element;
 
     // Initialize instance.
     this.init();

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -25,9 +25,13 @@
    *
    * @constructor
    * @param {HTMLElement} element The element that will be upgraded.
+   * @param {HTMLDocument|ShadowRoot=} optDom Optional DOM that will
+   * be upgraded.
    */
-  var MaterialTooltip = function MaterialTooltip(element) {
+  var MaterialTooltip = function MaterialTooltip(element, optDom) {
+    var optDom_ = optDom || document;
     this.element_ = element;
+    this.document_ = optDom_;
 
     // Initialize instance.
     this.init();
@@ -123,7 +127,7 @@
       var forElId = this.element_.getAttribute('for');
 
       if (forElId) {
-        this.forElement_ = document.getElementById(forElId);
+        this.forElement_ = this.document_.getElementById(forElId);
       }
 
       if (this.forElement_) {

--- a/test/index.html
+++ b/test/index.html
@@ -14,6 +14,7 @@
 <script src="../node_modules/mocha/mocha.js"></script>
 <script src="../node_modules/chai/chai.js"></script>
 <script src="../node_modules/chai-jquery/chai-jquery.js"></script>
+<script src="../node_modules/webcomponents.js/webcomponents.js"></script>
 <!-- <script src="../js/material.js"></script> -->
 <script>
   // Only necessary for PhantomJS 1.x

--- a/test/unit/componentHandler.js
+++ b/test/unit/componentHandler.js
@@ -135,6 +135,18 @@ describe('componentHandler', function() {
     document.body.removeChild(buttonTwo);
   });
 
+  it('should upgrade a given ShadowRoot', function() {
+    var div = document.createElement('div'); // create a :host
+    var shadow = div.createShadowRoot();
+    var button = document.createElement('button');
+    button.classList.add('mdl-js-button');
+    shadow.appendChild(button);
+    document.body.appendChild(div);
+    componentHandler.upgradeDom(undefined, undefined, shadow);
+    expect(shadow.querySelector('button').getAttribute('data-upgraded')).to.equal(',MaterialButton');
+    document.body.removeChild(div);
+  });
+
   it('should upgrade a single component to an element', function() {
     var el = document.createElement('button');
     el.setAttribute('data-upgraded', ',MaterialButtonPostfix');


### PR DESCRIPTION
I've a question about how to apply CSS material-design-lite within a [shadowRoot](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Shadow_DOM).
Here's an snippet that confuses me at all...

```html
<!-- second example from https://getmdl.io/components/index.html#textfields-section -->
<template>
  <form action="#">
    <div class="mdl-textfield mdl-js-textfield">
      <input class="mdl-textfield__input" type="text" pattern="-?[0-9]*(\.[0-9]+)?" id="sample2">
      <label class="mdl-textfield__label" for="sample2">Number...</label>
      <span class="mdl-textfield__error">Input is not a number!</span>
    </div>
  </form>
</template>
```

This PR solves the problem of adding javascript behavior to a new custom element. The main version uses [document](https://github.com/google/material-design-lite/blob/master/src/mdlComponentHandler.js#L169) as the source of all elements to upgrade. Consider the case when the shadowRoot is the source of the elements.
 
My use-case:
```javascript

  class MyCustomElement extends HTMLElement {
    // ... some code here
    attachedCallback() {
      // here this.shadowRoot contains the template given above
      window.componentHandler.upgradeAllRegistered(this.shadowRoot);
    }
    // ... some code there
  }
```

So, the template doesn't work, but, if add inside the template all the css from material.css then everything will work as expected.

How to make compatible the styles defined at _material.min.css_ with the shadowRoot?
Soon I'll write the test-cases for this PR