### PR TITLE
chore(stylelint): Ignore fieldset selectors in BEM linting.

### DIFF
--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -247,6 +247,8 @@ rules:
     componentName: ^[a-z]+(?:-[a-z]+)*$
     # <namespace>-<block>__<element>*--<modifier>*[<attribute>]*
     componentSelectors: ^\.mdl?-{componentName}(?:__[a-z]+(?:-[a-z]+)*)*(?:--[a-z]+(?:-[a-z]+)*)*(?:\[.+\])*$
+    ignoreSelectors:
+      - ^fieldset
 
   # SCSS naming patterns, just like our CSS conventions above.
   # (note for $-vars we use a leading underscore for "private" variables)


### PR DESCRIPTION
We target under fieldset which throws off the BEM linter a bit. This allows us to target fieldset
disabled states without linting errors.