### PR TITLE
feat(theme): Add compound param to mdl-theme-dark

### DIFF
--- a/packages/mdl-theme/README.md
+++ b/packages/mdl-theme/README.md
@@ -162,10 +162,20 @@ components. It creates a suitable selector for a component, and applies the prov
     }
   }
 }
+
+.mdl-foo--disabled {
+  opacity: .38;
+
+  @include mdl-theme-dark(".mdl-foo", /* $compound: */ true) {
+    opacity: .5;
+  }
+}
 ```
 
 > Note: If using the mixin on anything other than the base selector, you need to specify the base selector as a
 parameter. This ensures that the `--theme-dark` option is appended to the right class.
+
+> Note: If using the mixin with a modifier class, pass `true` for the second argument. This will tell the mixin to treat the selector it's being mixed into as a compound class rather than a descendant selector.
 
 The above generates the following CSS:
 
@@ -181,6 +191,14 @@ The above generates the following CSS:
 }
 .mdl-foo--theme-dark .mdl-foo__bar, .mdl-theme--dark .mdl-foo__bar {
   background: white;
+}
+
+.mdl-foo--disabled {
+  opacity: .38;
+}
+.mdl-foo--theme-dark.mdl-foo--disabled,
+.mdl-theme--dark .mdl-foo--disabled {
+  opacity: .5;
 }
 ```
 

--- a/packages/mdl-theme/_mixins.scss
+++ b/packages/mdl-theme/_mixins.scss
@@ -36,6 +36,8 @@
 /**
  * Creates a rule to be used in MDL components for dark theming, and applies the provided contents.
  * Should provide the $root-selector option if applied to anything other than the root selector.
+ * When used with a modifier class, provide a second argument of `true` for the $compound parameter
+ * to specify that this should be attached as a compound class.
  *
  * Usage example:
  *
@@ -55,14 +57,31 @@
  *     }
  *   }
  * }
+ *
+ * .mdl-foo--disabled {
+ *   opacity: .38;
+ *
+ *   @include mdl-theme-dark(".mdl-foo", true) {
+ *     opacity: .5;
+ *   }
+ * }
  * ```
  */
-@mixin mdl-theme-dark($root-selector: null) {
+@mixin mdl-theme-dark($root-selector: null, $compound: false) {
   @if ($root-selector) {
     @at-root {
-      #{$root-selector}--theme-dark &,
-      .mdl-theme--dark & {
-        @content;
+      @if ($compound) {
+        #{$root-selector}--theme-dark#{&},
+        .mdl-theme--dark & {
+          @content;
+        }
+      }
+
+      @else {
+        #{$root-selector}--theme-dark &,
+        .mdl-theme--dark & {
+          @content;
+        }
       }
     }
   }


### PR DESCRIPTION
This change adds an additional parameter to the mdl-theme-dark mixin which specifies that the
selector it is being mixed into should be treated as a compound selector. This is useful for
modifier classes that need to leverage the mixin.