### PR TITLE
Fixes upgradeElement() call on checkboxes and radiobuttons with ripple effect

### DIFF
--- a/src/checkbox/checkbox.js
+++ b/src/checkbox/checkbox.js
@@ -58,7 +58,6 @@
     FOCUS_HELPER: 'mdl-checkbox__focus-helper',
     TICK_OUTLINE: 'mdl-checkbox__tick-outline',
     RIPPLE_EFFECT: 'mdl-js-ripple-effect',
-    RIPPLE_IGNORE_EVENTS: 'mdl-js-ripple-effect--ignore-events',
     RIPPLE_CONTAINER: 'mdl-checkbox__ripple-container',
     RIPPLE_CENTER: 'mdl-ripple--center',
     RIPPLE: 'mdl-ripple',
@@ -230,7 +229,6 @@
       this.element_.appendChild(boxOutline);
 
       if (this.element_.classList.contains(this.CssClasses_.RIPPLE_EFFECT)) {
-        this.element_.classList.add(this.CssClasses_.RIPPLE_IGNORE_EVENTS);
         this.rippleContainerElement_ = document.createElement('span');
         this.rippleContainerElement_.classList.add(this.CssClasses_.RIPPLE_CONTAINER);
         this.rippleContainerElement_.classList.add(this.CssClasses_.RIPPLE_EFFECT);

--- a/src/radio/radio.js
+++ b/src/radio/radio.js
@@ -62,7 +62,6 @@
     RADIO_OUTER_CIRCLE: 'mdl-radio__outer-circle',
     RADIO_INNER_CIRCLE: 'mdl-radio__inner-circle',
     RIPPLE_EFFECT: 'mdl-js-ripple-effect',
-    RIPPLE_IGNORE_EVENTS: 'mdl-js-ripple-effect--ignore-events',
     RIPPLE_CONTAINER: 'mdl-radio__ripple-container',
     RIPPLE_CENTER: 'mdl-ripple--center',
     RIPPLE: 'mdl-ripple'
@@ -242,8 +241,6 @@
       var rippleContainer;
       if (this.element_.classList.contains(
           this.CssClasses_.RIPPLE_EFFECT)) {
-        this.element_.classList.add(
-            this.CssClasses_.RIPPLE_IGNORE_EVENTS);
         rippleContainer = document.createElement('span');
         rippleContainer.classList.add(
             this.CssClasses_.RIPPLE_CONTAINER);

--- a/src/ripple/ripple.js
+++ b/src/ripple/ripple.js
@@ -140,6 +140,8 @@
           this.element_.classList.contains(this.CssClasses_.RIPPLE_CENTER);
       if (!this.element_.classList.contains(
           this.CssClasses_.RIPPLE_EFFECT_IGNORE_EVENTS)) {
+        this.element_.classList.add(
+            this.CssClasses_.RIPPLE_EFFECT_IGNORE_EVENTS);
         this.rippleElement_ = this.element_.querySelector('.' +
             this.CssClasses_.RIPPLE);
         this.frameCount_ = 0;


### PR DESCRIPTION
how to replicate 1:
1] have a checkbox upgraded with upgradeDom() or automagicaly with oninit script
2] click on his label

expected: ripple works
actual: ripple broken

how to replicate 2:
1] have a checkbox upgraded with upgradeElement()
2] click on checkbox or the label

expected: ripple works
actual: ripple broken