### PR TITLE
feat(tooltip): Initial Implementation

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -32,6 +32,7 @@
           <li><a href="radio.html">Radio</a></li>
           <li><a href="ripple.html">Ripple</a></li>
           <li><a href="theme.html">Theme</a></li>
+          <li><a href="tooltip.html">Tooltip</a></li>
           <li><a href="typography.html">Typography</a></li>
         </ul>
       </nav>

--- a/demos/tooltip.html
+++ b/demos/tooltip.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2016 Google Inc. All rights reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      https://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License
+  -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>MDL Tooltip Demo</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <style>
+      /* Make the demo look a little bit better */
+    </style>
+    <script src="assets/material-design-lite.css.js" charset="utf-8"></script>
+  </head>
+  <body>
+    <main>
+      <h1>MDL Tooltip</h1>
+      <i class="material-icons mdl-tooltip" aria-label="Favorite">favorite</i>
+      <i class="material-icons mdl-tooltip" aria-label="Plus One">plus_one</i>
+
+      <button class="mdl-fab mdl-tooltip" aria-label="Edit">
+<svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg>
+      </button>
+
+      <button class="mdl-fab mdl-fab--plain mdl-tooltip material-icons" aria-label="Edit">
+        edit
+      </button>
+    </main>
+  </body>
+</html>

--- a/packages/material-design-lite/material-design-lite.scss
+++ b/packages/material-design-lite/material-design-lite.scss
@@ -23,4 +23,5 @@
 @import "mdl-radio/mdl-radio";
 @import "mdl-ripple/mdl-ripple";
 @import "mdl-theme/mdl-theme";
+@import "mdl-tooltip/mdl-tooltip";
 @import "mdl-typography/mdl-typography";

--- a/packages/material-design-lite/package.json
+++ b/packages/material-design-lite/package.json
@@ -14,6 +14,7 @@
     "mdl-fab": "^1.0.0",
     "mdl-radio": "^1.0.0",
     "mdl-ripple": "^1.0.0",
+    "mdl-tooltip": "^1.0.0",
     "mdl-typography": "^1.0.0"
   }
 }

--- a/packages/mdl-tooltip/README.md
+++ b/packages/mdl-tooltip/README.md
@@ -1,0 +1,39 @@
+# MDL Tooltip
+
+The MDL Tooltip component is a spec-aligned tooltip component adhering to the
+[Material Design tooltip requirements](https://material.google.com/components/tooltips.html).
+It works without JavaScript.
+
+## Installation
+
+> Note: Installation via the npm registry will be available after alpha.
+
+## Usage
+
+To use the tooltip component add the class `mdl-tooltip` to any element.
+Then provide that element an `aria-label` attribute to define what the contents of the tooltip should be.
+
+```html
+<!-- Using the material icons font for a favorite icon. -->
+<i class="material-icons mdl-tooltip" aria-label="Favorite">favorite</i>
+```
+
+## Developer Notes
+
+The tooltip takes advantage of the `::after` pseudo element.
+Tooltips can only be made with elements that do not use this themselves.
+To make your components work with tooltips take advantage of only `::before` within your component code.
+
+## CSS Classes
+
+### Block
+
+The `mdl-tooltip` class is the block definition for the component.
+
+### Element
+
+This component contains no inner elements.
+
+### Modifiers
+
+This component contains no modifier classes.

--- a/packages/mdl-tooltip/mdl-tooltip.scss
+++ b/packages/mdl-tooltip/mdl-tooltip.scss
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@keyframes mdl-tooltip-fade-in {
+  from {
+    transform: scale(.9, .9) translateX(-50%);
+    opacity: 0;
+  }
+
+  to {
+    transform: scale(1, 1) translateX(-50%);
+    opacity: .9;
+  }
+}
+
+@keyframes mdl-tooltip-fade-out {
+  to {
+    transform: scale(1, 1) translateX(-50%);
+    opacity: 0;
+  }
+}
+
+/* postcss-bem-linter: define tooltip */
+.mdl-tooltip {
+  position: relative;
+
+  &::after {
+    display: flex;
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    align-items: center;
+    justify-content: center;
+    height: 32px;
+    margin-top: 24px;
+    box-sizing: border-box;
+    padding: 0 16px;
+    transform: scale(.9, .9) translateX(-50%);
+    transform-origin: -14px 50%;
+    transition:
+      opacity 75ms cubic-bezier(0, 0, .2, 1),
+      transform 0s 75ms cubic-bezier(0, 0, .2, 1);
+    border-radius: 2px;
+    background: #616161;
+    color: white;
+    font-family: Roboto, sans-serif;
+    font-size: 14px;
+    font-weight: 500;
+    content: attr(aria-label);
+    opacity: 0;
+    animation-fill-mode: forwards;
+    pointer-events: none;
+    user-select: none;
+  }
+
+  &:focus::after,
+  &:hover::after {
+    transform: scale(1, 1) translateX(-50%);
+    transition:
+      opacity 150ms cubic-bezier(0, 0, .2, 1),
+      transform 150ms cubic-bezier(0, 0, .2, 1);
+    opacity: .9;
+  }
+
+  &:hover::after {
+    transition-delay: .8s;
+  }
+
+  /* @TODO(garbee) Update this media query to use the global queries setup by theming. */
+  @media (min-width: 1024px) {
+    &::after {
+      height: 22px;
+      margin-top: 14px;
+      padding: 0 8px;
+      font-size: 10px;
+    }
+  }
+}
+
+/* postcss-bem-linter: end */

--- a/packages/mdl-tooltip/package.json
+++ b/packages/mdl-tooltip/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "mdl-tooltip",
+  "description": "Material Design tooltip component.",
+  "version": "1.0.0",
+  "license": "Apache-2.0"
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -83,6 +83,7 @@ module.exports = [{
     'mdl-fab': path.resolve('./packages/mdl-fab/mdl-fab.scss'),
     'mdl-ripple': path.resolve('./packages/mdl-ripple/mdl-ripple.scss'),
     'mdl-theme': path.resolve('./packages/mdl-theme/mdl-theme.scss'),
+    'mdl-tooltip': path.resolve('./packages/mdl-tooltip/mdl-tooltip.scss'),
     'mdl-typography': path.resolve('./packages/mdl-typography/mdl-typography.scss')
   },
   output: {


### PR DESCRIPTION
Initial CSS-only tooltip implementation.

Docs contain a "Developer Notes" section for informing developers that `::after` is tooltip's space if used. Not sure how we should name that bit, but it is at least a good start to have it documented.

Closes #4495