### PR TITLE
(chore): Have stylelint ignore the build directory.

### DIFF
--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -2,6 +2,7 @@ extends: stylelint-config-standard
 ignoreFiles:
   - node_modules/**/*
   - packages/**/node_modules/**/*
+  - build/**/*
 plugins:
   - stylelint-selector-bem-pattern
   - stylelint-scss


### PR DESCRIPTION
This way when viewing the build files in an editor it won't complain about the output style.