### PR TITLE
Add buildDom() method

### DIFF
--- a/src/checkbox/checkbox.js
+++ b/src/checkbox/checkbox.js
@@ -56,6 +56,59 @@ class MaterialCheckbox extends MaterialComponent {
   }
 
   /**
+   * Generates an ID for a new checkbox. Keeps a counter to ensure uniqueness.
+   * @return {string} The generated ID.
+   */
+  static generateId_() {
+    MaterialCheckbox.autoCounter_ = (MaterialCheckbox.autoCounter_ || 0) + 1;
+    return `mdlcheckbox-${MaterialCheckbox.autoCounter_}`;
+  }
+
+  /**
+   * Creates the DOM subtree for a new checkbox.
+   *
+   * Options:
+   *   - {string} id: The ID to use on the input element.
+   *   - {string} text: The text to use on the checkbox.
+   *   - {boolean} checked: Whether the checkbox should initially be checked.
+   *   - {boolean} disabled: Whether the checkbox should initially be disabled.
+   *
+   * @return {Element} The DOM subtree for the component.
+   * @export
+   */
+  static buildDom(/** { id: string, text: string, checked: boolean,
+      disabled: boolean }= */ {
+      id = MaterialCheckbox.generateId_(),
+      text = '',
+      checked = false,
+      disabled = false
+    } = {}) {
+    let root = document.createElement('label');
+    let input = document.createElement('input');
+    let label = document.createElement('span');
+    root.htmlFor = id;
+    root.classList.add(MaterialCheckbox.cssClasses_.ROOT);
+    input.type = 'checkbox';
+    input.id = id;
+    input.classList.add(MaterialCheckbox.cssClasses_.INPUT);
+    input.checked = checked;
+    input.disabled = disabled;
+    root.appendChild(input);
+    label.classList.add(MaterialCheckbox.cssClasses_.LABEL);
+    label.text = text;
+    root.appendChild(label);
+
+    // Ensure correct first render.
+    if (checked) {
+      root.classList.add(MaterialCheckbox.cssClasses_.IS_CHECKED);
+    }
+    if (disabled) {
+      root.classList.add(MaterialCheckbox.cssClasses_.IS_DISABLED);
+    }
+    return root;
+  }
+
+  /**
    * CSS classes used in this component.
    *
    * @protected
@@ -66,6 +119,7 @@ class MaterialCheckbox extends MaterialComponent {
       ROOT: 'mdl-checkbox',
       JS: 'mdl-js-checkbox',
       INPUT: 'mdl-checkbox__input',
+      LABEL: 'mdl-checkbox__label',
 
       IS_FOCUSED: 'is-focused',
       IS_DISABLED: 'is-disabled',

--- a/src/checkbox/checkbox.js
+++ b/src/checkbox/checkbox.js
@@ -56,15 +56,6 @@ class MaterialCheckbox extends MaterialComponent {
   }
 
   /**
-   * Generates an ID for a new checkbox. Keeps a counter to ensure uniqueness.
-   * @return {string} The generated ID.
-   */
-  static generateId_() {
-    MaterialCheckbox.autoCounter_ = (MaterialCheckbox.autoCounter_ || 0) + 1;
-    return `mdlcheckbox-${MaterialCheckbox.autoCounter_}`;
-  }
-
-  /**
    * Creates the DOM subtree for a new component.
    * Greatly simplifies programmatic component creation.
    *
@@ -76,11 +67,8 @@ class MaterialCheckbox extends MaterialComponent {
     let root = document.createElement('label');
     let input = document.createElement('input');
     let label = document.createElement('span');
-    let id = MaterialCheckbox.generateId_();
-    root.htmlFor = id;
     root.classList.add(MaterialCheckbox.cssClasses_.ROOT);
     input.type = 'checkbox';
-    input.id = id;
     input.classList.add(MaterialCheckbox.cssClasses_.INPUT);
     root.appendChild(input);
     label.classList.add(MaterialCheckbox.cssClasses_.LABEL);

--- a/src/checkbox/checkbox.js
+++ b/src/checkbox/checkbox.js
@@ -24,13 +24,13 @@ class MaterialCheckbox extends MaterialComponent {
   /**
    * Initialize checkbox from a DOM node.
    *
-   * @param {Element} root The element being upgraded.
+   * @param {Element=} optRoot The element being upgraded.
    */
-  constructor(root) {
-    super(root);
+  constructor(optRoot) {
+    super(optRoot);
 
     // Check if the root has the right class.
-    if (!root.classList.contains(this.constructor.cssClasses_.ROOT)) {
+    if (!this.root_.classList.contains(this.constructor.cssClasses_.ROOT)) {
       throw new Error('MaterialCheckbox missing ' +
           `${this.constructor.cssClasses_.ROOT} class.`);
     }
@@ -65,46 +65,27 @@ class MaterialCheckbox extends MaterialComponent {
   }
 
   /**
-   * Creates the DOM subtree for a new checkbox.
+   * Creates the DOM subtree for a new component.
+   * Greatly simplifies programmatic component creation.
    *
-   * Options:
-   *   - {string} id: The ID to use on the input element.
-   *   - {string} text: The text to use on the checkbox.
-   *   - {boolean} checked: Whether the checkbox should initially be checked.
-   *   - {boolean} disabled: Whether the checkbox should initially be disabled.
-   *
+   * @protected
+   * @nocollapse
    * @return {Element} The DOM subtree for the component.
-   * @export
    */
-  static buildDom(/** { id: string, text: string, checked: boolean,
-      disabled: boolean }= */ {
-      id = MaterialCheckbox.generateId_(),
-      text = '',
-      checked = false,
-      disabled = false
-    } = {}) {
+  static buildDom_() {
     let root = document.createElement('label');
     let input = document.createElement('input');
     let label = document.createElement('span');
+    let id = MaterialCheckbox.generateId_();
     root.htmlFor = id;
     root.classList.add(MaterialCheckbox.cssClasses_.ROOT);
     input.type = 'checkbox';
     input.id = id;
     input.classList.add(MaterialCheckbox.cssClasses_.INPUT);
-    input.checked = checked;
-    input.disabled = disabled;
     root.appendChild(input);
     label.classList.add(MaterialCheckbox.cssClasses_.LABEL);
-    label.text = text;
     root.appendChild(label);
 
-    // Ensure correct first render.
-    if (checked) {
-      root.classList.add(MaterialCheckbox.cssClasses_.IS_CHECKED);
-    }
-    if (disabled) {
-      root.classList.add(MaterialCheckbox.cssClasses_.IS_DISABLED);
-    }
     return root;
   }
 

--- a/src/checkbox/snippets/check-off.html
+++ b/src/checkbox/snippets/check-off.html
@@ -1,5 +1,5 @@
-<label class="mdl-checkbox" for="checkbox-2">
-  <input type="checkbox" id="checkbox-2" class="mdl-checkbox__input">
+<label class="mdl-checkbox">
+  <input type="checkbox" class="mdl-checkbox__input">
   <span class="mdl-checkbox__label">Checkbox</span>
   <span class="mdl-checkbox__focus-helper"></span>
   <span class="mdl-checkbox__box-outline">

--- a/src/checkbox/snippets/check-on.html
+++ b/src/checkbox/snippets/check-on.html
@@ -1,5 +1,5 @@
-<label class="mdl-checkbox" for="checkbox-1">
-  <input type="checkbox" id="checkbox-1" class="mdl-checkbox__input" checked>
+<label class="mdl-checkbox">
+  <input type="checkbox" class="mdl-checkbox__input" checked>
   <span class="mdl-checkbox__label">Checkbox</span>
   <span class="mdl-checkbox__focus-helper"></span>
   <span class="mdl-checkbox__box-outline">

--- a/src/component.js
+++ b/src/component.js
@@ -30,6 +30,21 @@ class MaterialComponent { // eslint-disable-line no-unused-vars
     this.root_ = root;
   }
 
+  /* eslint-disable valid-jsdoc, no-unused-vars */
+  /**
+   * Creates the DOM subtree for a new component.
+   * Greatly simplifies programmatic component creation.
+   *
+   * @param {Object} options Component options (component-specific).
+   * @return {Element} The DOM subtree for the component.
+   * @export
+   */
+  static buildDom(options) {
+    // Empty in base class. Throw error if not correctly overriden.
+    throw new Error('Should be implemented in components.');
+  }
+  /* eslint-enable valid-jsdoc, no-unused-vars */
+
   // eslint-disable-next-line valid-jsdoc
   /**
    * CSS classes used in this component.

--- a/src/component.js
+++ b/src/component.js
@@ -20,30 +20,30 @@
  *
  * @export
  */
-class MaterialComponent { // eslint-disable-line no-unused-vars
+class MaterialComponent {
   /**
    * Initialize component from a DOM node.
    *
-   * @param {Element} root The element being upgraded.
+   * @param {Element=} optRoot The element being upgraded. If none, a new DOM
+   *     subtree gets created for the component.
    */
-  constructor(root) {
-    this.root_ = root;
+  constructor(optRoot) {
+    this.root_ = optRoot || this.constructor.buildDom_();
   }
 
-  /* eslint-disable valid-jsdoc, no-unused-vars */
+  // eslint-disable-next-line valid-jsdoc
   /**
    * Creates the DOM subtree for a new component.
    * Greatly simplifies programmatic component creation.
    *
-   * @param {Object} options Component options (component-specific).
+   * @protected
+   * @nocollapse
    * @return {Element} The DOM subtree for the component.
-   * @export
    */
-  static buildDom(options) {
+  static buildDom_() {
     // Empty in base class. Throw error if not correctly overriden.
     throw new Error('Should be implemented in components.');
   }
-  /* eslint-enable valid-jsdoc, no-unused-vars */
 
   // eslint-disable-next-line valid-jsdoc
   /**
@@ -96,6 +96,16 @@ class MaterialComponent { // eslint-disable-line no-unused-vars
     // Useful, but beware flashes of unstyled content when relying on this.
     this.root_.classList.add(
         `${this.constructor.cssClasses_.ROOT}--is-upgraded`);
+  }
+
+  /**
+   * Returns the root element for the component.
+   *
+   * @return {Element} The root element for the component.
+   * @export
+   */
+  get root() {
+    return this.root_;
   }
 
   /**

--- a/src/menu/menu.js
+++ b/src/menu/menu.js
@@ -24,13 +24,13 @@ class MaterialMenu extends MaterialComponent {
   /**
    * Initialize checkbox from a DOM node.
    *
-   * @param {Element} root The element being upgraded.
+   * @param {Element=} optRoot The element being upgraded.
    */
-  constructor(root) {
-    super(root);
+  constructor(optRoot) {
+    super(optRoot);
 
     // Check if the root has the right class.
-    if (!root.classList.contains(this.constructor.cssClasses_.ROOT)) {
+    if (!this.root_.classList.contains(this.constructor.cssClasses_.ROOT)) {
       throw new Error('MaterialMenu missing ' +
           `${this.constructor.cssClasses_.ROOT} class.`);
     }
@@ -64,30 +64,20 @@ class MaterialMenu extends MaterialComponent {
   }
 
   /**
-   * Creates the DOM subtree for a new switch.
+   * Creates the DOM subtree for a new component.
+   * Greatly simplifies programmatic component creation.
    *
-   * Options:
-   *   - {Array<string>} items: The text for the items to add to the menu.
-   *
+   * @protected
+   * @nocollapse
    * @return {Element} The DOM subtree for the component.
-   * @export
    */
-  static buildDom(/** {items: Array<string>}= */ {
-      items = []
-    } = {}) {
+  static buildDom_() {
     let root = document.createElement('div');
     root.classList.add(MaterialMenu.cssClasses_.ROOT);
 
     let list = document.createElement('ul');
     list.classList.add(MaterialMenu.cssClasses_.LIST);
     root.appendChild(list);
-
-    for (let i = 0; i < items.length; i++) {
-      let item = document.createElement('li');
-      item.classList.add(MaterialMenu.cssClasses_.ITEM);
-      item.textContent = items[i];
-      list.appendChild(item);
-    }
 
     return root;
   }

--- a/src/menu/menu.js
+++ b/src/menu/menu.js
@@ -64,6 +64,35 @@ class MaterialMenu extends MaterialComponent {
   }
 
   /**
+   * Creates the DOM subtree for a new switch.
+   *
+   * Options:
+   *   - {Array<string>} items: The text for the items to add to the menu.
+   *
+   * @return {Element} The DOM subtree for the component.
+   * @export
+   */
+  static buildDom(/** {items: Array<string>}= */ {
+      items = []
+    } = {}) {
+    let root = document.createElement('div');
+    root.classList.add(MaterialMenu.cssClasses_.ROOT);
+
+    let list = document.createElement('ul');
+    list.classList.add(MaterialMenu.cssClasses_.LIST);
+    root.appendChild(list);
+
+    for (let i = 0; i < items.length; i++) {
+      let item = document.createElement('li');
+      item.classList.add(MaterialMenu.cssClasses_.ITEM);
+      item.textContent = items[i];
+      list.appendChild(item);
+    }
+
+    return root;
+  }
+
+  /**
    * Number constants used in this component.
    *
    * @protected

--- a/src/radio/radio.js
+++ b/src/radio/radio.js
@@ -55,6 +55,59 @@ class MaterialRadio extends MaterialComponent {
   }
 
   /**
+   * Generates an ID for a new Radio. Keeps a counter to ensure uniqueness.
+   * @return {string} The generated ID.
+   */
+  static generateId_() {
+    MaterialRadio.autoCounter_ = (MaterialRadio.autoCounter_ || 0) + 1;
+    return `mdlradio-${MaterialRadio.autoCounter_}`;
+  }
+
+  /**
+   * Creates the DOM subtree for a new radio.
+   *
+   * Options:
+   *   - {string} id: The ID to use on the input element.
+   *   - {string} text: The text to use on the radio.
+   *   - {boolean} checked: Whether the radio should initially be checked.
+   *   - {boolean} disabled: Whether the radio should initially be disabled.
+   *
+   * @return {Element} The DOM subtree for the component.
+   * @export
+   */
+  static buildDom(/** { id: string, text: string, checked: boolean,
+      disabled: boolean }= */ {
+      id = MaterialRadio.generateId_(),
+      text = '',
+      checked = false,
+      disabled = false
+    } = {}) {
+    let root = document.createElement('label');
+    let input = document.createElement('input');
+    let label = document.createElement('span');
+    root.htmlFor = id;
+    root.classList.add(MaterialRadio.cssClasses_.ROOT);
+    input.type = 'radio';
+    input.id = id;
+    input.classList.add(MaterialRadio.cssClasses_.INPUT);
+    input.checked = checked;
+    input.disabled = disabled;
+    root.appendChild(input);
+    label.classList.add(MaterialRadio.cssClasses_.LABEL);
+    label.text = text;
+    root.appendChild(label);
+
+    // Ensure correct first render.
+    if (checked) {
+      root.classList.add(MaterialRadio.cssClasses_.IS_CHECKED);
+    }
+    if (disabled) {
+      root.classList.add(MaterialRadio.cssClasses_.IS_DISABLED);
+    }
+    return root;
+  }
+
+  /**
    * CSS classes used in this component.
    *
    * @override
@@ -66,6 +119,7 @@ class MaterialRadio extends MaterialComponent {
       ROOT: 'mdl-radio',
       JS: 'mdl-js-radio',
       INPUT: 'mdl-radio__input',
+      LABEL: 'mdl-radio__label',
 
       IS_FOCUSED: 'is-focused',
       IS_DISABLED: 'is-disabled',

--- a/src/radio/radio.js
+++ b/src/radio/radio.js
@@ -18,25 +18,27 @@
 /**
  * The MaterialRadio class wraps a Material Design radio component.
  *
+ * @extends {MaterialComponent}
  * @export
  */
 class MaterialRadio extends MaterialComponent {
   /**
    * Initialize radio from a DOM node.
    *
-   * @param {Element} root The element being upgraded.
+   * @param {Element=} optRoot The element being upgraded.
    */
-  constructor(root) {
-    super(root);
+  constructor(optRoot) {
+    super(optRoot);
 
     // Check if the root has the right class.
-    if (!root.classList.contains(this.constructor.cssClasses_.ROOT)) {
+    if (!this.root_.classList.contains(this.constructor.cssClasses_.ROOT)) {
       throw new Error('MaterialRadio missing ' +
           `${this.constructor.cssClasses_.ROOT} class.`);
     }
 
     // Look for required sub-nodes in the root's DOM.
-    this.input_ = root.querySelector(`.${MaterialRadio.cssClasses_.INPUT}`);
+    this.input_ =
+        this.root_.querySelector(`.${MaterialRadio.cssClasses_.INPUT}`);
     if (!this.input_) {
       throw new Error(
           `MaterialRadio missing ${MaterialRadio.cssClasses_.INPUT} node.`);
@@ -64,46 +66,27 @@ class MaterialRadio extends MaterialComponent {
   }
 
   /**
-   * Creates the DOM subtree for a new radio.
+   * Creates the DOM subtree for a new component.
+   * Greatly simplifies programmatic component creation.
    *
-   * Options:
-   *   - {string} id: The ID to use on the input element.
-   *   - {string} text: The text to use on the radio.
-   *   - {boolean} checked: Whether the radio should initially be checked.
-   *   - {boolean} disabled: Whether the radio should initially be disabled.
-   *
+   * @protected
+   * @nocollapse
    * @return {Element} The DOM subtree for the component.
-   * @export
    */
-  static buildDom(/** { id: string, text: string, checked: boolean,
-      disabled: boolean }= */ {
-      id = MaterialRadio.generateId_(),
-      text = '',
-      checked = false,
-      disabled = false
-    } = {}) {
+  static buildDom_() {
     let root = document.createElement('label');
     let input = document.createElement('input');
     let label = document.createElement('span');
+    let id = MaterialRadio.generateId_();
     root.htmlFor = id;
     root.classList.add(MaterialRadio.cssClasses_.ROOT);
     input.type = 'radio';
     input.id = id;
     input.classList.add(MaterialRadio.cssClasses_.INPUT);
-    input.checked = checked;
-    input.disabled = disabled;
     root.appendChild(input);
     label.classList.add(MaterialRadio.cssClasses_.LABEL);
-    label.text = text;
     root.appendChild(label);
 
-    // Ensure correct first render.
-    if (checked) {
-      root.classList.add(MaterialRadio.cssClasses_.IS_CHECKED);
-    }
-    if (disabled) {
-      root.classList.add(MaterialRadio.cssClasses_.IS_DISABLED);
-    }
     return root;
   }
 

--- a/src/radio/radio.js
+++ b/src/radio/radio.js
@@ -57,15 +57,6 @@ class MaterialRadio extends MaterialComponent {
   }
 
   /**
-   * Generates an ID for a new Radio. Keeps a counter to ensure uniqueness.
-   * @return {string} The generated ID.
-   */
-  static generateId_() {
-    MaterialRadio.autoCounter_ = (MaterialRadio.autoCounter_ || 0) + 1;
-    return `mdlradio-${MaterialRadio.autoCounter_}`;
-  }
-
-  /**
    * Creates the DOM subtree for a new component.
    * Greatly simplifies programmatic component creation.
    *
@@ -77,11 +68,8 @@ class MaterialRadio extends MaterialComponent {
     let root = document.createElement('label');
     let input = document.createElement('input');
     let label = document.createElement('span');
-    let id = MaterialRadio.generateId_();
-    root.htmlFor = id;
     root.classList.add(MaterialRadio.cssClasses_.ROOT);
     input.type = 'radio';
-    input.id = id;
     input.classList.add(MaterialRadio.cssClasses_.INPUT);
     root.appendChild(input);
     label.classList.add(MaterialRadio.cssClasses_.LABEL);

--- a/src/radio/snippets/radio-off.html
+++ b/src/radio/snippets/radio-off.html
@@ -1,5 +1,5 @@
-<label class="mdl-radio" for="option-2">
-  <input type="radio" id="option-2" class="mdl-radio__input" name="options" value="2">
+<label class="mdl-radio">
+  <input type="radio" class="mdl-radio__input" name="options" value="2">
   <span class="mdl-radio__label">Second</span>
   <span class="mdl-radio__outer-circle"></span>
   <span class="mdl-radio__inner-circle"></span>

--- a/src/radio/snippets/radio-on.html
+++ b/src/radio/snippets/radio-on.html
@@ -1,5 +1,5 @@
-<label class="mdl-radio" for="option-1">
-  <input type="radio" id="option-1" class="mdl-radio__input" name="options" value="1" checked>
+<label class="mdl-radio">
+  <input type="radio" class="mdl-radio__input" name="options" value="1" checked>
   <span class="mdl-radio__label">First</span>
   <span class="mdl-radio__outer-circle"></span>
   <span class="mdl-radio__inner-circle"></span>

--- a/src/switch/snippets/switch-off.html
+++ b/src/switch/snippets/switch-off.html
@@ -1,4 +1,4 @@
-<label class="mdl-switch" for="switch-2">
-  <input type="checkbox" id="switch-2" class="mdl-switch__input">
+<label class="mdl-switch">
+  <input type="checkbox" class="mdl-switch__input">
   <span class="mdl-switch__label"></span>
 </label>

--- a/src/switch/snippets/switch-on.html
+++ b/src/switch/snippets/switch-on.html
@@ -1,4 +1,4 @@
-<label class="mdl-switch" for="switch-1">
-  <input type="checkbox" id="switch-1" class="mdl-switch__input" checked>
+<label class="mdl-switch">
+  <input type="checkbox" class="mdl-switch__input" checked>
   <span class="mdl-switch__label"></span>
 </label>

--- a/src/switch/switch.js
+++ b/src/switch/switch.js
@@ -24,13 +24,13 @@ class MaterialSwitch extends MaterialComponent {
   /**
    * Initialize checkbox from a DOM node.
    *
-   * @param {Element} root The element being upgraded.
+   * @param {Element=} optRoot The element being upgraded.
    */
-  constructor(root) {
-    super(root);
+  constructor(optRoot) {
+    super(optRoot);
 
     // Check if the root has the right class.
-    if (!root.classList.contains(this.constructor.cssClasses_.ROOT)) {
+    if (!this.root_.classList.contains(this.constructor.cssClasses_.ROOT)) {
       throw new Error('MaterialSwitch missing ' +
           `${this.constructor.cssClasses_.ROOT} class.`);
     }
@@ -65,46 +65,27 @@ class MaterialSwitch extends MaterialComponent {
   }
 
   /**
-   * Creates the DOM subtree for a new switch.
+   * Creates the DOM subtree for a new component.
+   * Greatly simplifies programmatic component creation.
    *
-   * Options:
-   *   - {string} id: The ID to use on the input element.
-   *   - {string} text: The text to use on the switch.
-   *   - {boolean} checked: Whether the switch should initially be checked.
-   *   - {boolean} disabled: Whether the switch should initially be disabled.
-   *
+   * @protected
+   * @nocollapse
    * @return {Element} The DOM subtree for the component.
-   * @export
    */
-  static buildDom(/** { id: string, text: string, checked: boolean,
-      disabled: boolean }= */ {
-      id = MaterialSwitch.generateId_(),
-      text = '',
-      checked = false,
-      disabled = false
-    } = {}) {
+  static buildDom_() {
     let root = document.createElement('label');
     let input = document.createElement('input');
     let label = document.createElement('span');
+    let id = MaterialSwitch.generateId_();
     root.htmlFor = id;
     root.classList.add(MaterialSwitch.cssClasses_.ROOT);
     input.type = 'checkbox';
     input.id = id;
     input.classList.add(MaterialSwitch.cssClasses_.INPUT);
-    input.checked = checked;
-    input.disabled = disabled;
     root.appendChild(input);
     label.classList.add(MaterialSwitch.cssClasses_.LABEL);
-    label.text = text;
     root.appendChild(label);
 
-    // Ensure correct first render.
-    if (checked) {
-      root.classList.add(MaterialSwitch.cssClasses_.IS_CHECKED);
-    }
-    if (disabled) {
-      root.classList.add(MaterialSwitch.cssClasses_.IS_DISABLED);
-    }
     return root;
   }
 

--- a/src/switch/switch.js
+++ b/src/switch/switch.js
@@ -56,15 +56,6 @@ class MaterialSwitch extends MaterialComponent {
   }
 
   /**
-   * Generates an ID for a new switch. Keeps a counter to ensure uniqueness.
-   * @return {string} The generated ID.
-   */
-  static generateId_() {
-    MaterialSwitch.autoCounter_ = (MaterialSwitch.autoCounter_ || 0) + 1;
-    return `mdlswitch-${MaterialSwitch.autoCounter_}`;
-  }
-
-  /**
    * Creates the DOM subtree for a new component.
    * Greatly simplifies programmatic component creation.
    *
@@ -76,11 +67,8 @@ class MaterialSwitch extends MaterialComponent {
     let root = document.createElement('label');
     let input = document.createElement('input');
     let label = document.createElement('span');
-    let id = MaterialSwitch.generateId_();
-    root.htmlFor = id;
     root.classList.add(MaterialSwitch.cssClasses_.ROOT);
     input.type = 'checkbox';
-    input.id = id;
     input.classList.add(MaterialSwitch.cssClasses_.INPUT);
     root.appendChild(input);
     label.classList.add(MaterialSwitch.cssClasses_.LABEL);

--- a/src/switch/switch.js
+++ b/src/switch/switch.js
@@ -56,6 +56,59 @@ class MaterialSwitch extends MaterialComponent {
   }
 
   /**
+   * Generates an ID for a new switch. Keeps a counter to ensure uniqueness.
+   * @return {string} The generated ID.
+   */
+  static generateId_() {
+    MaterialSwitch.autoCounter_ = (MaterialSwitch.autoCounter_ || 0) + 1;
+    return `mdlswitch-${MaterialSwitch.autoCounter_}`;
+  }
+
+  /**
+   * Creates the DOM subtree for a new switch.
+   *
+   * Options:
+   *   - {string} id: The ID to use on the input element.
+   *   - {string} text: The text to use on the switch.
+   *   - {boolean} checked: Whether the switch should initially be checked.
+   *   - {boolean} disabled: Whether the switch should initially be disabled.
+   *
+   * @return {Element} The DOM subtree for the component.
+   * @export
+   */
+  static buildDom(/** { id: string, text: string, checked: boolean,
+      disabled: boolean }= */ {
+      id = MaterialSwitch.generateId_(),
+      text = '',
+      checked = false,
+      disabled = false
+    } = {}) {
+    let root = document.createElement('label');
+    let input = document.createElement('input');
+    let label = document.createElement('span');
+    root.htmlFor = id;
+    root.classList.add(MaterialSwitch.cssClasses_.ROOT);
+    input.type = 'checkbox';
+    input.id = id;
+    input.classList.add(MaterialSwitch.cssClasses_.INPUT);
+    input.checked = checked;
+    input.disabled = disabled;
+    root.appendChild(input);
+    label.classList.add(MaterialSwitch.cssClasses_.LABEL);
+    label.text = text;
+    root.appendChild(label);
+
+    // Ensure correct first render.
+    if (checked) {
+      root.classList.add(MaterialSwitch.cssClasses_.IS_CHECKED);
+    }
+    if (disabled) {
+      root.classList.add(MaterialSwitch.cssClasses_.IS_DISABLED);
+    }
+    return root;
+  }
+
+  /**
    * CSS classes used in this component.
    *
    * @protected
@@ -66,6 +119,7 @@ class MaterialSwitch extends MaterialComponent {
       ROOT: 'mdl-switch',
       JS: 'mdl-js-switch',
       INPUT: 'mdl-switch__input',
+      LABEL: 'mdl-switch__label',
 
       IS_FOCUSED: 'is-focused',
       IS_DISABLED: 'is-disabled',

--- a/test/unit/checkbox.js
+++ b/test/unit/checkbox.js
@@ -20,10 +20,8 @@ describe('MaterialCheckbox', function () {
     var label = document.createElement('label');
     var input = document.createElement('input');
     var labelText = document.createElement('span');
-    label.htmlFor = 'testCheckbox';
     label.className = 'mdl-checkbox';
     input.type = 'checkbox';
-    input.id = 'testCheckbox';
     input.className = 'mdl-checkbox__input';
     label.appendChild(input);
     labelText.className = 'mdl-checkbox__label';

--- a/test/unit/checkbox.js
+++ b/test/unit/checkbox.js
@@ -43,34 +43,10 @@ describe('MaterialCheckbox', function () {
     expect(el.classList.contains('mdl-checkbox--is-upgraded')).to.be.true;
   });
 
-  describe('.buildDom()', function () {
-    it('should return a valid DOM with no parameters', function() {
-      var el = MaterialCheckbox.buildDom();
-      expect(el).to.be.an.instanceof(Element);
-      var sw = new MaterialCheckbox(el);
-      expect(sw).to.be.an.instanceof(MaterialCheckbox);
-    });
-
-    it('should return a valid DOM with a provided id', function() {
-      var el = MaterialCheckbox.buildDom({
-        id: 'testId'
-      });
-      expect(el).to.be.an.instanceof(Element);
-      expect(el.querySelector('#testId')).to.not.be.null;
-      var sw = new MaterialCheckbox(el);
-      expect(sw).to.be.an.instanceof(MaterialCheckbox);
-    });
-
-    it('should return a valid DOM with a provided text', function() {
-      var el = MaterialCheckbox.buildDom({
-        text: 'Test checkbox'
-      });
-      expect(el).to.be.an.instanceof(Element);
-      expect(el.querySelector('.mdl-checkbox__label').text).to
-          .equal('Test checkbox');
-      var sw = new MaterialCheckbox(el);
-      expect(sw).to.be.an.instanceof(MaterialCheckbox);
-    });
+  it('should build a valid DOM with no parameters', function() {
+    var checkbox = new MaterialCheckbox();
+    expect(checkbox).to.be.an.instanceof(MaterialCheckbox);
+    expect(checkbox.root).to.be.an.instanceof(Element);
   });
 
   it('should get checked class after being checked', function() {

--- a/test/unit/checkbox.js
+++ b/test/unit/checkbox.js
@@ -43,6 +43,36 @@ describe('MaterialCheckbox', function () {
     expect(el.classList.contains('mdl-checkbox--is-upgraded')).to.be.true;
   });
 
+  describe('.buildDom()', function () {
+    it('should return a valid DOM with no parameters', function() {
+      var el = MaterialCheckbox.buildDom();
+      expect(el).to.be.an.instanceof(Element);
+      var sw = new MaterialCheckbox(el);
+      expect(sw).to.be.an.instanceof(MaterialCheckbox);
+    });
+
+    it('should return a valid DOM with a provided id', function() {
+      var el = MaterialCheckbox.buildDom({
+        id: 'testId'
+      });
+      expect(el).to.be.an.instanceof(Element);
+      expect(el.querySelector('#testId')).to.not.be.null;
+      var sw = new MaterialCheckbox(el);
+      expect(sw).to.be.an.instanceof(MaterialCheckbox);
+    });
+
+    it('should return a valid DOM with a provided text', function() {
+      var el = MaterialCheckbox.buildDom({
+        text: 'Test checkbox'
+      });
+      expect(el).to.be.an.instanceof(Element);
+      expect(el.querySelector('.mdl-checkbox__label').text).to
+          .equal('Test checkbox');
+      var sw = new MaterialCheckbox(el);
+      expect(sw).to.be.an.instanceof(MaterialCheckbox);
+    });
+  });
+
   it('should get checked class after being checked', function() {
     var el = createCheckbox();
     var checkbox = new MaterialCheckbox(el);

--- a/test/unit/checkbox.js
+++ b/test/unit/checkbox.js
@@ -20,7 +20,7 @@ describe('MaterialCheckbox', function () {
     var label = document.createElement('label');
     var input = document.createElement('input');
     var labelText = document.createElement('span');
-    label.for = 'testCheckbox';
+    label.htmlFor = 'testCheckbox';
     label.className = 'mdl-checkbox';
     input.type = 'checkbox';
     input.id = 'testCheckbox';

--- a/test/unit/menu.js
+++ b/test/unit/menu.js
@@ -45,6 +45,28 @@ describe('MaterialMenu', function () {
     expect(function() { new MaterialMenu(el) }).to.throw(Error);
   });
 
+  describe('.buildDom()', function () {
+    it('should return a valid DOM with no parameters', function() {
+      var el = MaterialMenu.buildDom();
+      expect(el).to.be.an.instanceof(Element);
+      var sw = new MaterialMenu(el);
+      expect(sw).to.be.an.instanceof(MaterialMenu);
+    });
+
+    it('should return a valid DOM with a provided list of items', function() {
+      var testItems = ['foo', 'bar', 'foobar'];
+      var el = MaterialMenu.buildDom({
+        items: testItems
+      });
+      expect(el).to.be.an.instanceof(Element);
+      var items = el.querySelectorAll('.mdl-menu__item');
+      expect(items.length).to.be.equal(3);
+      for (var i = 0; i < items.length; i++) {
+        expect(items[i].textContent).to.be.equal(testItems[i]);
+      }
+    });
+  });
+
   it('should start the showing animation on show()', function(done) {
     var el = createMenu();
     var menu = new MaterialMenu(el);

--- a/test/unit/menu.js
+++ b/test/unit/menu.js
@@ -45,26 +45,10 @@ describe('MaterialMenu', function () {
     expect(function() { new MaterialMenu(el) }).to.throw(Error);
   });
 
-  describe('.buildDom()', function () {
-    it('should return a valid DOM with no parameters', function() {
-      var el = MaterialMenu.buildDom();
-      expect(el).to.be.an.instanceof(Element);
-      var sw = new MaterialMenu(el);
-      expect(sw).to.be.an.instanceof(MaterialMenu);
-    });
-
-    it('should return a valid DOM with a provided list of items', function() {
-      var testItems = ['foo', 'bar', 'foobar'];
-      var el = MaterialMenu.buildDom({
-        items: testItems
-      });
-      expect(el).to.be.an.instanceof(Element);
-      var items = el.querySelectorAll('.mdl-menu__item');
-      expect(items.length).to.be.equal(3);
-      for (var i = 0; i < items.length; i++) {
-        expect(items[i].textContent).to.be.equal(testItems[i]);
-      }
-    });
+  it('should build a valid DOM with no parameters', function() {
+    var menu = new MaterialMenu();
+    expect(menu).to.be.an.instanceof(MaterialMenu);
+    expect(menu.root).to.be.an.instanceof(Element);
   });
 
   it('should start the showing animation on show()', function(done) {

--- a/test/unit/radio.js
+++ b/test/unit/radio.js
@@ -43,6 +43,36 @@ describe('MaterialRadio', function () {
     expect(el.classList.contains('mdl-radio--is-upgraded')).to.be.true;
   });
 
+  describe('.buildDom()', function () {
+    it('should return a valid DOM with no parameters', function() {
+      var el = MaterialRadio.buildDom();
+      expect(el).to.be.an.instanceof(Element);
+      var sw = new MaterialRadio(el);
+      expect(sw).to.be.an.instanceof(MaterialRadio);
+    });
+
+    it('should return a valid DOM with a provided id', function() {
+      var el = MaterialRadio.buildDom({
+        id: 'testId'
+      });
+      expect(el).to.be.an.instanceof(Element);
+      expect(el.querySelector('#testId')).to.not.be.null;
+      var sw = new MaterialRadio(el);
+      expect(sw).to.be.an.instanceof(MaterialRadio);
+    });
+
+    it('should return a valid DOM with a provided text', function() {
+      var el = MaterialRadio.buildDom({
+        text: 'Test radio'
+      });
+      expect(el).to.be.an.instanceof(Element);
+      expect(el.querySelector('.mdl-radio__label').text).to
+          .equal('Test radio');
+      var sw = new MaterialRadio(el);
+      expect(sw).to.be.an.instanceof(MaterialRadio);
+    });
+  });
+
   it('should get checked class after being checked', function() {
     var el = createRadio();
     var radio = new MaterialRadio(el);

--- a/test/unit/radio.js
+++ b/test/unit/radio.js
@@ -20,10 +20,10 @@ describe('MaterialRadio', function () {
     var label = document.createElement('label');
     var input = document.createElement('input');
     var labelText = document.createElement('span');
-    label.for = 'testCheckbox';
+    label.htmlFor = 'testRadio';
     label.className = 'mdl-radio';
     input.type = 'radio';
-    input.id = 'testCheckbox';
+    input.id = 'testRadio';
     input.className = 'mdl-radio__input';
     label.appendChild(input);
     labelText.className = 'mdl-radio__label';

--- a/test/unit/radio.js
+++ b/test/unit/radio.js
@@ -20,10 +20,8 @@ describe('MaterialRadio', function () {
     var label = document.createElement('label');
     var input = document.createElement('input');
     var labelText = document.createElement('span');
-    label.htmlFor = 'testRadio';
     label.className = 'mdl-radio';
     input.type = 'radio';
-    input.id = 'testRadio';
     input.className = 'mdl-radio__input';
     label.appendChild(input);
     labelText.className = 'mdl-radio__label';

--- a/test/unit/radio.js
+++ b/test/unit/radio.js
@@ -43,34 +43,10 @@ describe('MaterialRadio', function () {
     expect(el.classList.contains('mdl-radio--is-upgraded')).to.be.true;
   });
 
-  describe('.buildDom()', function () {
-    it('should return a valid DOM with no parameters', function() {
-      var el = MaterialRadio.buildDom();
-      expect(el).to.be.an.instanceof(Element);
-      var sw = new MaterialRadio(el);
-      expect(sw).to.be.an.instanceof(MaterialRadio);
-    });
-
-    it('should return a valid DOM with a provided id', function() {
-      var el = MaterialRadio.buildDom({
-        id: 'testId'
-      });
-      expect(el).to.be.an.instanceof(Element);
-      expect(el.querySelector('#testId')).to.not.be.null;
-      var sw = new MaterialRadio(el);
-      expect(sw).to.be.an.instanceof(MaterialRadio);
-    });
-
-    it('should return a valid DOM with a provided text', function() {
-      var el = MaterialRadio.buildDom({
-        text: 'Test radio'
-      });
-      expect(el).to.be.an.instanceof(Element);
-      expect(el.querySelector('.mdl-radio__label').text).to
-          .equal('Test radio');
-      var sw = new MaterialRadio(el);
-      expect(sw).to.be.an.instanceof(MaterialRadio);
-    });
+  it('should build a valid DOM with no parameters', function() {
+    var radio = new MaterialRadio();
+    expect(radio).to.be.an.instanceof(MaterialRadio);
+    expect(radio.root).to.be.an.instanceof(Element);
   });
 
   it('should get checked class after being checked', function() {

--- a/test/unit/switch.js
+++ b/test/unit/switch.js
@@ -43,34 +43,10 @@ describe('MaterialSwitch', function () {
     expect(el.classList.contains('mdl-switch--is-upgraded')).to.be.true;
   });
 
-  describe('.buildDom()', function () {
-    it('should return a valid DOM with no parameters', function() {
-      var el = MaterialSwitch.buildDom();
-      expect(el).to.be.an.instanceof(Element);
-      var sw = new MaterialSwitch(el);
-      expect(sw).to.be.an.instanceof(MaterialSwitch);
-    });
-
-    it('should return a valid DOM with a provided id', function() {
-      var el = MaterialSwitch.buildDom({
-        id: 'testId'
-      });
-      expect(el).to.be.an.instanceof(Element);
-      expect(el.querySelector('#testId')).to.not.be.null;
-      var sw = new MaterialSwitch(el);
-      expect(sw).to.be.an.instanceof(MaterialSwitch);
-    });
-
-    it('should return a valid DOM with a provided text', function() {
-      var el = MaterialSwitch.buildDom({
-        text: 'Test switch'
-      });
-      expect(el).to.be.an.instanceof(Element);
-      expect(el.querySelector('.mdl-switch__label').text).to
-          .equal('Test switch');
-      var sw = new MaterialSwitch(el);
-      expect(sw).to.be.an.instanceof(MaterialSwitch);
-    });
+  it('should build a valid DOM with no parameters', function() {
+    var sw = new MaterialSwitch();
+    expect(sw).to.be.an.instanceof(MaterialSwitch);
+    expect(sw.root).to.be.an.instanceof(Element);
   });
 
   it('should get checked class after being checked', function() {

--- a/test/unit/switch.js
+++ b/test/unit/switch.js
@@ -20,7 +20,7 @@ describe('MaterialSwitch', function () {
     var label = document.createElement('label');
     var input = document.createElement('input');
     var labelText = document.createElement('span');
-    label.for = 'testSwitch';
+    label.htmlFor = 'testSwitch';
     label.className = 'mdl-switch';
     input.type = 'checkbox';
     input.id = 'testSwitch';

--- a/test/unit/switch.js
+++ b/test/unit/switch.js
@@ -43,6 +43,36 @@ describe('MaterialSwitch', function () {
     expect(el.classList.contains('mdl-switch--is-upgraded')).to.be.true;
   });
 
+  describe('.buildDom()', function () {
+    it('should return a valid DOM with no parameters', function() {
+      var el = MaterialSwitch.buildDom();
+      expect(el).to.be.an.instanceof(Element);
+      var sw = new MaterialSwitch(el);
+      expect(sw).to.be.an.instanceof(MaterialSwitch);
+    });
+
+    it('should return a valid DOM with a provided id', function() {
+      var el = MaterialSwitch.buildDom({
+        id: 'testId'
+      });
+      expect(el).to.be.an.instanceof(Element);
+      expect(el.querySelector('#testId')).to.not.be.null;
+      var sw = new MaterialSwitch(el);
+      expect(sw).to.be.an.instanceof(MaterialSwitch);
+    });
+
+    it('should return a valid DOM with a provided text', function() {
+      var el = MaterialSwitch.buildDom({
+        text: 'Test switch'
+      });
+      expect(el).to.be.an.instanceof(Element);
+      expect(el.querySelector('.mdl-switch__label').text).to
+          .equal('Test switch');
+      var sw = new MaterialSwitch(el);
+      expect(sw).to.be.an.instanceof(MaterialSwitch);
+    });
+  });
+
   it('should get checked class after being checked', function() {
     var el = createSwitch();
     var sw = new MaterialSwitch(el);

--- a/test/unit/switch.js
+++ b/test/unit/switch.js
@@ -20,10 +20,8 @@ describe('MaterialSwitch', function () {
     var label = document.createElement('label');
     var input = document.createElement('input');
     var labelText = document.createElement('span');
-    label.htmlFor = 'testSwitch';
     label.className = 'mdl-switch';
     input.type = 'checkbox';
-    input.id = 'testSwitch';
     input.className = 'mdl-switch__input';
     label.appendChild(input);
     labelText.className = 'mdl-switch__label';


### PR DESCRIPTION
This PR adds a `buildDom` method to the base class and components, which developers can use to get back a valid DOM structure for a new component instance. This is useful to developers that are implementing a fully dynamic application and instantiate all components from JS.

@surma @Garbee WDYT? Am I taking the right approach when building the DOM, and with the options objects?