### PR TITLE
feat(ripple): Add support for theme styles via improved configuration

### DIFF
--- a/demos/ripple.html
+++ b/demos/ripple.html
@@ -105,6 +105,19 @@
         </div>
       </section>
       <section>
+        <h2>Theme Styles</h2>
+        <div
+          class="mdl-ripple-surface mdl-ripple-surface--primary
+                 mdl-theme--primary demo-surface mdl-elevation--z2" tabindex="0">
+          Primary
+        </div>
+        <div
+          class="mdl-ripple-surface mdl-ripple-surface--accent
+                 mdl-theme--accent demo-surface mdl-elevation--z2" tabindex="0">
+          Accent
+        </div>
+      </section>
+      <section>
         <h2>Applied to <code>&lt;button&gt; element</h2>
           <button type="button" class="mdl-ripple-surface mdl-elevation--z2 demo-surface">button</button>
       </section>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -164,7 +164,7 @@ module.exports = function(config) {
 
 function determineBrowsers() {
   var browsers = USING_SL ? Object.keys(SL_LAUNCHERS) : ['Chrome'];
-  if (!process.env.IS_SECURE) {
+  if (USING_TRAVISCI && !process.env.IS_SECURE) {
     console.warn(
       'NOTICE: Falling back to firefox browser, as travis-ci JWT addon is currently not working ' +
       'with Sauce Labs. See - https://github.com/travis-ci/travis-ci/issues/6569'

--- a/packages/mdl-ripple/README.md
+++ b/packages/mdl-ripple/README.md
@@ -5,6 +5,7 @@
   - [Installation](#installation)
   - [Usage](#usage)
       - [Adding the ripple Sass](#adding-the-ripple-sass)
+        - [The full Sass API](#the-full-sass-api)
       - [Adding the ripple JS](#adding-the-ripple-js)
         - [ES2015](#es2015)
         - [CommonJS](#commonjs)
@@ -19,6 +20,7 @@
     - [Integrating ripples into MDL components](#integrating-ripples-into-mdl-components)
     - [Using a sentinel element for a ripple](#using-a-sentinel-element-for-a-ripple)
   - [Caveat: Safari](#caveat-safari)
+  - [Caveat: Theme Custom Variables](#caveat-theme-custom-variables)
 
 MDL Ripple provides the Javascript and CSS required
 to provide components (or any element at all) with a
@@ -113,6 +115,20 @@ When a ripple is successfully initialized on an element, it dynamically adds a `
 ```
 
 This code sets up `.surface` with the correct css variables as well as `will-change` properties to support the ripple. It then dynamically generates the correct selectors such that the surface's `::before` element functions as a background ripple, and the surface's `::after` element functions as a foreground ripple.
+
+##### The full Sass API
+
+Both `mdl-ripple-bg` and `mdl-ripple-fg` take an `$config` map as an optional
+argument, with which you can specify the following parameters:
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `pseudo` | The name of the pseudo-element you want to use to style the ripple. Using pseudo-elements to style ripples obviates the need for any extra DOM and is recommended. However,
+if given `null` it will style the element directly, rather than attaching styles to the pseudo element. | `null` |
+| `radius` | For _bounded_ ripples, specifies radii of the ripple circles. Can be any valid numeric CSS unit. | `100%` |
+| `theme-style` | When provided, will use a style specified by `mdl-theme` to provide colors to the ripple. For example, passing `(theme-style: primary)` would make the ripples the color of the theme's primary color. Note that there are some current limitations here. See [below](#caveat-theme-custom-variables) | `null` |
+| `base-color` | The RGB color (_without_ an alpha component) of the ripple. This will only be used if `theme-style` isn't specified. | `black` |
+| `opacity` | A unitless number from `0-1` specifying the opacity that either the `base-color` or the `theme-style` color will take on. | `.06` |
 
 #### Adding the ripple JS
 
@@ -214,7 +230,19 @@ a ripple:
 <div class="mdl-ripple-surface my-surface" tabindex="0">Ripples FTW!</div>
 ```
 
-Check out our demo (in the top-level `demos/` directory) to see this class in action.
+There are also modifier classes that can be used for styling ripple surfaces using the configured
+theme's primary and accent colors
+
+```html
+<div class="mdl-ripple-surface mdl-ripple-surface--primary my-surface" tabindex="0">
+  Surface with a primary-colored ripple.
+</div>
+<div class="mdl-ripple-surface mdl-ripple-surface--accent my-surface" tabindex="0">
+  Surface with an accent-colored ripple.
+</div>
+```
+
+Check out our demo (in the top-level `demos/` directory) to see these classes in action.
 
 ### Using the foundation
 
@@ -272,3 +300,20 @@ webkit versions: Webkit builds which have this bug fixed (e.g. the builds used i
 support [CSS 4 Hex Notation](https://drafts.csswg.org/css-color/#hex-notation) while those do not
 have the fix don't. We use this to reliably feature-detect whether we are working with a WebKit
 build that can handle our usage of CSS variables.
+
+## Caveat: Theme Custom Variables
+
+> TL;DR theme custom variable changes will not propagate to ripples if the browser does not support
+> [CSS 4 color-mod functions](https://drafts.csswg.org/css-color/).
+
+The way that [mdl-theme works](https://github.com/google/material-design-lite/tree/master/packages/mdl-theme#mdl-theme-prop-mixin) is that it emits two properties: one with the hard-coded sass variable, and another for a
+CSS variable that can be interpolated. The problem is that ripple backgrounds need to have an opacity, and currently there's no way to opacify a pre-existing color defined by a CSS variable.
+There is an editor's draft for a `color-mod` function (see link in TL;DR) that _can_ do this:
+
+```css
+background: color(var(--mdl-theme-primary) a(6%));
+```
+
+But as far as we know, no browsers yet support it. We have added a `@supports` clause into our code
+to make sure that it can be used as soon as browsers adopt it, but for now this means that _changes
+to your theme via a custom variable will not propagate to ripples._ We don't see this being a gigantic issue as we envision most users configuring one theme via sass. For places where you do need this, special treatment will have to be given.

--- a/packages/mdl-ripple/_mixins.scss
+++ b/packages/mdl-ripple/_mixins.scss
@@ -14,8 +14,19 @@
  * limitations under the License.
  */
 
+@import "mdl-theme/variables";
 @import "./keyframes";
 @import "./variables";
+
+@function mdl-ripple-default-config_() {
+  @return (
+    pseudo: null,
+    radius: 100%,
+    base-color: black,
+    opacity: .06,
+    theme-style: null
+  );
+}
 
 @mixin mdl-ripple-base() {
   --mdl-ripple-left: 0;
@@ -33,7 +44,39 @@
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
-@mixin mdl-ripple-bg-base($color, $radius: 100%) {
+@mixin mdl-ripple-color_($config) {
+  /* stylelint-disable scss/dollar-variable-pattern */
+  $base-color: map-get($config, base-color);
+  $opacity: map-get($config, opacity);
+  $theme-style: map-get($config, theme-style);
+
+  /* stylelint-disable at-rule-empty-line-before, block-closing-brace-newline-after */
+  @if ($theme-style) {
+    $theme-value: map-get($mdl-theme-property-values, $theme-style);
+    $css-var: var(--mdl-theme-#{$theme-style}, $theme-value);
+    /* stylelint-enable scss/dollar-variable-pattern */
+
+    background-color: rgba($theme-value, $opacity);
+
+    // See: https://drafts.csswg.org/css-color/#modifying-colors
+    // While this is currently unsupported as of now, it will begin to work by default as browsers
+    // begin to implement the CSS 4 color spec.
+    @supports (background-color: color(green a(10%))) {
+      background-color: color(#{$css-var} a(#{percentage($opacity)}));
+    }
+  } @else {
+    background-color: rgba($base-color, $opacity);
+  }
+  /* stylelint-enable at-rule-empty-line-before, block-closing-brace-newline-after */
+}
+
+@mixin mdl-ripple-bg-base_($config) {
+  /* stylelint-disable scss/dollar-variable-pattern */
+  $radius: map-get($config, radius);
+  /* stylelint-enable scss/dollar-variable-pattern */
+
+  @include mdl-ripple-color_($config);
+
   position: absolute;
   top: calc(50% - #{$radius});
   left: calc(50% - #{$radius});
@@ -42,20 +85,24 @@
   transform: scale(1);
   transition: opacity 200ms linear;
   border-radius: 50%;
-  background-color: $color;
   opacity: 0;
   pointer-events: none;
 }
 
-@mixin mdl-ripple-bg($pseudo: null, $color: rgba(black, .06)) {
+@mixin mdl-ripple-bg($config: ()) {
+  /* stylelint-disable scss/dollar-variable-pattern */
+  $config: map-merge(mdl-ripple-default-config_(), $config);
+  $pseudo: map-get($config, pseudo);
+  /* stylelint-enable scss/dollar-variable-pattern */
+
   /* stylelint-disable at-rule-empty-line-before, block-closing-brace-newline-after */
   @if ($pseudo) {
     &#{$pseudo} {
-      @include mdl-ripple-bg-base($color);
+      @include mdl-ripple-bg-base_($config);
       content: "";
     }
   } @else {
-    @include mdl-ripple-bg-base($color);
+    @include mdl-ripple-bg-base_($config);
   }
   /* stylelint-enable at-rule-empty-line-before, block-closing-brace-newline-after */
 
@@ -83,27 +130,33 @@
   }
 }
 
-@mixin mdl-ripple-fg-base($color) {
+@mixin mdl-ripple-fg-base_($config) {
+  @include mdl-ripple-color_($config);
+
   position: absolute;
   width: var(--mdl-ripple-fg-size);
   height: var(--mdl-ripple-fg-size);
   transform: scale(0);
   transform-origin: center center;
   border-radius: 50%;
-  background-color: $color;
   opacity: 0;
   pointer-events: none;
 }
 
-@mixin mdl-ripple-fg($pseudo: null, $color: rgba(black, .06)) {
+@mixin mdl-ripple-fg($config: ()) {
+  /* stylelint-disable scss/dollar-variable-pattern */
+  $config: map-merge(mdl-ripple-default-config_(), $config);
+  $pseudo: map-get($config, pseudo);
+  /* stylelint-enable scss/dollar-variable-pattern */
+
   /* stylelint-disable at-rule-empty-line-before, block-closing-brace-newline-after */
   @if ($pseudo) {
     &#{$pseudo} {
-      @include mdl-ripple-fg-base($color);
+      @include mdl-ripple-fg-base_($config);
       content: "";
     }
   } @else {
-    @include mdl-ripple-fg-base($color);
+    @include mdl-ripple-fg-base_($config);
   }
   /* stylelint-enable at-rule-empty-line-before, block-closing-brace-newline-after */
 

--- a/packages/mdl-ripple/mdl-ripple.scss
+++ b/packages/mdl-ripple/mdl-ripple.scss
@@ -15,6 +15,7 @@
  */
 
 @import "mdl-animation/variables";
+@import "mdl-theme/mixins";
 @import "./mixins";
 
 /* postcss-bem-linter: define ripple-surface */
@@ -51,8 +52,28 @@
 
   &.mdl-ripple-upgraded {
     @include mdl-ripple-base;
-    @include mdl-ripple-bg("::before", rgba(black, .06));
-    @include mdl-ripple-fg("::after", rgba(black, .06));
+    @include mdl-ripple-bg((pseudo: "::before"));
+    @include mdl-ripple-fg((pseudo: "::after"));
+  }
+
+  &--primary.mdl-ripple-upgraded {
+    &::before,
+    &::after {
+      @include mdl-theme-prop(background-color, primary);
+    }
+
+    @include mdl-ripple-bg((pseudo: "::before", theme-style: primary, opacity: .14));
+    @include mdl-ripple-fg((pseudo: "::after", theme-style: primary, opacity: .14));
+  }
+
+  &--accent.mdl-ripple-upgraded {
+    &::before,
+    &::after {
+      @include mdl-theme-prop(background-color, primary);
+    }
+
+    @include mdl-ripple-bg((pseudo: "::before", theme-style: accent, opacity: .14));
+    @include mdl-ripple-fg((pseudo: "::after", theme-style: accent, opacity: .14));
   }
 }
 


### PR DESCRIPTION
Improves the functionality of the ripple's sass API so that using it in conjunction with themes is
better supported. Also makes the API more ergonomic by removing the awkward positional arguments in
favor of a config map.

Also fixes auxiliary karma issue where Travis-CI JWT checks were
yielding false negatives.

BREAKING CHANGE: mdl-ripple-bg/mdl-ripple-fg now accept config maps as their initial parameter, rather than
positional argument. Pass '(pseudo: "::before")' as the first argument rather than '"::before"'.