### PR TITLE
feat(snackbar): add initial mdl-snackbar implementation.

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -36,6 +36,7 @@
           <li><a href="icon-toggle.html">Icon Toggle</a></li>
           <li><a href="list.html">List</a></li>
           <li><a href="radio.html">Radio</a></li>
+          <li><a href="snackbar.html">Snackbar</a></li>
           <li><a href="ripple.html">Ripple</a></li>
           <li><a href="theme.html">Theme</a></li>
           <li><a href="typography.html">Typography</a></li>

--- a/demos/snackbar.html
+++ b/demos/snackbar.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2016 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License
+-->
+<html class="mdl-typography">
+  <head>
+    <meta charset="utf-8">
+    <title>MDL Snackbar Demo</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <style>
+      .mdl-snackbar { transform: translateY(100%); }
+    </style>
+    <script src="assets/material-design-lite.css.js" charset="utf-8"></script>
+  </head>
+  <body>
+    <main>
+      <h1>MDL Snackbar</h1>
+      <section>
+        <h2>Basic Example</h2>
+        <div>
+          <div class="mdl-checkbox-wrapper">
+            <div class="mdl-checkbox-wrapper__layout">
+              <div class="mdl-checkbox">
+                <input type="checkbox"
+                       class="mdl-checkbox__native-control"
+                       id="multiline"
+                       aria-labelledby="multiline-label" />
+                <div class="mdl-checkbox__background">
+                  <svg version="1.1" class="mdl-checkbox__checkmark"
+                       xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                       xml:space="preserve">
+                    <path class="mdl-checkbox__checkmark__path" fill="none" stroke="white"
+                          d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+                  </svg>
+                <div class="mdl-checkbox__mixedmark"></div>
+              </div>
+            </div>
+            <label for="multiline" id="multiline-label">Multiline</label>
+          </div>
+
+          <div class="mdl-checkbox-wrapper">
+            <div class="mdl-checkbox-wrapper__layout">
+              <div class="mdl-checkbox">
+                <input type="checkbox"
+                       class="mdl-checkbox__native-control"
+                       id="action-on-bottom"
+                       aria-labelledby="action-on-bottom-label" />
+                <div class="mdl-checkbox__background">
+                  <svg version="1.1" class="mdl-checkbox__checkmark"
+                       xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                       xml:space="preserve">
+                    <path class="mdl-checkbox__checkmark__path" fill="none" stroke="white"
+                          d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+                  </svg>
+                <div class="mdl-checkbox__mixedmark"></div>
+              </div>
+            </div>
+            <label for="action-on-bottom" id="action-on-bottom-label">Action On Bottom</label>
+          </div>
+        </div>
+
+        <div>
+          <label for="message">Message Text</label>
+          <input type="text" id="message" value="Message deleted">
+        </div>
+
+        <div>
+          <label for="action">Action Text</label>
+          <input type="text" id="action" value="Undo">
+        </div>
+
+        <button type="button" id="show-snackbar">Show</button>
+        <button type="button" id="show-rtl-snackbar">Show RTL</button>
+
+        <div id="mdl-js-snackbar"
+             class="mdl-snackbar"
+             aria-live="assertive"
+             aria-atomic="true"
+             aria-hidden="true">
+          <div class="mdl-snackbar__text"></div>
+          <div class="mdl-snackbar__action-wrapper">
+            <button type="button" class="mdl-button mdl-snackbar__action-button"></button>
+          </div>
+        </div>
+        <div dir="rtl">
+          <div id="mdl-rtl-js-snackbar"
+               class="mdl-snackbar"
+               aria-live="assertive"
+               aria-atomic="true"
+               aria-hidden="true">
+            <div class="mdl-snackbar__text"></div>
+            <div class="mdl-snackbar__action-wrapper">
+              <button type="button" class="mdl-button mdl-snackbar__action-button"></button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <script src="assets/material-design-lite.js" charset="utf-8"></script>
+    <script>
+      (function(global) {
+        'use strict';
+        var snackbar = new global.mdl.Snackbar(document.getElementById('mdl-js-snackbar'));
+        var rtlSnackbar = new global.mdl.Snackbar(document.getElementById('mdl-rtl-js-snackbar'));
+        var messageInput = document.getElementById('message');
+        var actionInput = document.getElementById('action');
+        var multilineInput = document.getElementById('multiline');
+        var actionOnBottomInput = document.getElementById('action-on-bottom');
+
+        var show = function(sb) {
+          var data =  {
+            message: messageInput.value,
+            actionOnBottom: actionOnBottomInput.checked,
+            multiline: multilineInput.checked
+          };
+          if (actionInput.value) {
+            data.actionText = actionInput.value;
+            data.actionHandler = function() {
+              console.log(data);
+            }
+          }
+          sb.show(data);
+        };
+
+        document.getElementById('show-snackbar').addEventListener('click', function() {
+          show(snackbar);
+        });
+
+        document.getElementById('show-rtl-snackbar').addEventListener('click', function() {
+          show(rtlSnackbar);
+        });
+      })(this);
+    </script>
+  </body>
+</html>

--- a/examples/vue/src/App.vue
+++ b/examples/vue/src/App.vue
@@ -18,11 +18,15 @@
   <div>
    <p>Change count: {{changeCount}}</p>
   </div>
+
+  <button type="button" @click="showSnackbar">Show Snackbar</button>
+  <snackbar event='mailSent'></snackbar>
 </div>
 </template>
 
 <script lang="babel">
 import Ripple from './v-mdl-ripple/Ripple';
+import Snackbar from './v-mdl-snackbar/Snackbar';
 import Checkbox from './v-mdl-checkbox/Checkbox';
 import CheckboxLabel from './v-mdl-checkbox/CheckboxLabel';
 import CheckboxWrapper from './v-mdl-checkbox/CheckboxWrapper';
@@ -36,11 +40,20 @@ export default {
       changeCount: 0
     }
   },
-  components: { Checkbox, CheckboxWrapper, CheckboxLabel },
+  components: { Checkbox, CheckboxWrapper, CheckboxLabel, Snackbar },
   directives: { Ripple },
   watch: {
     checked () {
       this.changeCount++;
+    }
+  },
+  methods: {
+    showSnackbar () {
+      this.$root.$emit('mailSent', {
+        message: 'Mail Sent',
+        actionText: 'Undo',
+        actionHandler: () => console.log('Undo it')
+      });
     }
   }
 }

--- a/examples/vue/src/v-mdl-snackbar/Snackbar.vue
+++ b/examples/vue/src/v-mdl-snackbar/Snackbar.vue
@@ -1,0 +1,102 @@
+
+<template>
+<div ref="root" class="mdl-snackbar" :class="classes" aria-live="assertive" aria-atomic="true" :aria-hidden="hidden">
+  <div class="mdl-snackbar__text">{{message}}</div>
+  <div class="mdl-snackbar__action-wrapper">
+    <button type="button" @click="actionClicked" class="mdl-button mdl-snackbar__action-button" :aria-hidden="actionHidden">{{actionText}}</button>
+</div>
+</template>
+
+<script lang="babel">
+import { MDLSnackbarFoundation } from 'mdl-snackbar';
+
+const { TRANS_END_EVENT_NAME } = MDLSnackbarFoundation.strings;
+
+export default {
+  props: {
+    event: String,
+    eventSource: {
+      required: false,
+      default () {
+        return this.$root;
+      }
+    }
+  },
+  data () {
+    return {
+      classes: {},
+      message: '',
+      actionText: '',
+      hidden: false,
+      actionHidden: false,
+      animHandlers: [],
+      actionClickHandlers: [],
+      foundation: null
+    };
+  },
+  mounted () {
+    let vm = this;
+    this.foundation = new MDLSnackbarFoundation({
+      addClass (className) {
+        vm.$set(vm.classes, className, true);
+      },
+      removeClass (className) {
+        vm.$delete(vm.classes, className);
+      },
+      setAriaHidden () {
+        vm.hidden = true;
+      },
+      unsetAriaHidden () {
+        vm.hidden = false;
+      },
+      setActionAriaHidden () {
+        vm.actionHidden = true;
+      },
+      unsetActionAriaHidden () {
+        vm.actionHidden = false;
+      },
+      setMessageText (message) {
+        vm.message = message;
+      },
+      setActionText (actionText) {
+        vm.actionText = actionText;
+      },
+      registerActionClickHandler (handler) {
+        vm.actionClickHandlers.push(handler);
+      },
+      deregisterChangeHandler (handler) {
+        let index = vm.actionClickHandlers.indexOf(handler);
+        if (index >= 0) {
+          vm.actionClickHandlers.splice(index, 1)
+        }
+      },
+      registerTransitionEndHandler (handler) {
+        vm.$refs.root.addEventListener(TRANS_END_EVENT_NAME, handler);
+      },
+      deregisterTransitionEndHandler (handler) {
+        vm.$refs.root.removeEventListener(TRANS_END_EVENT_NAME, handler);
+      }
+    });
+    this.foundation.init();
+
+    this.eventSource.$on(this.event, (data) => {
+      this.foundation.show(data)
+    });
+  },
+  beforeUnmount () {
+    this.foundation.destroy();
+  },
+  methods: {
+    actionClicked (event) {
+      this.actionClickHandlers.forEach((h) => h(event));
+    }
+  }
+}
+
+</script>
+
+<style lang="scss">
+@import 'mdl-button/mdl-button.scss';
+@import 'mdl-snackbar/mdl-snackbar.scss';
+
+</style>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "mkdirp build && webpack",
     "build:min": "mkdirp build && cross-env MDL_ENV=production webpack -p",
     "dist": "npm run clean && npm run build && npm run build:min",
-    "dev": "npm run clean && cross-env MDL_ENV=development webpack-dev-server --content-base demos --inline --hot",
+    "dev": "npm run clean && cross-env MDL_ENV=development webpack-dev-server --content-base demos --inline --hot --host 0.0.0.0",
     "fix:js": "eslint --fix packages test webpack.config.js karma.conf.js",
     "fix:css": "stylefmt -R packages",
     "fix": "npm-run-all --parallel fix:*",

--- a/packages/material-design-lite/index.js
+++ b/packages/material-design-lite/index.js
@@ -20,6 +20,7 @@ import IconToggle from 'mdl-icon-toggle';
 import Radio from 'mdl-radio';
 import Ripple from 'mdl-ripple';
 import {MDLTemporaryDrawer as TemporaryDrawer} from 'mdl-drawer';
+import Snackbar from 'mdl-snackbar';
 import autoInit from 'mdl-auto-init';
 
 // Register all components
@@ -28,6 +29,7 @@ autoInit.register('MDLTemporaryDrawer', TemporaryDrawer);
 autoInit.register('MDLRipple', Ripple);
 autoInit.register('MDLIconToggle', IconToggle);
 autoInit.register('MDLRadio', Radio);
+autoInit.register('MDLSnackbar', Snackbar);
 
 // Export all components.
 export {
@@ -36,6 +38,7 @@ export {
   IconToggle,
   Radio,
   Ripple,
+  Snackbar,
   TemporaryDrawer,
   autoInit
 };

--- a/packages/material-design-lite/package.json
+++ b/packages/material-design-lite/package.json
@@ -16,6 +16,7 @@
     "mdl-icon-toggle": "^1.0.0",
     "mdl-radio": "^1.0.0",
     "mdl-ripple": "^1.0.0",
+    "mdl-snackbar": "^1.0.0",
     "mdl-typography": "^1.0.0"
   }
 }

--- a/packages/mdl-snackbar/README.md
+++ b/packages/mdl-snackbar/README.md
@@ -1,0 +1,139 @@
+# MDL Snackbar
+
+The MDL Snackbar component is a spec-aligned snackbar/toast component adhering to the
+[Material Design snackbars & toasts requirements](https://material.google.com/components/snackbars-toasts.html#snackbars-toasts-specs).
+It requires JavaScript the trigger the display and hide of the snackbar.
+
+## Installation
+
+> Note: Installation via the npm registry will be available after alpha.
+
+## Usage
+
+### Snackbar DOM
+
+```html
+<div class="mdl-snackbar"
+     aria-live="assertive"
+     aria-atomic="true"
+     aria-hidden="true">
+  <div class="mdl-snackbar__text"></div>
+  <div class="mdl-snackbar__action-wrapper">
+    <button type="button" class="mdl-button mdl-snackbar__action-button"></button>
+  </div>
+</div>
+```
+
+### Using the JS Component
+
+MDL Snackbar ships with a Component / Foundation combo which provides the API for showing snackbar
+messages with optional action.
+
+#### Including in code
+
+##### ES2015
+
+```javascript
+import MDLSnackbar, {MDLSnackbarFoundation} from 'mdl-snackbar';
+```
+
+##### CommonJS
+
+```javascript
+const mdlSnackbar = require('mdl-snackbar');
+const MDLSnackbar = mdlSnackbar.default;
+const MDLSnackbarFoundation = mdlSnackbar.MDLSnackbarFoundation;
+```
+
+##### AMD
+
+```javascript
+require(['path/to/mdl-snackbar'], mdlSnackbar => {
+  const MDLSnackbar = mdlSnackbar.default;
+  const MDLSnackbarFoundation = mdlSnackbar.MDLSnackbarFoundation;
+});
+```
+
+##### Global
+
+```javascript
+const MDLSnackbar = mdl.Snackbar.default;
+const MDLSnackbarFoundation = mdl.Snackbar.MDLSnackbarFoundation;
+```
+
+#### Fully-automatic: DOM Rendering + Initialization
+
+```javascript
+const root = MDLSnackbar.buildDom();
+const snackbar = MDLSnackbar.attachTo(root);
+// append root to element, etc...
+```
+
+You can use `MDLSnackbar.buildDom` to dynamically construct snackbar DOM for you.
+
+#### Using an existing element.
+
+If you do not care about retaining the component instance for the snackbar, simply call `attachTo()`
+and pass it a DOM element.  
+
+```javascript
+mdl.Snackbar.attachTo(document.querySelector('.mdl-snackbar'));
+```
+
+#### Manual Instantiation
+
+Snackbars can easily be initialized using their default constructors as well, similar to `attachTo`.
+
+```javascript
+import MDLSnackbar from 'mdl-snackbar';
+
+const snackbar = new MDLSnackbar(document.querySelector('.mdl-snackbar'));
+```
+
+### Showing a message and action
+
+Once you have obtained an MDLSnackbar instance attached to the DOM, you can use
+the `show` method to trigger the display of a message with optional action. The
+`show`  method takes an object for snackbar data. The table below shows the
+properties and their usage.
+
+| Property | Effect | Remarks | Type |
+|-----------|--------|---------|---------|
+| message   | The text message to display. | Required | String |
+| timeout   | The amount of time in milliseconds to show the snackbar. | Optional (default 2750) | Integer |
+| actionHandler | The function to execute when the action is clicked. | Optional | Function |
+| actionText | The text to display for the action button. | Required if actionHandler is set |  String |
+| multiline | Whether to show the snackbar with space for multiple lines of text | Optional |  Boolean |
+| actionOnBottom | Whether to show the action below the multiple lines of text | Optional, applies when multiline is true |  Boolean |
+
+### Using the Foundation Class
+
+MDL Snackbar ships with an `MDLSnackbarFoundation` class that external frameworks and libraries can
+use to integrate the component. As with all foundation classes, an adapter object must be provided.
+The adapter for snackbars must provide the following functions, with correct signatures:
+
+| Method Signature | Description |
+| --- | --- |
+| `addClass(className: string) => void` | Adds a class to the root element. |
+| `removeClass(className: string) => void` | Removes a class from the root element. |
+| `setAriaHidden() => void` | Sets `aria-hidden="true"` on the root element. |
+| `unsetAriaHidden() => void` | Removes the `aria-hidden` attribute from the root element. |
+| `setMessageText(message: string) => void` | Set the text content of the message element. |
+| `setActionText(actionText: string) => void` | Set the text content of the action element. |
+| `setActionAriaHidden() => void` | Sets `aria-hidden="true"` on the action element. |
+| `unsetActionAriaHidden() => void` | Removes the `aria-hidden` attribute from the action element. |
+| `registerActionClickHandler(handler: EventListener) => void` | Registers an event handler to be called when a `click` event is triggered on the action element. |
+| `deregisterActionClickHandler(handler: EventListener) => void` | Deregisters an event handler from a `click` event on the action element. This will only be called with handlers that have previously been passed to `registerActionClickHandler` calls. |
+| `registerTransitionEndHandler(handler: EventListener) => void` | Registers an event handler to be called when an `transitionend` event is triggered on the root element. Note that you must account for vendor prefixes in order for this to work correctly. |
+| `deregisterTransitionEndHandler(handler: EventListener) => void` | Deregisters an event handler from an `transitionend` event listener. This will only be called with handlers that have previously been passed to `registerTransitionEndHandler` calls. |
+
+## Avoiding Flash-Of-Unstyled-Content (FOUC)
+
+If you are loading the `mdl-snackbar` CSS asynchronously, you may experience a brief flash-of-unstyled-content (FOUC) due to the
+snackbar's translate transition running once the CSS loads. To avoid this temporary FOUC, you can add the following simple style
+before the `mdl-snackbar` CSS is loaded:
+
+```css
+.mdl-snackbar { transform: translateY(100%); }
+```
+This will move the snackbar offscreen until the CSS is fully loaded and avoids a translate transition upon load.

--- a/packages/mdl-snackbar/_variables.scss
+++ b/packages/mdl-snackbar/_variables.scss
@@ -14,17 +14,9 @@
  * limitations under the License.
  */
 
-@import "mdl-animation/mdl-animation";
-@import "mdl-button/mdl-button";
-@import "mdl-card/mdl-card";
-@import "mdl-checkbox/mdl-checkbox";
-@import "mdl-drawer/mdl-drawer";
-@import "mdl-elevation/mdl-elevation";
-@import "mdl-fab/mdl-fab";
-@import "mdl-icon-toggle/mdl-icon-toggle";
-@import "mdl-list/mdl-list";
-@import "mdl-radio/mdl-radio";
-@import "mdl-ripple/mdl-ripple";
-@import "mdl-snackbar/mdl-snackbar";
-@import "mdl-theme/mdl-theme";
-@import "mdl-typography/mdl-typography";
+// Hard coded since the color is not present in any palette.
+$mdl-snackbar-background-color: #323232;
+$mdl-snackbar-foreground-color: white;
+// TODO: Better spot to pull this breakpoint?
+//$snackbar-tablet-breakpoint: $grid-tablet-breakpoint;
+$mdl-snackbar-tablet-breakpoint: 600px;

--- a/packages/mdl-snackbar/constants.js
+++ b/packages/mdl-snackbar/constants.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const ROOT = 'mdl-snackbar';
+
+export const cssClasses = {
+  ROOT,
+  TEXT: `${ROOT}__text`,
+  ACTION_WRAPPER: `${ROOT}__action-wrapper`,
+  ACTION_BUTTON: `${ROOT}__action-button`,
+  ACTIVE: `${ROOT}--active`,
+  MULTILINE: `${ROOT}--multiline`,
+  ACTION_ON_BOTTOM: `${ROOT}--action-on-bottom`
+};
+
+export const strings = {
+  get TRANS_END_EVENT_NAME() {
+    const el = document.createElement('div');
+    // NOTE: We can immediately assume that the prefix is 'webkit' in browsers that don't
+    // support unprefixed transtions since the only browsers up to two major versions back that
+    // don't support unprefixed names are mobile Safari and Android native browser, both of
+    // which use the 'webkit' prefix.
+    return 'transition' in el.style ? 'transitionend' : 'webkitTransitionEnd';
+  },
+
+  get TEXT_SELECTOR() {
+    return `.${cssClasses.TEXT}`;
+  },
+
+  get ACTION_WRAPPER_SELECTOR() {
+    return `.${cssClasses.ACTION_WRAPPER}`;
+  },
+
+  get ACTION_BUTTON_SELECTOR() {
+    return `.${cssClasses.ACTION_BUTTON}`;
+  }
+};
+
+export const numbers = {
+  MESSAGE_TIMEOUT: 2750
+};

--- a/packages/mdl-snackbar/foundation.js
+++ b/packages/mdl-snackbar/foundation.js
@@ -1,0 +1,157 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {MDLFoundation} from 'mdl-base';
+import {cssClasses, strings, numbers} from './constants';
+
+export default class MDLSnackbarFoundation extends MDLFoundation {
+  static get cssClasses() {
+    return cssClasses;
+  }
+
+  static get strings() {
+    return strings;
+  }
+
+  static get defaultAdapter() {
+    return {
+      addClass: (/* className: string */) => {},
+      removeClass: (/* className: string */) => {},
+      setAriaHidden: () => {},
+      unsetAriaHidden: () => {},
+      setMessageText: (/* message: string */) => {},
+      setActionText: (/* actionText: string */) => {},
+      setActionAriaHidden: () => {},
+      unsetActionAriaHidden: () => {},
+      registerActionClickHandler: (/* handler: EventListener */) => {},
+      deregisterActionClickHandler: (/* handler: EventListener */) => {},
+      registerTransitionEndHandler: (/* handler: EventListener */) => {},
+      deregisterTransitionEndHandler: (/* handler: EventListener */) => {}
+    };
+  }
+
+  get active() {
+    return this.active_;
+  }
+
+  constructor(adapter) {
+    super(Object.assign(MDLSnackbarFoundation.defaultAdapter, adapter));
+
+    this.active_ = false;
+    this.queue_ = [];
+    this.actionClickHandler_ = () => this.invokeAction_();
+  }
+
+  init() {
+    this.adapter_.registerActionClickHandler(this.actionClickHandler_);
+    this.adapter_.setAriaHidden();
+    this.adapter_.setActionAriaHidden();
+  }
+
+  destroy() {
+    this.adapter_.deregisterActionClickHandler(this.actionClickHandler_);
+  }
+
+  show(data) {
+    if (!data) {
+      throw new Error(
+        'Please provide a data object with at least a message to display.');
+    }
+    if (!data.message) {
+      throw new Error('Please provide a message to be displayed.');
+    }
+    if (data.actionHandler && !data.actionText) {
+      throw new Error('Please provide action text with the handler.');
+    }
+
+    if (this.active) {
+      this.queue_.push(data);
+      return;
+    }
+
+    const {ACTIVE, MULTILINE, ACTION_ON_BOTTOM} = cssClasses;
+    const {MESSAGE_TIMEOUT} = numbers;
+
+    this.adapter_.setMessageText(data.message);
+
+    if (data.multiline) {
+      this.adapter_.addClass(MULTILINE);
+      if (data.actionOnBottom) {
+        this.adapter_.addClass(ACTION_ON_BOTTOM);
+      }
+    }
+
+    if (data.actionHandler) {
+      this.adapter_.setActionText(data.actionText);
+      this.actionHandler_ = data.actionHandler;
+      this.setActionHidden_(false);
+    } else {
+      this.setActionHidden_(true);
+      this.actionHandler_ = null;
+      this.adapter_.setActionText(null);
+    }
+
+    this.active_ = true;
+    this.adapter_.addClass(ACTIVE);
+    this.adapter_.unsetAriaHidden();
+
+    setTimeout(this.cleanup_.bind(this), data.timeout || MESSAGE_TIMEOUT);
+  }
+
+  invokeAction_() {
+    if (!this.actionHandler_) {
+      return;
+    }
+
+    this.actionHandler_();
+  }
+
+  cleanup_() {
+    const {ACTIVE, MULTILINE, ACTION_ON_BOTTOM} = cssClasses;
+
+    this.adapter_.removeClass(ACTIVE);
+
+    const handler = () => {
+      this.adapter_.deregisterTransitionEndHandler(handler);
+      this.adapter_.removeClass(MULTILINE);
+      this.adapter_.removeClass(ACTION_ON_BOTTOM);
+      this.setActionHidden_(true);
+      this.adapter_.setMessageText(null);
+      this.adapter_.setActionText(null);
+      this.adapter_.setAriaHidden();
+      this.active_ = false;
+      this.showNext_();
+    };
+
+    this.adapter_.registerTransitionEndHandler(handler);
+  }
+
+  showNext_() {
+    if (!this.queue_.length) {
+      return;
+    }
+
+    this.show(this.queue_.shift());
+  }
+
+  setActionHidden_(isHidden) {
+    if (isHidden) {
+      this.adapter_.setActionAriaHidden();
+    } else {
+      this.adapter_.unsetActionAriaHidden();
+    }
+  }
+}

--- a/packages/mdl-snackbar/index.js
+++ b/packages/mdl-snackbar/index.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDLComponent from 'mdl-base';
+import MDLSnackbarFoundation from './foundation';
+
+export {MDLSnackbarFoundation};
+
+export default class MDLSnackbar extends MDLComponent {
+  static buildDom() {
+    const {ROOT: CSS_ROOT, TEXT, ACTION_WRAPPER, ACTION_BUTTON} = MDLSnackbarFoundation.cssClasses;
+
+    const root = document.createElement('div');
+    root.classList.add(CSS_ROOT);
+    root.setAttribute('aria-live', 'assertive');
+    root.setAttribute('aria-atomic', 'true');
+    root.setAttribute('aria-hidden', 'true');
+    root.innerHTML = `
+      <div class="${TEXT}"></div>
+      <div class="${ACTION_WRAPPER}">
+        <button type="button" class="mdl-button ${ACTION_BUTTON}"></button>
+      </div>
+    `;
+
+    return root;
+  }
+
+  static attachTo(root) {
+    return new MDLSnackbar(root);
+  }
+
+  show(data) {
+    this.foundation_.show(data);
+  }
+
+  getDefaultFoundation() {
+    const {
+      TRANS_END_EVENT_NAME,
+      TEXT_SELECTOR,
+      ACTION_BUTTON_SELECTOR
+    } = MDLSnackbarFoundation.strings;
+    const getText = () => this.root_.querySelector(TEXT_SELECTOR);
+    const getActionButton = () => this.root_.querySelector(ACTION_BUTTON_SELECTOR);
+
+    /* eslint brace-style: "off" */
+    return new MDLSnackbarFoundation({
+      addClass: className => this.root_.classList.add(className),
+      removeClass: className => this.root_.classList.remove(className),
+      setAriaHidden: () => this.root_.setAttribute('aria-hidden', 'true'),
+      unsetAriaHidden: () => this.root_.removeAttribute('aria-hidden'),
+      setActionAriaHidden: () => getActionButton().setAttribute('aria-hidden', 'true'),
+      unsetActionAriaHidden: () => getActionButton().removeAttribute('aria-hidden'),
+      setActionText: text => { getActionButton().textContent = text; },
+      setMessageText: text => { getText().textContent = text; },
+      registerActionClickHandler: handler => getActionButton().addEventListener('click', handler),
+      deregisterActionClickHandler: handler => getActionButton().removeEventListener('click', handler),
+      registerTransitionEndHandler: handler => this.root_.addEventListener(TRANS_END_EVENT_NAME, handler),
+      deregisterTransitionEndHandler: handler => this.root_.removeEventListener(TRANS_END_EVENT_NAME, handler)
+    });
+  }
+}

--- a/packages/mdl-snackbar/mdl-snackbar.scss
+++ b/packages/mdl-snackbar/mdl-snackbar.scss
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import "mdl-animation/mixins";
+@import "mdl-theme/mixins";
+@import "mdl-typography/mixins";
+@import "./variables";
+
+/* stylelint-disable scss/dollar-variable-pattern, scss/at-mixin-pattern */
+@mixin _mdl-snackbar-reflexive-margin($default-side, $value, $reset-opposite-margin: true) {
+  @if (index((right, left), $default-side) == null) {
+    @error "Invalid default margin side #{default-side}. Please specifiy either right or left";
+  }
+
+  $rtl-side: left;
+
+  @if ($default-side == left) {
+    $rtl-side: right;
+  }
+
+  margin-#{$default-side}: $value;
+  [dir="rtl"] & {
+    margin-#{$rtl-side}: $value;
+
+    @if ($reset-opposite-margin) {
+      margin-#{$default-side}: 0;
+    }
+  }
+}
+
+/* stylelint-enable scss/dollar-variable-pattern, scss/at-mixin-pattern */
+
+/* postcss-bem-linter: define snackbar */
+.mdl-snackbar {
+  display: flex;
+  position: fixed;
+  bottom: 0;
+  left: 50%;
+  align-items: center;
+  justify-content: flex-start;
+  padding-right: 24px;
+  padding-left: 24px;
+  transform: translate(0, 100%);
+  transition: transform .25s $mdl-animation-fast-out-linear-in-timing-function;
+  background-color: $mdl-snackbar-background-color;
+  will-change: transform;
+  pointer-events: none;
+
+  @media (max-width: ($mdl-snackbar-tablet-breakpoint - 1)) {
+    left: 0;
+    width: calc(100% - 48px);
+  }
+
+  @media (min-width: $mdl-snackbar-tablet-breakpoint) {
+    min-width: 288px;
+    max-width: 568px;
+    transform: translate(-50%, 100%);
+    border-radius: 2px;
+  }
+
+  &--active {
+    transform: translate(0, 0);
+    pointer-events: auto;
+    transition: transform .25s $mdl-animation-linear-out-slow-in-timing-function;
+
+    @media (min-width: $mdl-snackbar-tablet-breakpoint) {
+      transform: translate(-50%, 0);
+    }
+  }
+
+  &--action-on-bottom {
+    flex-direction: column;
+  }
+
+  &--action-on-bottom &__text {
+    margin-right: inherit;
+  }
+
+  &--action-on-bottom &__action-wrapper {
+    flex-direction: column;
+    justify-content: flex-start;
+    margin-top: -12px;
+    margin-bottom: 8px;
+    margin-left: auto;
+  }
+
+  &__text {
+    @include mdl-typography(body1);
+    @include _mdl-snackbar-reflexive-margin(right, auto, true);
+    display: flex;
+    align-items: center;
+    height: 48px;
+    transition: opacity .3s $mdl-animation-fast-out-linear-in-timing-function;
+    color: $mdl-snackbar-foreground-color;
+    opacity: 0;
+  }
+
+  &--active &__text {
+    opacity: 1;
+  }
+
+  &--multiline &__text {
+    height: 80px;
+  }
+
+  &__action-button {
+    @include mdl-theme-prop(color, accent);
+    min-width: auto;
+    height: inherit;
+    margin-right: -16px;
+    transition: opacity .3s $mdl-animation-fast-out-linear-in-timing-function;
+
+    opacity: 0;
+    visibility: hidden;
+
+    &::-moz-focus-inner {
+      border: 0;
+    }
+    &:not([aria-hidden]) {
+      @include _mdl-snackbar-reflexive-margin(left, 8px, true);
+      opacity: 1;
+      visibility: inherit;
+    }
+  }
+}
+
+/* postcss-bem-linter: end */

--- a/packages/mdl-snackbar/package.json
+++ b/packages/mdl-snackbar/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "mdl-snackbar",
+  "description": "A material design snackbar/toast component",
+  "version": "1.0.0",
+  "license": "MIT",
+  "main": "./index.js",
+  "dependencies": {
+    "mdl-animation": "^1.0.0",
+    "mdl-base": "^1.0.0",
+    "mdl-button": "^1.0.0",
+    "mdl-theme": "^1.0.0"
+  }
+}

--- a/test/unit/mdl-snackbar/foundation.test.js
+++ b/test/unit/mdl-snackbar/foundation.test.js
@@ -1,0 +1,338 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import test from 'tape';
+import lolex from 'lolex';
+import td from 'testdouble';
+import MDLSnackbarFoundation from '../../../packages/mdl-snackbar/foundation';
+import {cssClasses, strings, numbers} from '../../../packages/mdl-snackbar/constants';
+
+function setupTest() {
+  const mockAdapter = td.object(MDLSnackbarFoundation.defaultAdapter);
+
+  const foundation = new MDLSnackbarFoundation(mockAdapter);
+  return {foundation, mockAdapter};
+}
+
+test('exports strings', t => {
+  t.deepEqual(MDLSnackbarFoundation.strings, strings);
+  t.end();
+});
+
+test('exports cssClasses', t => {
+  t.deepEqual(MDLSnackbarFoundation.cssClasses, cssClasses);
+  t.end();
+});
+
+test('defaultAdapter returns a complete adapter implementation', t => {
+  const {defaultAdapter} = MDLSnackbarFoundation;
+  const methods = Object.keys(defaultAdapter).filter(k => typeof defaultAdapter[k] === 'function');
+
+  t.equal(methods.length, Object.keys(defaultAdapter).length, 'Every adapter key must be a function');
+  t.deepEqual(methods, [
+    'addClass', 'removeClass', 'setAriaHidden', 'unsetAriaHidden', 'setMessageText',
+    'setActionText', 'setActionAriaHidden', 'unsetActionAriaHidden',
+    'registerActionClickHandler', 'deregisterActionClickHandler',
+    'registerTransitionEndHandler', 'deregisterTransitionEndHandler'
+  ]);
+  // Test default methods
+  methods.forEach(m => t.doesNotThrow(defaultAdapter[m]));
+
+  t.end();
+});
+
+test('#init calls adapter.registerActionClickHandler() with a action click handler function', t => {
+  const {foundation, mockAdapter} = setupTest();
+  const {isA} = td.matchers;
+
+  foundation.init();
+  t.doesNotThrow(() => td.verify(mockAdapter.registerActionClickHandler(isA(Function))));
+  t.end();
+});
+
+test('#destroy calls adapter.deregisterActionClickHandler() with a registerActionClickHandler function', t => {
+  const {foundation, mockAdapter} = setupTest();
+  const {isA} = td.matchers;
+
+  let changeHandler;
+  td.when(mockAdapter.registerActionClickHandler(isA(Function))).thenDo(function(handler) {
+    changeHandler = handler;
+  });
+  foundation.init();
+
+  foundation.destroy();
+  t.doesNotThrow(() => td.verify(mockAdapter.deregisterActionClickHandler(changeHandler)));
+
+  t.end();
+});
+
+test('#init calls adapter.setAriaHidden to ensure snackbar starts hidden', t => {
+  const {foundation, mockAdapter} = setupTest();
+
+  foundation.init();
+  t.doesNotThrow(() => td.verify(mockAdapter.setAriaHidden()));
+  t.end();
+});
+
+test('#init calls adapter.setActionAriaHidden to ensure snackbar action starts hidden', t => {
+  const {foundation, mockAdapter} = setupTest();
+
+  foundation.init();
+  t.doesNotThrow(() => td.verify(mockAdapter.setActionAriaHidden()));
+  t.end();
+});
+
+test('#show without a data object throws an error', t => {
+  const {foundation} = setupTest();
+
+  foundation.init();
+  t.throws(() => foundation.show(), Error);
+  t.end();
+});
+
+test('#show without a message throws an error', t => {
+  const {foundation} = setupTest();
+
+  foundation.init();
+  t.throws(() => foundation.show({}), Error);
+  t.end();
+});
+
+test('#show with an actionHandler but no actionText throws an error', t => {
+  const {foundation} = setupTest();
+
+  foundation.init();
+  const data = {
+    message: 'Message Deleted',
+    actionHandler: () => {}
+  };
+  t.throws(() => foundation.show(data), Error);
+  t.end();
+});
+
+test('#show should add the active class', t => {
+  const {foundation, mockAdapter} = setupTest();
+
+  foundation.init();
+  foundation.show({message: 'Message Deleted'});
+  t.doesNotThrow(() => td.verify(mockAdapter.addClass(cssClasses.ACTIVE)));
+  t.end();
+});
+
+test('#show should call foundation#unsetAriaHidden() to show the snackbar', t => {
+  const {foundation, mockAdapter} = setupTest();
+
+  foundation.init();
+  foundation.show({message: 'Message Deleted'});
+  t.doesNotThrow(() => td.verify(mockAdapter.unsetAriaHidden()));
+  t.end();
+});
+
+test('#show should set the message text', t => {
+  const {foundation, mockAdapter} = setupTest();
+
+  foundation.init();
+  foundation.show({message: 'Message Deleted'});
+  t.doesNotThrow(() => td.verify(mockAdapter.setMessageText('Message Deleted')));
+  t.end();
+});
+
+test('#show should make the foundation active', t => {
+  const {foundation} = setupTest();
+
+  foundation.init();
+  foundation.show({message: 'Message Deleted'});
+  t.equals(foundation.active, true);
+  t.end();
+});
+
+test('#show with action text and handler should set the action text', t => {
+  const {foundation, mockAdapter} = setupTest();
+
+  foundation.init();
+  foundation.show({
+    message: 'Message Deleted',
+    actionText: 'Undo',
+    actionHandler: () => {}
+  });
+
+  t.doesNotThrow(() => td.verify(mockAdapter.setActionText('Undo')));
+  t.end();
+});
+
+test('#show with action text and handler should unset action aria-hidden', t => {
+  const {foundation, mockAdapter} = setupTest();
+
+  foundation.init();
+  foundation.show({
+    message: 'Message Deleted',
+    actionText: 'Undo',
+    actionHandler: () => {}
+  });
+
+  t.doesNotThrow(() => td.verify(mockAdapter.unsetActionAriaHidden()));
+  t.end();
+});
+
+test('#show({ mutliline: true }) should add multiline modifier', t => {
+  const {foundation, mockAdapter} = setupTest();
+
+  foundation.init();
+  foundation.show({message: 'Message Deleted', multiline: true});
+  t.doesNotThrow(() => td.verify(mockAdapter.addClass(cssClasses.MULTILINE)));
+  t.end();
+});
+
+test('#show({ mutliline: true, actionOnBottom: true }) should add action-on-bottom modifier', t => {
+  const {foundation, mockAdapter} = setupTest();
+
+  foundation.init();
+  foundation.show({
+    message: 'Message Deleted',
+    multiline: true,
+    actionOnBottom: true
+  });
+
+  t.doesNotThrow(() => td.verify(mockAdapter.addClass(cssClasses.ACTION_ON_BOTTOM)));
+  t.end();
+});
+
+test('#show({ mutliline: false, actionOnBottom: true }) does not add action-on-bottom modifier', t => {
+  const {foundation, mockAdapter} = setupTest();
+
+  foundation.init();
+  foundation.show({
+    message: 'Message Deleted',
+    actionOnBottom: true
+  });
+
+  t.doesNotThrow(() => td.verify(mockAdapter.addClass(cssClasses.ACTION_ON_BOTTOM), {times: 0}));
+  t.end();
+});
+
+test('#show while snackbar is already showing will queue the data object.', t => {
+  const {foundation, mockAdapter} = setupTest();
+
+  foundation.init();
+  foundation.show({
+    message: 'Message Deleted'
+  });
+
+  foundation.show({
+    message: 'Message Archived'
+  });
+
+  t.doesNotThrow(() => td.verify(mockAdapter.setMessageText('Message Archived'), {times: 0}));
+  t.end();
+});
+
+test('#show while snackbar is already showing will show after the timeout and transition end', t => {
+  const clock = lolex.install();
+  const {foundation, mockAdapter} = setupTest();
+  const {isA} = td.matchers;
+
+  foundation.init();
+
+  let transEndHandler;
+  td.when(mockAdapter.registerTransitionEndHandler(isA(Function)))
+    .thenDo(handler => {
+      transEndHandler = handler;
+    });
+
+  foundation.show({
+    message: 'Message Deleted'
+  });
+
+  foundation.show({
+    message: 'Message Archived'
+  });
+
+  clock.tick(numbers.MESSAGE_TIMEOUT);
+  transEndHandler();
+
+  t.doesNotThrow(() => td.verify(mockAdapter.setMessageText('Message Archived')));
+  clock.uninstall();
+  t.end();
+});
+
+test('#show will remove active class after the timeout', t => {
+  const clock = lolex.install();
+  const {foundation, mockAdapter} = setupTest();
+
+  foundation.init();
+
+  foundation.show({
+    message: 'Message Deleted'
+  });
+
+  clock.tick(numbers.MESSAGE_TIMEOUT);
+
+  t.doesNotThrow(() => td.verify(mockAdapter.removeClass(cssClasses.ACTIVE)));
+  clock.uninstall();
+  t.end();
+});
+
+test('#show will add an transition end handler after the timeout', t => {
+  const clock = lolex.install();
+  const {foundation, mockAdapter} = setupTest();
+  const {isA} = td.matchers;
+
+  foundation.init();
+
+  foundation.show({
+    message: 'Message Deleted'
+  });
+
+  clock.tick(numbers.MESSAGE_TIMEOUT);
+
+  t.doesNotThrow(() => td.verify(mockAdapter.registerTransitionEndHandler(isA(Function))));
+  clock.uninstall();
+  t.end();
+});
+
+test('#show will clean up snackbar after the timeout and transition end', t => {
+  const clock = lolex.install();
+  const {foundation, mockAdapter} = setupTest();
+  const {isA} = td.matchers;
+
+  foundation.init();
+
+  let transEndHandler;
+  td.when(mockAdapter.registerTransitionEndHandler(isA(Function)))
+    .thenDo(handler => {
+      transEndHandler = handler;
+    });
+
+  foundation.show({
+    message: 'Message Deleted',
+    actionText: 'Undo',
+    multiline: true,
+    actionOnBottom: true,
+    actionHandler: () => {}
+  });
+
+  clock.tick(numbers.MESSAGE_TIMEOUT);
+  transEndHandler();
+
+  t.doesNotThrow(() => td.verify(mockAdapter.setMessageText(null)));
+  t.doesNotThrow(() => td.verify(mockAdapter.setActionText(null)));
+  t.doesNotThrow(() => td.verify(mockAdapter.removeClass(cssClasses.MULTILINE)));
+  t.doesNotThrow(() => td.verify(mockAdapter.removeClass(cssClasses.ACTION_ON_BOTTOM)));
+  t.doesNotThrow(() => td.verify(mockAdapter.deregisterTransitionEndHandler(transEndHandler)));
+
+  clock.uninstall();
+  t.end();
+});

--- a/test/unit/mdl-snackbar/mdl-snackbar.test.js
+++ b/test/unit/mdl-snackbar/mdl-snackbar.test.js
@@ -1,0 +1,173 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import test from 'tape';
+import bel from 'bel';
+import td from 'testdouble';
+import {compare} from 'dom-compare';
+import domEvents from 'dom-events';
+
+import MDLSnackbar, {MDLSnackbarFoundation} from '../../../packages/mdl-snackbar';
+
+const {strings} = MDLSnackbarFoundation;
+
+function getFixture() {
+  return bel`
+    <div class="mdl-snackbar" aria-live="assertive" aria-atomic="true" aria-hidden="true">
+      <div class="mdl-snackbar__text"></div>
+      <div class="mdl-snackbar__action-wrapper">
+        <button type="button" class="mdl-button mdl-snackbar__action-button"></button>
+      </div>
+    </div>
+  `;
+}
+
+function setupTest() {
+  const root = getFixture();
+  const component = new MDLSnackbar(root);
+  return {root, component};
+}
+
+test('buildDom returns a built snackbar element', t => {
+  const expected = getFixture();
+  const actual = MDLSnackbar.buildDom();
+
+  const comparison = compare(expected, actual);
+  const diffs = comparison.getDifferences();
+
+  if (diffs.length) {
+    const diffMsgs = diffs.map(({node, message}) => `\t* ${node} - ${message}`).join('\n');
+    t.fail(`Improper DOM Object. Diff failed:\n${diffMsgs}\n`);
+  } else {
+    t.pass();
+  }
+
+  t.end();
+});
+
+test('attachTo initializes and returns a MDLSnackbar instance', t => {
+  t.true(MDLSnackbar.attachTo(getFixture()) instanceof MDLSnackbar);
+  t.end();
+});
+
+test('foundationAdapter#addClass adds a class to the root element', t => {
+  const {root, component} = setupTest();
+  component.getDefaultFoundation().adapter_.addClass('foo');
+  t.true(root.classList.contains('foo'));
+  t.end();
+});
+
+test('adapter#removeClass removes a class from the root element', t => {
+  const {root, component} = setupTest();
+  root.classList.add('foo');
+  component.getDefaultFoundation().adapter_.removeClass('foo');
+  t.false(root.classList.contains('foo'));
+  t.end();
+});
+
+test('foundationAdapter#setAriaHidden adds aria-hidden="true" to the root element', t => {
+  const {root, component} = setupTest();
+  component.getDefaultFoundation().adapter_.setAriaHidden();
+  t.true(root.getAttribute('aria-hidden'));
+  t.end();
+});
+
+test('foundationAdapter#unsetAriaHidden removes "aria-hidden" from the root element', t => {
+  const {root, component} = setupTest();
+  root.setAttribute('aria-hidden', true);
+  component.getDefaultFoundation().adapter_.unsetAriaHidden();
+  t.false(root.getAttribute('aria-hidden'));
+  t.end();
+});
+
+test('foundationAdapter#setMessageText sets the text content of the text element', t => {
+  const {root, component} = setupTest();
+  component.getDefaultFoundation().adapter_.setMessageText('Message Deleted');
+  t.equal(root.querySelector(strings.TEXT_SELECTOR).textContent, 'Message Deleted');
+  t.end();
+});
+
+test('foundationAdapter#setActionText sets the text content of the action button element', t => {
+  const {root, component} = setupTest();
+  component.getDefaultFoundation().adapter_.setActionText('Undo');
+  t.equal(root.querySelector(strings.ACTION_BUTTON_SELECTOR).textContent, 'Undo');
+  t.end();
+});
+
+test('foundationAdapter#setActionAriaHidden adds aria-hidden="true" to the action button element', t => {
+  const {root, component} = setupTest();
+  component.getDefaultFoundation().adapter_.setActionAriaHidden();
+  t.true(root.querySelector(strings.ACTION_BUTTON_SELECTOR).getAttribute('aria-hidden'));
+  t.end();
+});
+
+test('foundationAdapter#unsetActionAriaHidden removes "aria-hidden" from the action button element', t => {
+  const {root, component} = setupTest();
+  const actionButton = root.querySelector(strings.ACTION_BUTTON_SELECTOR);
+  actionButton.setAttribute('aria-hidden', true);
+  component.getDefaultFoundation().adapter_.unsetActionAriaHidden();
+  t.false(actionButton.getAttribute('aria-hidden'));
+  t.end();
+});
+
+test('foundationAdapter#registerActionClickHandler adds the handler to be called when action is clicked', t => {
+  const {root, component} = setupTest();
+  const handler = td.func('clickHandler');
+
+  component.getDefaultFoundation().adapter_.registerActionClickHandler(handler);
+
+  root.querySelector(strings.ACTION_BUTTON_SELECTOR).click();
+  t.doesNotThrow(() => td.verify(handler(td.matchers.anything())));
+  t.end();
+});
+
+test('foundationAdapter#deregisterActionClickHandler removes the handler to be called when action is clicked', t => {
+  const {root, component} = setupTest();
+  const handler = td.func('clickHandler');
+  const actionButton = root.querySelector(strings.ACTION_BUTTON_SELECTOR);
+
+  actionButton.addEventListener('click', handler);
+
+  component.getDefaultFoundation().adapter_.deregisterActionClickHandler(handler);
+
+  actionButton.click();
+
+  t.doesNotThrow(() => td.verify(handler(td.matchers.anything()), {times: 0}));
+  t.end();
+});
+
+test('foundationAdapter#registerTransitionEndHandler adds an event listener to the root', t => {
+  const {root, component} = setupTest();
+  const handler = td.func('transitionEndHandler');
+
+  component.getDefaultFoundation().adapter_.registerTransitionEndHandler(handler);
+
+  domEvents.emit(root, 'transitionend');
+  t.doesNotThrow(() => td.verify(handler(td.matchers.anything())));
+  t.end();
+});
+
+test('foundationAdapter#deregisterTransitionEndHandler adds an event listener to the root', t => {
+  const {root, component} = setupTest();
+  const handler = td.func('transitionEndHandler');
+
+  root.addEventListener('transitionend', handler);
+  component.getDefaultFoundation().adapter_.deregisterTransitionEndHandler(handler);
+
+  domEvents.emit(root, 'transitionend');
+  t.doesNotThrow(() => td.verify(handler(td.matchers.anything()), {times: 0}));
+  t.end();
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,7 @@ module.exports = [{
     Base: [path.resolve('./packages/mdl-base/index.js')],
     Checkbox: [path.resolve('./packages/mdl-checkbox/index.js')],
     IconToggle: [path.resolve('./packages/mdl-icon-toggle/index.js')],
+    Snackbar: [path.resolve('./packages/mdl-snackbar/index.js')],
     Radio: [path.resolve('./packages/mdl-radio/index.js')],
     Ripple: [path.resolve('./packages/mdl-ripple/index.js')],
     Drawer: [path.resolve('./packages/mdl-drawer/index.js')]
@@ -82,6 +83,7 @@ module.exports = [{
     'mdl-card': path.resolve('./packages/mdl-card/mdl-card.scss'),
     'mdl-drawer': path.resolve('./packages/mdl-drawer/mdl-drawer.scss'),
     'mdl-checkbox': path.resolve('./packages/mdl-checkbox/mdl-checkbox.scss'),
+    'mdl-snackbar': path.resolve('./packages/mdl-snackbar/mdl-snackbar.scss'),
     'mdl-elevation': path.resolve('./packages/mdl-elevation/mdl-elevation.scss'),
     'mdl-fab': path.resolve('./packages/mdl-fab/mdl-fab.scss'),
     'mdl-icon-toggle': path.resolve('./packages/mdl-icon-toggle/mdl-icon-toggle.scss'),


### PR DESCRIPTION
* Same 'showSnackbar' API in component/foundation.
* Basic adapter API for various interactions.
* Adds VueJS example as well.
* Some test coverage.
* ~~Closes~~ Part of #4490.