### PR TITLE
chore(package.json): add babel-loader because it is a peerdependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 /coverage
 packages/*/dist
 *.log
+.idea

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "autoprefixer": "^6.3.6",
+    "babel-core": "^6.0.0",
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",


### PR DESCRIPTION
got an error during npm install: babel-loader@6.2.5 requires a peer of babel-core@^6.0.0 but none was installed. This unmet peer dependency results in javascript load errors in the demos and the angular2 examples.

from https://github.com/babel/babel-loader:

> Note: npm deprecated auto-installing of peerDependencies since npm@3, so required peer dependencies like babel-core and webpack must be listed explicitly in your package.json

.