### PR TITLE
chore(infrastructure): Set up continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sudo: required
+language: node_js
+node_js:
+  - node # stable
+  - '4' # LTS
+branches:
+  only:
+    - master
+before_install:
+  - '[ -n "$SAUCE_ACCESS_KEY" ] || echo "NON-SECURE BUILD. Falling back to Chrome + FF only."'
+  - '[ -n "$SAUCE_ACCESS_KEY" ] || export CHROME_BIN=/usr/bin/google-chrome'
+  - '[ -n "$SAUCE_ACCESS_KEY" ] || export DISPLAY=:99.0'
+  - '[ -n "$SAUCE_ACCESS_KEY" ] || sh -e /etc/init.d/xvfb start'
+  - '[ -n "$SAUCE_ACCESS_KEY" ] || sudo apt-get update'
+  - '[ -n "$SAUCE_ACCESS_KEY" ] || sudo apt-get install -y libappindicator1 fonts-liberation'
+  - '[ -n "$SAUCE_ACCESS_KEY" ] || wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb'
+  - '[ -n "$SAUCE_ACCESS_KEY" ] || sudo dpkg -i google-chrome*.deb'
+env:
+  global:
+    - SAUCE_USERNAME=material-sauce
+    -
+      secure: aJ9IOc3ngZAujpeNdRRfEZf32tEiPJhNEt/QeoKspP+ivDDxtX4tP+5PlefnQqu5z4M1puF4A6UyiKXZJ5AThFBX0L+FP531lCNibZppyK7KZgl68O92iBooA0EZH45Pb36v9rN5Xl4ZwzJhcx8QiFWXwHp3fQHCgtoxiSdaOBt3l63Wg1vCFPSPPI/8BGiJDwxrOretholor63gMBXUoxJl2ZCMG8NnT5KF1YBzi6ZEWtMLBnuEeKxQcgi3l70UJfR9K/VTfxaoctGrc9UfmyJmD27gGHdBZc0HfZF0Z00SufXn7hILUqfaioJPzRylKxEy0h0KTeX5ZBEQNeLXSIxfcnFHbKk5OeTCkIF+cs9hUrhQfwTpoxyLNPNNeg8P2DMkUvBy/QllEuiESg3LcJlM/ziLhHJpZ7MerbSAZC91rQKX7N/2R8UkaKH6GkEMf5JtK+t1s1fgInBMfPt6oqY250GFq6QJaO/n9a5ndBnDIkjBqbUQYD+8IE793t9HjAN7XwYBk+WgLiStWR+FACLN1VLg8+9K6SfnQujOO2ZYXe2Q2Bdbwk5QqJQCvvb1WHKRMOG2+DN9A2S8zOVfGdC1B9Ih/UZXmXF0r+fEOiY2yuWhgSwd5r16KERxgnG189Gs+7kveT0gfl8SUdEXTEF+fATGEcG+RIv2LSrCNVY=
+addons:
+  firefox: latest
+  sauce_connect: true

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "karma": "^1.1.1",
     "karma-chrome-launcher": "^1.0.1",
     "karma-coverage": "^1.1.0",
+    "karma-firefox-launcher": "^1.0.0",
+    "karma-sauce-launcher": "^1.0.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-tap": "^2.0.1",
     "karma-webpack": "^1.7.0",

--- a/test/unit/mdl-auto-init/mdl-auto-init.test.js
+++ b/test/unit/mdl-auto-init/mdl-auto-init.test.js
@@ -21,7 +21,7 @@ const createFixture = () => bel`
 
 const setupTest = () => {
   mdlAutoInit.deregisterAll();
-  mdlAutoInit.register(FakeComponent.name, FakeComponent);
+  mdlAutoInit.register('FakeComponent', FakeComponent);
   return createFixture();
 };
 


### PR DESCRIPTION
* Add .travis.yml file to the repo, enabling TravisCI to run against PRs
  for master and branches of.
* Set up Sauce Labs running on the last two versions of every major
  browser (excluding Android 4 and Opera). Android 4 is quite old, and
  Opera is very similar to Chrome as it uses blink/chromium under the hood.
* Fix false negative in IE11 for mdl-auto-init test.

Part of #4464