### PR TITLE
fix(fab): Remove webkit (and blink) tap target highlight.

### DIFF
--- a/packages/mdl-fab/mdl-fab.scss
+++ b/packages/mdl-fab/mdl-fab.scss
@@ -39,6 +39,7 @@
   fill: currentColor;
   -moz-appearance: none;
   -webkit-appearance: none;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 
   &--mini {
     width: 40px;


### PR DESCRIPTION
The highlight is not needed since we provide active state directly.

Just one LGTM please for such a minor change.