### PR TITLE
fix(theme): Fix CSS custom property bugs in theming.

### DIFF
--- a/packages/mdl-theme/_mixins.scss
+++ b/packages/mdl-theme/_mixins.scss
@@ -30,7 +30,7 @@
   }
 
   #{$property}: map-get($mdl-theme-property-values, $style);
-  #{$property}: var(--mdl-theme-#{$style});
+  #{$property}: var(--mdl-theme-#{$style}, map-get($mdl-theme-property-values, $style));
 }
 
 /**

--- a/packages/mdl-theme/mdl-theme.scss
+++ b/packages/mdl-theme/mdl-theme.scss
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@import "./variables";
+@import "./mixins";
 
 :root {
   @each $style in map-keys($mdl-theme-property-values) {
@@ -24,13 +24,13 @@
 
 /* Special case, so that .mdl-theme--background changes background color, not text color. */
 .mdl-theme--background {
-  background-color: map-get($mdl-theme-property-values, background);
+  @include mdl-theme-prop(background-color, background);
 }
 
 @each $style in map-keys($mdl-theme-property-values) {
   @if $style != "background" {
     .mdl-theme--#{$style} {
-      color: map-get($mdl-theme-property-values, $style);
+      @include mdl-theme-prop(color, $style);
     }
   }
 }
@@ -38,6 +38,6 @@
 /* CSS rules for using primary and accent as background colors. */
 @each $style in ("primary", "accent") {
   .mdl-theme--#{$style}-bg {
-    background-color: map-get($mdl-theme-property-values, $style);
+    @include mdl-theme-prop(background-color, $style);
   }
 }


### PR DESCRIPTION
This commit fixes two bugs:
- Generated CSS classes were not using custom properties.
- The theme mixin was not adding a default value to the custom
  property access, thus causing problems when the custom
  property was not defined.

@Garbee Sorry for forgetting about the latter after we'd talked about it!