### PR TITLE
fix(demos): Make all demos mobile-ready

### DIFF
--- a/demos/button.html
+++ b/demos/button.html
@@ -15,6 +15,7 @@
   <head>
     <meta charset="utf-8">
     <title>MDL Button Demo</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <style>
       /* Make the demo look a little bit better */

--- a/demos/card.html
+++ b/demos/card.html
@@ -18,13 +18,20 @@
   <head>
     <meta charset="utf-8">
     <title>MDL Card Demo</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <script src="assets/material-design-lite.css.js" charset="utf-8"></script>
     <style>
       .demo-card {
         max-width: 21.875rem; /* 350sp */
-        margin-bottom: 24px;
+        margin-bottom: 48px;
+      }
+
+      @media(min-width: 768px) {
+        .demo-card {
+          margin-bottom: 24px;
+        }
       }
 
       .demo-card--with-avatar .mdl-card__primary {

--- a/demos/checkbox.html
+++ b/demos/checkbox.html
@@ -18,6 +18,7 @@
   <head>
     <meta charset="utf-8">
     <title>MDL Checkbox Demo</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="assets/material-design-lite.css.js" charset="utf-8"></script>
     <style media="screen">
       section {
@@ -137,7 +138,7 @@
                 <div class="mdl-checkbox__mixedmark"></div>
               </div>
             </div>
-            <label for="my-checkbox" id="my-checkbox-label">This is my checkbox</label>
+            <label for="checkbox-dark" id="dark-checkbox-label">This is my checkbox</label>
           </div>
         </div>
         <button type="button" onclick="document.getElementById('checkbox-dark').disabled = !document.getElementById('checkbox-dark').disabled;">Toggle Disabled</button>

--- a/demos/elevation.html
+++ b/demos/elevation.html
@@ -18,6 +18,7 @@
   <head>
     <meta charset="utf-8">
     <title>MDL Elevation Demo</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="assets/material-design-lite.css.js" charset="utf-8"></script>
     <style>
       .demo-surfaces {
@@ -133,7 +134,7 @@
       </section>
       <section>
         <div id="hover-el" class="mdl-elevation--z2 mdl-elevation-transition">
-          <p>Hover over me for a transition</p>
+          <p>Hover over or tap me for a transition</p>
         </div>
       </section>
     </main>

--- a/demos/fab.html
+++ b/demos/fab.html
@@ -15,6 +15,7 @@
   <head>
     <meta charset="utf-8">
     <title>MDL FAB Demo</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <style>
       /* Make the demo look a little bit better */

--- a/demos/index.html
+++ b/demos/index.html
@@ -18,6 +18,7 @@
   <head>
     <meta charset="utf-8">
     <title>MDL Demos</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="assets/material-design-lite.css.js" charset="utf-8"></script>
   </head>
   <body>

--- a/demos/radio.html
+++ b/demos/radio.html
@@ -18,6 +18,7 @@
   <head>
     <meta charset="utf-8">
     <title>MDL Radio Demo</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="assets/material-design-lite.css.js" charset="utf-8"></script>
     <style type="text/css">
     .surface {

--- a/demos/ripple.html
+++ b/demos/ripple.html
@@ -18,6 +18,7 @@
   <head>
     <meta charset="utf-8">
     <title>MDL Ripple Demo</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="assets/material-design-lite.css.js" charset="utf-8"></script>
     <style type="text/css">
     .surface {

--- a/demos/theme.html
+++ b/demos/theme.html
@@ -18,6 +18,7 @@
   <head>
     <meta charset="utf-8">
     <title>MDL Theme Demo</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <script src="assets/material-design-lite.css.js" charset="utf-8"></script>
@@ -46,7 +47,15 @@
         padding: 16px;
         border: 1px solid black;
         align-items: center;
+        flex-direction: column;
       }
+
+      @media(min-width: 768px) {
+        .demo-theme__text-styles {
+          flex-direction: row;
+        }
+      }
+
       .demo-theme__text-styles > span {
         padding: 0 16px;
       }

--- a/demos/typography.html
+++ b/demos/typography.html
@@ -18,6 +18,7 @@
   <head>
     <meta charset="utf-8">
     <title>MDL Typography Demo</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <script src="assets/material-design-lite.css.js" charset="utf-8"></script>
@@ -31,7 +32,15 @@
         display: flex;
         align-items: center;
         justify-content: space-between;
+        flex-direction: column;
       }
+
+      @media(min-width: 768px) {
+        .demo-typography--color-styles {
+          flex-direction: row;
+        }
+      }
+
       .demo-typography--light-bg {
         background-color: #fafafa;
       }

--- a/packages/mdl-button/mdl-button.scss
+++ b/packages/mdl-button/mdl-button.scss
@@ -41,6 +41,7 @@
   vertical-align: middle;
   box-sizing: border-box;
   -webkit-appearance: none;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 
   @include mdl-theme-dark {
     @include mdl-theme-prop(color, text-primary-on-dark);
@@ -112,6 +113,7 @@
           This should be the 700-shade when active instead of a black shade.
           Due to the complexity involved in adhering fully it is being ignored.
           Instead re-using the existing architecture for shading works just fine.
+          - With <3 from Garbee
         */
         color: black;
       }


### PR DESCRIPTION
Add meta viewport and any additional demo-only CSS so they can be ran in mobile emualtion and on-devices properly.

Just need one LGTM here from someone. Changes are fairly trivial and demo-specific for manual testing purposes.