### PR TITLE
Fixes element.MaterialRadio.[un]check() calls on radio lists

### DIFF
--- a/src/radio/radio.js
+++ b/src/radio/radio.js
@@ -202,7 +202,7 @@
    */
   MaterialRadio.prototype.check = function() {
     this.btnElement_.checked = true;
-    this.onChange_();
+    this.onChange_(null);
   };
   MaterialRadio.prototype['check'] = MaterialRadio.prototype.check;
 
@@ -213,7 +213,7 @@
    */
   MaterialRadio.prototype.uncheck = function() {
     this.btnElement_.checked = false;
-    this.onChange_();
+    this.onChange_(null);
   };
   MaterialRadio.prototype['uncheck'] = MaterialRadio.prototype.uncheck;
 

--- a/src/radio/radio.js
+++ b/src/radio/radio.js
@@ -202,7 +202,7 @@
    */
   MaterialRadio.prototype.check = function() {
     this.btnElement_.checked = true;
-    this.updateClasses_();
+    this.onChange_();
   };
   MaterialRadio.prototype['check'] = MaterialRadio.prototype.check;
 
@@ -213,7 +213,7 @@
    */
   MaterialRadio.prototype.uncheck = function() {
     this.btnElement_.checked = false;
-    this.updateClasses_();
+    this.onChange_();
   };
   MaterialRadio.prototype['uncheck'] = MaterialRadio.prototype.uncheck;
 


### PR DESCRIPTION
how to reproduce:
1] have multiple MaterialRadio components with identical name
2] call MaterialRadio.check() on two of them

expected: only the second one is selected
actual: both are selected