### PR TITLE
Remove outline border when mouse click

### DIFF
--- a/src/layout/_layout.scss
+++ b/src/layout/_layout.scss
@@ -202,6 +202,7 @@
       position: absolute;
       color: $layout-header-text-color;
       background-color: inherit;
+      outline: none;
 
       @media screen and (max-width: $layout-screen-size-threshold) {
         margin: 4px;


### PR DESCRIPTION
MDL version: **1.1.3**
Browser: **Chrome**
Browser version: **51.0.2704.106 m**
Operating system: **Windows**
Operating system version: **Windows 10**

When click the drawer button, a outline border appears. With this PR, this problem has solved.

![outline](https://cloud.githubusercontent.com/assets/16328050/16853860/b291a97e-49e4-11e6-8730-63b6ea0b349d.png)
