### PR TITLE
fix(card): Remove overflow hidden

### DIFF
--- a/packages/mdl-card/mdl-card.scss
+++ b/packages/mdl-card/mdl-card.scss
@@ -26,7 +26,6 @@
   flex-direction: column;
   justify-content: flex-end;
   padding: 0;
-  overflow: hidden;
   box-sizing: border-box;
 
   &__primary {


### PR DESCRIPTION
Overflow hidden is not needed on card styles by default, and can lead to
unexpected results.

Fixes #4751

BREAKING CHANGE: Changes the overflow style of cards. Users relying on
overflow:hidden; will have to add it back themselves.