### PR TITLE
feat(examples): add VueJS temporary drawer demo.

### DIFF
--- a/examples/vue/src/App.vue
+++ b/examples/vue/src/App.vue
@@ -1,38 +1,80 @@
 
 <template>
 <div>
-  <div class="demo-surface" v-ripple><p>{{label}}</p></div>
-  <div>
-    <checkbox-wrapper :align-end='alignEnd'>
-      <checkbox v-model="checked" label="Test me" id="my-check" label-id="my-check-label"></checkbox>
-      <checkbox-label id="my-check-label" for="my-check" :label="label"></checkbox-label>
-    </checkbox-wrapper>
-  </div>
-  <div>
-    <checkbox-wrapper>
-      <checkbox v-model="alignEnd" label="Test me" id="my-check" label-id="my-check-label"></checkbox>
-      <checkbox-label id="my-check-label" for="my-check" label="Align End?"></checkbox-label>
-    </checkbox-wrapper>
-    <input v-model="label"></input>
-  </div>
-  <div>
-   <p>Change count: {{changeCount}}</p>
+  <div class="demo-toolbar mdl-theme--primary-bg mdl-theme--text-primary-on-primary mdl-typography--title mdl-elevation--z4">
+    <button class="demo-menu material-icons" @click="$refs.drawer.open()">menu</button>
   </div>
 
-  <button type="button" @click="showSnackbar">Show Snackbar</button>
-  <snackbar event='mailSent'></snackbar>
+  <temporary-drawer ref="drawer" style="z-index: 20;">
+    <div slot="header" class="mdl-temporary-drawer__header-content mdl-theme--primary-bg mdl-them--text-primary-on-primary">
+      Header here
+    </div>
 
-  <icon-toggle v-model="favorited"
-               :toggle-on="{'label': favoritedLabel, 'content': 'favorite'}"
-               :toggle-off="{'label': 'Add to favorites', 'content': 'favorite_border'}">
-  </icon-toggle>
-  <div>
-   <div>
-     <label for="favorited-label">Favorited Label</label>
-     <input id="favorited-label" v-model="favoritedLabel"></input>
-   </div>
-   <p>Favorited?: {{favorited}}</p>
-  </div>
+    <nav class="mdl-list-group">
+      <div id="icon-with-text-demo" class="mdl-list">
+        <a class="mdl-list-item mdl-temporary-drawer--selected" href="#">
+          <i class="material-icons mdl-list-item__start-detail" aria-hidden="true">inbox</i>Inbox
+        </a>
+        <a class="mdl-list-item" href="#">
+          <i class="material-icons mdl-list-item__start-detail" aria-hidden="true">star</i>Star
+        </a>
+        <a class="mdl-list-item" href="#">
+          <i class="material-icons mdl-list-item__start-detail" aria-hidden="true">send</i>Sent Mail
+        </a>
+        <a class="mdl-list-item" href="#">
+          <i class="material-icons mdl-list-item__start-detail" aria-hidden="true">drafts</i>Drafts
+        </a>
+      </div>
+
+      <hr class="mdl-list-divider">
+
+      <div class="mdl-list">
+        <a class="mdl-list-item" href="#">
+          <i class="material-icons mdl-list-item__start-detail" aria-hidden="true">email</i>All Mail
+        </a>
+        <a class="mdl-list-item" href="#">
+          <i class="material-icons mdl-list-item__start-detail" aria-hidden="true">delete</i>Trash
+        </a>
+        <a class="mdl-list-item" href="#">
+          <i class="material-icons mdl-list-item__start-detail" aria-hidden="true">report</i>Spam
+        </a>
+      </div>
+    </nav>
+  </temporary-drawer>
+
+  <main>
+    <div class="demo-surface" v-ripple><p>{{label}}</p></div>
+    <div>
+      <checkbox-wrapper :align-end='alignEnd'>
+        <checkbox v-model="checked" label="Test me" id="my-check" label-id="my-check-label"></checkbox>
+        <checkbox-label id="my-check-label" for="my-check" :label="label"></checkbox-label>
+      </checkbox-wrapper>
+    </div>
+    <div>
+      <checkbox-wrapper>
+        <checkbox v-model="alignEnd" label="Test me" id="my-check" label-id="my-check-label"></checkbox>
+        <checkbox-label id="my-check-label" for="my-check" label="Align End?"></checkbox-label>
+      </checkbox-wrapper>
+      <input v-model="label"></input>
+    </div>
+    <div>
+     <p>Change count: {{changeCount}}</p>
+    </div>
+    <button type="button" @click="showSnackbar">Show Snackbar</button>
+    <snackbar event='mailSent'></snackbar>
+
+    <icon-toggle v-model="favorited"
+                 :toggle-on="{'label': favoritedLabel, 'content': 'favorite'}"
+                 :toggle-off="{'label': 'Add to favorites', 'content': 'favorite_border'}">
+    </icon-toggle>
+    <div>
+     <div>
+       <label for="favorited-label">Favorited Label</label>
+       <input id="favorited-label" v-model="favoritedLabel"></input>
+     </div>
+     <p>Favorited?: {{favorited}}</p>
+    </div>
+  </main>
 </div>
 </template>
 
@@ -43,6 +85,7 @@ import Checkbox from './v-mdl-checkbox/Checkbox';
 import IconToggle from './v-mdl-icon-toggle/IconToggle';
 import CheckboxLabel from './v-mdl-checkbox/CheckboxLabel';
 import CheckboxWrapper from './v-mdl-checkbox/CheckboxWrapper';
+import TemporaryDrawer from './v-mdl-drawer/TemporaryDrawer';
 
 export default {
   data () {
@@ -55,7 +98,7 @@ export default {
       favoritedLabel: 'Remove from favorites'
     }
   },
-  components: { Checkbox, CheckboxWrapper, CheckboxLabel, IconToggle, Snackbar },
+  components: { Checkbox, CheckboxWrapper, CheckboxLabel, IconToggle, Snackbar, TemporaryDrawer },
   directives: { Ripple },
   watch: {
     checked () {
@@ -77,10 +120,42 @@ export default {
 <style lang="scss">
 @import 'mdl-ripple/mdl-ripple.scss';
 @import 'mdl-elevation/mdl-elevation.scss';
+@import 'mdl-list/mdl-list.scss';
+@import 'mdl-theme/mdl-theme.scss';
+
+.demo-toolbar {
+  width: 100%;
+  height: 56px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 0 16px;
+  box-sizing: border-box;
+}
+@media (min-width: 600px) {
+  .demo-toolbar {
+    height: 64px;
+  }
+}
+
+.demo-menu {
+  background: none;
+  border: none;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  margin: 0;
+  color: #FFF;
+  box-sizing: border-box;
+}
 
 .demo-surface {
   @include mdl-elevation(2);
   width: 150px;
   height: 150px;
+}
+
+main {
+  padding: 12px;
 }
 </style>

--- a/examples/vue/src/index.html
+++ b/examples/vue/src/index.html
@@ -2,11 +2,19 @@
 <html>
   <head>
     <title>v-mdl-checkbox test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" type="text/css">
+    <style type="text/css">
+    .demo-body {
+      padding: 0;
+      margin: 0;
+      box-sizing: border-box;
+    }
+    </style>
   </head>
 
-  <body class="mdl-typography">
+  <body class="mdl-typography demo-body">
     <div id="test"></div>
   </body>
 </html>

--- a/examples/vue/src/v-mdl-drawer/TemporaryDrawer.vue
+++ b/examples/vue/src/v-mdl-drawer/TemporaryDrawer.vue
@@ -1,0 +1,113 @@
+
+<template>
+<aside class="mdl-temporary-drawer mdl-typography" :class="classes">
+  <nav ref="drawer" class="mdl-temporary-drawer__drawer">
+    
+    <div class="mdl-temporary-drawer__toolbar-spacer" v-if="$slots['toolbar-spacer'] || toolbarSpacer">
+      <slot name="toolbar-spacer"></slot>
+    </div>
+
+    <header class="mdl-temporary-drawer__header" v-if="$slots.header">
+        <slot name="header"></slot>
+    </header>
+
+    <slot></slot>
+  </nav>
+</aside>
+
+</template>
+
+<script lang="babel">
+import { MDLTemporaryDrawerFoundation } from 'mdl-drawer';
+import * as utils from 'mdl-drawer/util';
+
+export default {
+  props: ['toolbarSpacer'],
+  data () {
+    return {
+      classes: {},
+      changeHandlers: [],
+      foundation: null
+    };
+  },
+  mounted () {
+    const {FOCUSABLE_ELEMENTS, OPACITY_VAR_NAME} = MDLTemporaryDrawerFoundation.strings;
+
+    let vm = this;
+    this.foundation = new MDLTemporaryDrawerFoundation({
+      addClass (className) {
+        vm.$set(vm.classes, className, true);
+      },
+      removeClass (className) {
+        vm.$delete(vm.classes, className);
+      },
+      hasClass (className) {
+        return Boolean(vm.classes[className]) || (vm.$el && vm.$el.classList.contains(className));
+      },
+      hasNecessaryDom () {
+        return Boolean(vm.$refs.drawer);
+      },
+      registerInteractionHandler (evt, handler) {
+        vm.$el.addEventListener(evt, handler);
+      },
+      deregisterInteractionHandler (evt, handler) {
+        vm.$el.removeEventListener(evt, handler);
+      },
+      registerDrawerInteractionHandler (evt, handler) {
+        vm.$refs.drawer.addEventListener(evt, handler);
+      },
+      deregisterDrawerInteractionHandler (evt, handler) {
+        vm.$refs.drawer.removeEventListener(evt, handler);
+      },
+      registerTransitionEndHandler (handler) {
+        vm.$refs.drawer.addEventListener('transitionend', handler);
+      },
+      deregisterTransitionEndHandler (handler) {
+        vm.$refs.drawer.removeEventListener('transitionend', handler);
+      },
+      getDrawerWidth () {
+        return vm.$refs.drawer.clientWidth;
+      },
+      setTranslateX (value) {
+        vm.$refs.drawer.style.setProperty(
+          utils.getTransformPropertyName(),
+          value === null ? null : `translateX(${value}px)`
+        );
+      },
+      updateCssVariable (value) {
+        vm.$el.style.setProperty(OPACITY_VAR_NAME, value);
+      },
+      getFocusableElements () {
+        return vm.$refs.drawer.querySelectorAll(FOCUSABLE_ELEMENTS);
+      },
+      saveElementTabState (el) {
+        utils.saveElementTabState(el);
+      },
+      restoreElementTabState (el) {
+        utils.restoreElementTabState(el);
+      },
+      makeElementUntabbable (el) {
+        el.setAttribute('tabindex', -1);
+      },
+      isRtl () {
+        /* global getComputedStyle */
+        return getComputedStyle(vm.$el).getPropertyValue('direction') === 'rtl';
+      }
+    });
+    this.foundation.init();
+  },
+  beforeUnmount () {
+    this.foundation.destroy();
+  },
+  methods: {
+    open () {
+      this.foundation.open();
+    }
+  }
+}
+
+</script>
+
+<style lang="scss">
+@import 'mdl-drawer/mdl-drawer.scss';
+</style>

--- a/packages/mdl-drawer/index.js
+++ b/packages/mdl-drawer/index.js
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-import MDLTemporaryDrawer from './temporary';
+import MDLTemporaryDrawer, {MDLTemporaryDrawerFoundation} from './temporary';
 
-export {MDLTemporaryDrawer};
+export {MDLTemporaryDrawer, MDLTemporaryDrawerFoundation};

--- a/packages/mdl-drawer/temporary/index.js
+++ b/packages/mdl-drawer/temporary/index.js
@@ -18,6 +18,8 @@ import MDLComponent from 'mdl-base';
 import MDLTemporaryDrawerFoundation from './foundation';
 import * as util from '../util';
 
+export {MDLTemporaryDrawerFoundation};
+
 export default class MDLTemporaryDrawer extends MDLComponent {
   static buildDom() {
     const {ROOT: CSS_ROOT} = MDLTemporaryDrawerFoundation.cssClasses;


### PR DESCRIPTION
* Add a basic VueJS temporary drawer component, using default slot
  for content, and two different optional slots for toolbar spacer,
  and header.
* Export the MDLTemporaryDrawerFoundation for use by alternate
  host components.
* Add the temporary drawer to the VueJS demo app.