### PR TITLE
Add issue template outlining feature request / bug reporting guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,35 @@
+** PLEASE READ THIS BEFORE FILING AN ISSUE **
+
+## Feature Requests / Breaking Changes in mdl-1.x
+
+The MDL core team has actively begun work on the next major version of MDL, dubbed **MDL v2**. Because we are a small team that's hyper-focused on delivering the best Material Design Library possible for the web, _it is highly unlikely that we will be actively working on new features or making backwards-incompatible changes for MDL as it currently exists._
+
+If there is a non-breaking feature you would like to see implemented in `mdl-1.x` and are willing to contribute, we'd be happy to offer assistance with you doing so. But we will not personally be actively working on said features.
+
+While we are just getting started with our next version of MDL, you can see our current progress on [master](https://github.com/google/material-design-lite/tree/master) as well as an overview of the direction we're headed in our [(WIP) developer guide](https://github.com/google/material-design-lite/blob/master/docs/DEVELOPER.md) as well as our [initial POC branch](https://github.com/google/material-design-lite/tree/experimental/v2-architecture-poc) for our new architecture.
+
+If you're interested in information for a specific MDL v2 component, check out our [v2-component issues](https://github.com/google/material-design-lite/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Av2-component) to see which v2 milestone it's associated with and feel free to subscribe to that issue for updates.
+
+## Bugs
+
+Please include the following information with your bug report:
+
+> What MDL Version are you using? (please be specific, e.g. _major.minor.patch_)
+
+
+> What browser(s) is this bug affecting (including version)? 
+
+
+> What OS (and version) are you using?
+
+
+> What are the steps to reproduce the bug? Can you create a plunker/codepen/jsfiddle which reproduces it?
+
+
+> What is the expected behavior?
+
+
+> What is the actual behavior?
+
+
+> Any other information you believe would be useful?


### PR DESCRIPTION
This commit adds an [Issue Template](https://github.com/blog/2111-issue-and-pull-request-templates) to this repo alerting users to
the status of features / breaking 1.x changes by the core team, as well
as bug reporting guidelines.

This will hopefully help stabilize the work being done for #4462