### PR TITLE
chore(stylelint): Allow px for font sizes as well.

### DIFF
--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -177,6 +177,7 @@ rules:
   declaration-property-unit-whitelist:
     font-size:
       - "rem"
+      - "px"
   # The following prefix rules are enabled since we use autoprefixer
   at-rule-no-vendor-prefix: true
   media-feature-name-no-vendor-prefix: true


### PR DESCRIPTION
Some parts of the spec are defined as point units specifically, which we translate to pixels. Until
we have further guidance, these places should be obeyed as pixel.