### PR TITLE
feat(checkbox): Add accessor properties / foundation methods to API

### DIFF
--- a/demos/checkbox.html
+++ b/demos/checkbox.html
@@ -150,7 +150,7 @@
         'use strict';
         var checkbox = new global.mdl.Checkbox(document.getElementById('mdl-js-checkbox'));
         document.getElementById('make-ind').addEventListener('click', function() {
-          document.getElementById('my-checkbox').indeterminate = true;
+          checkbox.indeterminate = true;
         });
       })(this);
     </script>

--- a/packages/mdl-checkbox/README.md
+++ b/packages/mdl-checkbox/README.md
@@ -132,6 +132,25 @@ import MDLCheckbox from 'mdl-checkbox';
 const checkbox = new MDLCheckbox(document.querySelector('.mdl-checkbox'));
 ```
 
+#### MDLCheckbox API
+
+The MDLCheckbox API provides accessor properties similar to those found on a native checkbox element.
+
+##### MDLCheckbox.checked
+
+Boolean. Returns whether or not the checkbox is checked. Setting this property will update the
+underlying checkbox element.
+
+##### MDLCheckbox.indeterminate
+
+Boolean. Returns whether or not the checkbox is indeterminate. Setting this property will update the
+underlying checkbox element.
+
+##### MDLCheckbox.disabled
+
+Boolean. Returns whether or not the checkbox is disabled. Setting this property will update the
+underlying checkbox element.
+
 ### Using the Foundation Class
 
 MDL Checkbox ships with an `MDLCheckboxFoundation` class that external frameworks and libraries can
@@ -151,6 +170,36 @@ vendor prefixes in order for this to work correctly. |
 | `forceLayout() => void` | Force-trigger a layout on the root element. This is needed to restart
 animations correctly. If you find that you do not need to do this, you can simply make it a no-op. |
 | `isAttachedToDOM() => boolean` | Returns true if the component is currently attached to the DOM, false otherwise.` |
+
+#### MDLCheckboxFoundation API
+
+##### MDLCheckboxFoundation.isChecked() => boolean
+
+Returns whether or not the underlying input is checked. Returns false when no input is available.
+
+##### MDLCheckboxFoundation.setChecked(checked: boolean)
+
+Updates the `checked` property on the underlying input. Does nothing when the underlying input is
+not present.
+
+##### MDLCheckboxFoundation.isIndeterminate() => boolean
+
+Returns whether or not the underlying input is indeterminate. Returns false when no input is
+available.
+
+##### MDLCheckboxFoundation.setIndeterminate(indeterminate: boolean)
+
+Updates the `indeterminate` property on the underlying input. Does nothing when the underlying input
+is not present.
+
+##### MDLCheckboxFoundation.isDisabled() => boolean
+
+Returns whether or not the underlying input is disabled. Returns false when no input is available.
+
+##### MDLCheckboxFoundation.setDisabled(disabled: boolean)
+
+Updates the `disabled` property on the underlying input. Does nothing when the underlying input is
+not present.
 
 ## Theming
 

--- a/packages/mdl-checkbox/foundation.js
+++ b/packages/mdl-checkbox/foundation.js
@@ -72,11 +72,32 @@ export default class MDLCheckboxFoundation extends MDLFoundation {
     this.uninstallPropertyChangeHooks_();
   }
 
+  isChecked() {
+    return this.getNativeControl_().checked;
+  }
+
+  setChecked(checked) {
+    this.getNativeControl_().checked = checked;
+  }
+
+  isIndeterminate() {
+    return this.getNativeControl_().indeterminate;
+  }
+
+  setIndeterminate(indeterminate) {
+    this.getNativeControl_().indeterminate = indeterminate;
+  }
+
+  isDisabled() {
+    return this.getNativeControl_().disabled;
+  }
+
+  setDisabled(disabled) {
+    this.getNativeControl_().disabled = disabled;
+  }
+
   installPropertyChangeHooks_() {
-    const nativeCb = this.adapter_.getNativeControl();
-    if (!nativeCb) {
-      return;
-    }
+    const nativeCb = this.getNativeControl_();
     const cbProto = Object.getPrototypeOf(nativeCb);
 
     CB_PROTO_PROPS.forEach(controlState => {
@@ -98,10 +119,7 @@ export default class MDLCheckboxFoundation extends MDLFoundation {
   }
 
   uninstallPropertyChangeHooks_() {
-    const nativeCb = this.adapter_.getNativeControl();
-    if (!nativeCb) {
-      return;
-    }
+    const nativeCb = this.getNativeControl_();
     const cbProto = Object.getPrototypeOf(nativeCb);
 
     CB_PROTO_PROPS.forEach(controlState => {
@@ -186,6 +204,14 @@ export default class MDLCheckboxFoundation extends MDLFoundation {
         return newState === TRANSITION_STATE_CHECKED ?
           ANIM_INDETERMINATE_CHECKED : ANIM_INDETERMINATE_UNCHECKED;
     }
+  }
+
+  getNativeControl_() {
+    return this.adapter_.getNativeControl() || {
+      checked: false,
+      indeterminate: false,
+      disabled: false
+    };
   }
 }
 

--- a/packages/mdl-checkbox/index.js
+++ b/packages/mdl-checkbox/index.js
@@ -24,19 +24,47 @@ export default class MDLCheckbox extends MDLComponent {
     return new MDLCheckbox(root);
   }
 
+  get nativeCb_() {
+    const {NATIVE_CONTROL_SELECTOR} = MDLCheckboxFoundation.strings;
+    return this.root_.querySelector(NATIVE_CONTROL_SELECTOR);
+  }
+
   getDefaultFoundation() {
-    const {ANIM_END_EVENT_NAME, NATIVE_CONTROL_SELECTOR} = MDLCheckboxFoundation.strings;
-    const nativeCb = this.root_.querySelector(NATIVE_CONTROL_SELECTOR);
+    const {ANIM_END_EVENT_NAME} = MDLCheckboxFoundation.strings;
     return new MDLCheckboxFoundation({
       addClass: className => this.root_.classList.add(className),
       removeClass: className => this.root_.classList.remove(className),
       registerAnimationEndHandler: handler => this.root_.addEventListener(ANIM_END_EVENT_NAME, handler),
       deregisterAnimationEndHandler: handler => this.root_.removeEventListener(ANIM_END_EVENT_NAME, handler),
-      registerChangeHandler: handler => nativeCb.addEventListener('change', handler),
-      deregisterChangeHandler: handler => nativeCb.removeEventListener('change', handler),
-      getNativeControl: () => nativeCb,
+      registerChangeHandler: handler => this.nativeCb_.addEventListener('change', handler),
+      deregisterChangeHandler: handler => this.nativeCb_.removeEventListener('change', handler),
+      getNativeControl: () => this.nativeCb_,
       forceLayout: () => this.root_.offsetWidth,
       isAttachedToDOM: () => Boolean(this.root_.parentNode)
     });
+  }
+
+  get checked() {
+    return this.foundation_.isChecked();
+  }
+
+  set checked(checked) {
+    this.foundation_.setChecked(checked);
+  }
+
+  get indeterminate() {
+    return this.foundation_.isIndeterminate();
+  }
+
+  set indeterminate(indeterminate) {
+    this.foundation_.setIndeterminate(indeterminate);
+  }
+
+  get disabled() {
+    return this.foundation_.isDisabled();
+  }
+
+  set disabled(disabled) {
+    this.foundation_.setDisabled(disabled);
   }
 }

--- a/test/unit/mdl-checkbox/foundation.test.js
+++ b/test/unit/mdl-checkbox/foundation.test.js
@@ -193,6 +193,81 @@ test('#destroy handles case when WebIDL attrs cannot be overridden (Safari)', t 
   t.end();
 });
 
+test('#setChecked updates the value of nativeControl.checked', t => {
+  const {foundation, nativeControl} = setupTest();
+  foundation.setChecked(true);
+  t.true(foundation.isChecked());
+  t.true(nativeControl.checked);
+  foundation.setChecked(false);
+  t.false(foundation.isChecked());
+  t.false(nativeControl.checked);
+  t.end();
+});
+
+test('#setChecked works when no native control is returned', t => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.getNativeControl()).thenReturn(null);
+  t.doesNotThrow(() => foundation.setChecked(true));
+  t.end();
+});
+
+test('#isChecked returns false when no native control is returned', t => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.getNativeControl()).thenReturn(null);
+  t.false(foundation.isChecked());
+  t.end();
+});
+
+test('#setIndeterminate updates the value of nativeControl.indeterminate', t => {
+  const {foundation, nativeControl} = setupTest();
+  foundation.setIndeterminate(true);
+  t.true(foundation.isIndeterminate());
+  t.true(nativeControl.indeterminate);
+  foundation.setIndeterminate(false);
+  t.false(foundation.isIndeterminate());
+  t.false(nativeControl.indeterminate);
+  t.end();
+});
+
+test('#setIndeterminate works when no native control is returned', t => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.getNativeControl()).thenReturn(null);
+  t.doesNotThrow(() => foundation.setIndeterminate(true));
+  t.end();
+});
+
+test('#isIndeterminate returns false when no native control is returned', t => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.getNativeControl()).thenReturn(null);
+  t.false(foundation.isIndeterminate());
+  t.end();
+});
+
+test('#setDisabled updates the value of nativeControl.disabled', t => {
+  const {foundation, nativeControl} = setupTest();
+  foundation.setDisabled(true);
+  t.true(foundation.isDisabled());
+  t.true(nativeControl.disabled);
+  foundation.setDisabled(false);
+  t.false(foundation.isDisabled());
+  t.false(nativeControl.disabled);
+  t.end();
+});
+
+test('#isDisabled returns false when no native control is returned', t => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.getNativeControl()).thenReturn(null);
+  t.false(foundation.isDisabled());
+  t.end();
+});
+
+test('#setDisabled works when no native control is returned', t => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.getNativeControl()).thenReturn(null);
+  t.doesNotThrow(() => foundation.setDisabled(true));
+  t.end();
+});
+
 testChangeHandler('unchecked -> checked animation class', {
   checked: true,
   indeterminate: false

--- a/test/unit/mdl-checkbox/mdl-checkbox.test.js
+++ b/test/unit/mdl-checkbox/mdl-checkbox.test.js
@@ -56,7 +56,34 @@ test('attachTo initializes and returns a MDLCheckbox instance', t => {
   t.end();
 });
 
-test('foundationAdapter#addClass adds a class to the root element', t => {
+test('get/set checked updates the checked property on the native checkbox element', t => {
+  const {root, component} = setupTest();
+  const cb = root.querySelector(strings.NATIVE_CONTROL_SELECTOR);
+  component.checked = true;
+  t.true(cb.checked);
+  t.equal(component.checked, cb.checked);
+  t.end();
+});
+
+test('get/set indeterminate updates the indeterminate property on the native checkbox element', t => {
+  const {root, component} = setupTest();
+  const cb = root.querySelector(strings.NATIVE_CONTROL_SELECTOR);
+  component.indeterminate = true;
+  t.true(cb.indeterminate);
+  t.equal(component.indeterminate, cb.indeterminate);
+  t.end();
+});
+
+test('get/set disabled updates the indeterminate property on the native checkbox element', t => {
+  const {root, component} = setupTest();
+  const cb = root.querySelector(strings.NATIVE_CONTROL_SELECTOR);
+  component.disabled = true;
+  t.true(cb.disabled);
+  t.equal(component.disabled, cb.disabled);
+  t.end();
+});
+
+test('adapter#addClass adds a class to the root element', t => {
   const {root, component} = setupTest();
   component.getDefaultFoundation().adapter_.addClass('foo');
   t.true(root.classList.contains('foo'));


### PR DESCRIPTION
* Add `checked`, `indeterminate`, and `disabled` accessor properties /
  methods to component / foundation (respectively) mirroring the native
  HTMLCheckboxElement API.
* Light cleanup and refactoring.

Resolves #4681
[Delivers #128594215]