### PR TITLE
chore(stylelint): Only allow rem for font-size.

### DIFF
--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -174,6 +174,9 @@ rules:
     - vertical-align
     - visibility
     - z-index
+  declaration-property-unit-whitelist:
+    font-size:
+      - "rem"
   # The following prefix rules are enabled since we use autoprefixer
   at-rule-no-vendor-prefix: true
   media-feature-name-no-vendor-prefix: true


### PR DESCRIPTION
REM units align with what the specification uses as `sp` closest. So we uses rem in order to adjust
to client font size changes.