### PR TITLE
fix(fab): Allow any child of a fab to align properly in all browsers.

### DIFF
--- a/packages/mdl-fab/mdl-fab.scss
+++ b/packages/mdl-fab/mdl-fab.scss
@@ -93,7 +93,18 @@
     border: 0;
   }
 
+  /*
+    This allows for using SVGs within them to align properly in all browsers.
+    Can remove once: https://bugzilla.mozilla.org/show_bug.cgi?id=1294515 is resolved.
+  */
+
   /* stylelint-disable selector-no-type */
+
+  /* postcss-bem-linter: ignore */
+  > svg {
+    width: 100%;
+  }
+
   fieldset:disabled &,
   &:disabled {
     background-color: rgba(0, 0, 0, .12);


### PR DESCRIPTION
Some browsers don't want to align an SVG child in the center. This patch allows for anything given as a child to have full width which makes all engines align them to the center of the fab. Universal selector here also allows for less overhead needing to add in an extra class for inner nodes.

Weird quirk I found in FF while finishing up tooltips.