### PR TITLE
fix(theme): Improve mdl-theme-dark mixin.

### DIFF
--- a/packages/mdl-theme/README.md
+++ b/packages/mdl-theme/README.md
@@ -144,7 +144,7 @@ Here is the full list of colors available to the mixin:
 #### mdl-theme-dark mixin
 
 This mixin is mostly used for MDL component development, and provides a standard way of applying dark themes to
-components. It creates a suitable top-level selector for a component, and applies the provided content inside of it:
+components. It creates a suitable selector for a component, and applies the provided content inside of it:
 
 ```scss
 .mdl-foo {
@@ -157,12 +157,15 @@ components. It creates a suitable top-level selector for a component, and applie
   &__bar {
     background: black;
 
-    @include mdl-theme-dark {
+    @include mdl-theme-dark(".mdl-foo") {
       background: white;
     }
   }
 }
 ```
+
+> Note: If using the mixin on anything other than the base selector, you need to specify the base selector as a
+parameter. This ensures that the `--theme-dark` option is appended to the right class.
 
 The above generates the following CSS:
 
@@ -187,7 +190,7 @@ A user could thus apply a dark theme to a component by either targeting it speci
 <div class="mdl-foo mdl-foo--theme-dark"></div>
 ```
 
-Or by using the `mdl-theme--dark` global modifier class that affects all children:
+Or instead apply it to everything under a parent element, by using the `mdl-theme--dark` global modifier class:
 
 ```html
 <body class="mdl-theme--dark">

--- a/packages/mdl-theme/_mixins.scss
+++ b/packages/mdl-theme/_mixins.scss
@@ -35,7 +35,7 @@
 
 /**
  * Creates a rule to be used in MDL components for dark theming, and applies the provided contents.
- * Can be applied to the component, sub-components (&__foo) and options (&--foo), but only if done separately.
+ * Should provide the $root-selector option if applied to anything other than the root selector.
  *
  * Usage example:
  *
@@ -50,42 +50,25 @@
  *   &__bar {
  *     background: black;
  *
- *     @include mdl-theme-dark {
+ *     @include mdl-theme-dark(".mdl-foo") {
  *       background: white;
  *     }
  *   }
  * }
  * ```
  */
-@mixin mdl-theme-dark() {
-  $selector: #{&};
-  $component: $selector;
-
-  // Are we inside of a subcomponent (e.g. mdl-foo__bar)?
-  $index: str-index($component, "__");
-
-  @if $index {
-    $component: str-slice($component, 1, $index - 1);
-  }
-
-  // Are we inside of an option (e.g. mdl-foo--bar)?
-  $index: str-index($component, "--");
-
-  @if $index {
-    $component: str-slice($component, 1, $index - 1);
-  }
-
-  // Now $component refers to the base class (e.g. mdl-foo).
-
-  // Is the mixin being injected into the base class (e.g. mdl-foo)?
-  @if $component == $selector {
-    @at-root #{$component}--theme-dark, .mdl-theme--dark & {
-      @content;
+@mixin mdl-theme-dark($root-selector: null) {
+  @if ($root-selector) {
+    @at-root {
+      #{$root-selector}--theme-dark &,
+      .mdl-theme--dark & {
+        @content;
+      }
     }
   }
 
   @else {
-    #{$component}--theme-dark &,
+    &--theme-dark,
     .mdl-theme--dark & {
       @content;
     }


### PR DESCRIPTION
This makes the mixin less fragile, by not depending on BEM notation to
work correctly.

@traviskaufman PTAL!