### PR TITLE
Swapped two variable defaults

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -191,8 +191,8 @@ $layout-drawer-bg-color: unquote("rgb(#{$palette-grey-50})") !default;
 $layout-drawer-border-color: unquote("rgb(#{$palette-grey-300})") !default;
 $layout-text-color: unquote("rgb(#{$palette-grey-800})") !default;
 $layout-drawer-navigation-color: #757575 !default;
-$layout-drawer-navigation-link-active-background: unquote("rgb(#{$color-light-contrast})") !default;
-$layout-drawer-navigation-link-active-color: unquote("rgb(#{$palette-grey-300})") !default;
+$layout-drawer-navigation-link-active-background: unquote("rgb(#{$palette-grey-300})") !default;
+$layout-drawer-navigation-link-active-color: unquote("rgb(#{$color-light-contrast})") !default;
 
 // Header
 $layout-header-bg-color: unquote("rgb(#{$color-primary})") !default;


### PR DESCRIPTION
The default values of the variables `$layout-drawer-navigation-link-active-background`, and `$layout-drawer-navigation-link-active-color` were swapped.