### PR TITLE
fix(layout): Fix react router tab navigation and content display issue

### DIFF
--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -533,7 +533,6 @@
       var href = tab.href.split('#')[1];
       var panel = layout.content_.querySelector('#' + href);
       layout.resetTabState_(tabs);
-      layout.resetPanelState_(panels);
       tab.classList.add(layout.CssClasses_.IS_ACTIVE);
       panel.classList.add(layout.CssClasses_.IS_ACTIVE);
     }
@@ -551,7 +550,6 @@
 
     tab.addEventListener('click', function(e) {
       if (tab.getAttribute('href').charAt(0) === '#') {
-        e.preventDefault();
         selectTab();
       }
     });


### PR DESCRIPTION
Removed two lines, one which calls a method that removes the is-active class from tab panels. The

other line was deleted to allow default handling for clicks, allowing react router to route

properly.

closes #4767