### PR TITLE
fix(drawer): Correctly align highlight on firefox

### DIFF
--- a/packages/mdl-drawer/_mixins.scss
+++ b/packages/mdl-drawer/_mixins.scss
@@ -124,6 +124,7 @@
   /* TODO(sgomes): Revisit when we have interactive lists. */
   .mdl-list-item::before {
     position: absolute;
+    top: 0;
     left: 0;
     width: 100%;
     height: 100%;


### PR DESCRIPTION
@sgomes @sfdexter FYI