### PR TITLE
Use `customEvent`

### DIFF
--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -229,7 +229,7 @@ componentHandler = (function() {
 
       var ev;
       if ('CustomEvent' in window && typeof window.CustomEvent === 'function') {
-        ev = new Event('mdl-componentupgraded', {
+        ev = new CustomEvent('mdl-componentupgraded', {
           bubbles: true, cancelable: false
         });
       } else {
@@ -360,7 +360,7 @@ componentHandler = (function() {
 
       var ev;
       if ('CustomEvent' in window && typeof window.CustomEvent === 'function') {
-        ev = new Event('mdl-componentdowngraded', {
+        ev = new CustomEvent('mdl-componentdowngraded', {
           bubbles: true, cancelable: false
         });
       } else {


### PR DESCRIPTION
Fixes #4239 

This method according to [caniuse data](http://caniuse.com/#search=CustomEvent) should supply support to all of our supported browsers cleanly.

Still needs testing in:
* [x] Firefox
* [x] FF Mobile
* [x] IE 10
* [x] IE 11
* [x] Safari
* [ ] Mobile Safari
* [ ] Mobile IE if possible