### PR TITLE
feat(examples): add initial VueJS icon toggle integration.

### DIFF
--- a/examples/vue/src/App.vue
+++ b/examples/vue/src/App.vue
@@ -21,6 +21,18 @@
 
   <button type="button" @click="showSnackbar">Show Snackbar</button>
   <snackbar event='mailSent'></snackbar>
+
+  <icon-toggle v-model="favorited"
+               :toggle-on="{'label': favoritedLabel, 'content': 'favorite'}"
+               :toggle-off="{'label': 'Add to favorites', 'content': 'favorite_border'}">
+  </icon-toggle>
+  <div>
+   <div>
+     <label for="favorited-label">Favorited Label</label>
+     <input id="favorited-label" v-model="favoritedLabel"></input>
+   </div>
+   <p>Favorited?: {{favorited}}</p>
+  </div>
 </div>
 </template>
 
@@ -28,6 +40,7 @@
 import Ripple from './v-mdl-ripple/Ripple';
 import Snackbar from './v-mdl-snackbar/Snackbar';
 import Checkbox from './v-mdl-checkbox/Checkbox';
+import IconToggle from './v-mdl-icon-toggle/IconToggle';
 import CheckboxLabel from './v-mdl-checkbox/CheckboxLabel';
 import CheckboxWrapper from './v-mdl-checkbox/CheckboxWrapper';
 
@@ -37,10 +50,12 @@ export default {
       label: 'Test Me',
       checked: true,
       alignEnd: false,
-      changeCount: 0
+      changeCount: 0,
+      favorited: true,
+      favoritedLabel: 'Remove from favorites'
     }
   },
-  components: { Checkbox, CheckboxWrapper, CheckboxLabel, Snackbar },
+  components: { Checkbox, CheckboxWrapper, CheckboxLabel, IconToggle, Snackbar },
   directives: { Ripple },
   watch: {
     checked () {

--- a/examples/vue/src/v-mdl-icon-toggle/IconToggle.vue
+++ b/examples/vue/src/v-mdl-icon-toggle/IconToggle.vue
@@ -1,0 +1,104 @@
+
+<template>
+<i class="mdl-icon-toggle material-icons" :class="classes" role="button" aria-pressed="false"
+   :tabindex="tabIndex"
+   :data-toggle-on='toggleOnData'
+   :data-toggle-off='toggleOffData'>
+  {{text}}
+</i>
+</template>
+
+<script lang="babel">
+import { MDLIconToggleFoundation } from 'mdl-icon-toggle';
+
+export default {
+  props: ['toggleOn', 'toggleOff', 'value'],
+  data () {
+    return {
+      classes: {},
+      tabIndex: 0,
+      text: '',
+      foundation: null
+    };
+  },
+  mounted () {
+    // TODO: add the ripple
+    let vm = this;
+    this.foundation = new MDLIconToggleFoundation({
+      addClass (className) {
+        vm.$set(vm.classes, className, true);
+      },
+      removeClass (className) {
+        vm.$delete(vm.classes, className);
+      },
+      registerInteractionHandler (type, handler) {
+        vm.$el.addEventListener(type, handler);
+      },
+      deregisterInteractionHandler (type, handler) {
+        vm.$el.removeEventListener(type, handler);
+      },
+      setText (text) {
+        vm.text = text;
+      },
+      getTabIndex () {
+        return vm.tabIndex;
+      },
+      setTabIndex (tabIndex) {
+        vm.tabIndex = tabIndex;
+      },
+      getAttr (name) {
+        return vm.$el.getAttribute(name);
+      },
+      setAttr (name, value) {
+        vm.$el.setAttribute(name, value);
+      },
+      rmAttr (name) {
+        vm.$el.removeAttribute(name);
+      },
+      notifyChange (evtData) {
+        const evtType = 'MDLIconToggle:change';
+        let evt;
+        /* global CustomEvent */
+        if (typeof CustomEvent === 'function') {
+          evt = new CustomEvent(evtType, {detail: evtData});
+        } else {
+          evt = document.createEvent('CustomEvent');
+          evt.initCustomEvent(evtType, false, false, evtData);
+        }
+
+        vm.$el.dispatchEvent(evt);
+        vm.$emit('input', evtData.isOn);
+      }
+    });
+    this.foundation.init();
+    this.foundation.toggle(this.value);
+  },
+  beforeUnmount () {
+    this.foundation.destroy();
+  },
+  watch: {
+    'toggleOn': {
+      handler () { this.foundation.refreshToggleData(); },
+      deep: true
+    },
+    'toggleOff': {
+      handler () { this.foundation.refreshToggleData(); },
+      deep: true
+    }
+  },
+  computed: {
+    toggleOnData () {
+      return JSON.stringify(this.toggleOn);
+    },
+    toggleOffData () {
+      return JSON.stringify(this.toggleOff);
+    }
+  }
+}
+
+</script>
+
+<style lang="scss">
+@import 'mdl-icon-toggle/mdl-icon-toggle.scss';
+
+</style>


### PR DESCRIPTION
* Add basic icon toggle component.
* Add example icon toggle usage to demo App with v-model binding.