### PR TITLE
feat(ripple): Add createAdapter() static method

### DIFF
--- a/packages/mdl-ripple/index.js
+++ b/packages/mdl-ripple/index.js
@@ -32,6 +32,23 @@ export default class MDLRipple extends MDLComponent {
     return ripple;
   }
 
+  static createAdapter(instance) {
+    return {
+      browserSupportsCssVars: () => supportsCssVariables(window),
+      isUnbounded: () => instance.unbounded,
+      isSurfaceActive: () => instance.root_[MATCHES](':active'),
+      addClass: className => instance.root_.classList.add(className),
+      removeClass: className => instance.root_.classList.remove(className),
+      registerInteractionHandler: (evtType, handler) => instance.root_.addEventListener(evtType, handler),
+      deregisterInteractionHandler: (evtType, handler) => instance.root_.removeEventListener(evtType, handler),
+      registerResizeHandler: handler => window.addEventListener('resize', handler),
+      deregisterResizeHandler: handler => window.removeEventListener('resize', handler),
+      updateCssVariable: (varName, value) => instance.root_.style.setProperty(varName, value),
+      computeBoundingRect: () => instance.root_.getBoundingClientRect(),
+      getWindowPageOffset: () => ({x: window.pageXOffset, y: window.pageYOffset})
+    };
+  }
+
   get unbounded() {
     return this.unbounded_;
   }
@@ -47,20 +64,7 @@ export default class MDLRipple extends MDLComponent {
   }
 
   getDefaultFoundation() {
-    return new MDLRippleFoundation({
-      browserSupportsCssVars: () => supportsCssVariables(window),
-      isUnbounded: () => this.unbounded,
-      isSurfaceActive: () => this.root_[MATCHES](':active'),
-      addClass: className => this.root_.classList.add(className),
-      removeClass: className => this.root_.classList.remove(className),
-      registerInteractionHandler: (evtType, handler) => this.root_.addEventListener(evtType, handler),
-      deregisterInteractionHandler: (evtType, handler) => this.root_.removeEventListener(evtType, handler),
-      registerResizeHandler: handler => window.addEventListener('resize', handler),
-      deregisterResizeHandler: handler => window.removeEventListener('resize', handler),
-      updateCssVariable: (varName, value) => this.root_.style.setProperty(varName, value),
-      computeBoundingRect: () => this.root_.getBoundingClientRect(),
-      getWindowPageOffset: () => ({x: window.pageXOffset, y: window.pageYOffset})
-    });
+    return new MDLRippleFoundation(MDLRipple.createAdapter(this));
   }
 
   initialSyncWithDOM() {

--- a/test/unit/mdl-ripple/mdl-ripple.test.js
+++ b/test/unit/mdl-ripple/mdl-ripple.test.js
@@ -51,6 +51,13 @@ test('attachTo overrides unbounded data attr when explicitly specified', t => {
   t.end();
 });
 
+test('createAdapter() returns the same adapter used by default for the ripple', t => {
+  const root = bel`<div></div>`;
+  const component = MDLRipple.attachTo(root);
+  t.deepEqual(Object.keys(MDLRipple.createAdapter()), Object.keys(component.foundation_.adapter_));
+  t.end();
+});
+
 function setupTest() {
   const root = bel`<div></div>`;
   const component = new MDLRipple(root);


### PR DESCRIPTION
createAdapter() easily lets other MDLComponents create ripple adapters that they can then extend to their needs. Updated the README with some tips/tricks on where this could be useful. Note that the icon toggle has an immediate need for this functionality.