### PR TITLE
fix(textfield): Correct typography to allow for proper transforms

### DIFF
--- a/demos/textfield.html
+++ b/demos/textfield.html
@@ -83,7 +83,7 @@
     <section>
       <h2>Password field with validation</h2>
       <div class="mdl-textfield">
-        <input required minlength=8 type="password" class="mdl-textfield__input" id="pw"
+        <input required pattern=".{8,}" type="password" class="mdl-textfield__input" id="pw"
                aria-controls="pw-validation-msg">
         <label for="pw" class="mdl-textfield__label">Choose password</label>
       </div>

--- a/packages/mdl-textfield/mdl-textfield.scss
+++ b/packages/mdl-textfield/mdl-textfield.scss
@@ -18,6 +18,7 @@
 @import "mdl-theme/variables";
 @import "mdl-theme/mixins";
 @import "mdl-typography/mixins";
+@import "mdl-typography/variables";
 
 $mdl-textfield-error-on-light: #d50000;
 $mdl-textfield-error-on-dark: #ff6e6e;
@@ -32,13 +33,17 @@ $mdl-textfield-disabled-border-on-dark: rgba(white, .3);
 
 /* postcss-bem-linter: define textfield */
 .mdl-textfield {
-  @include mdl-typography(subheading1);
+  @include mdl-typography-base;
+
+  // We use only a subset of the MDL typography values here as changing things such as line-height
+  // affects how the labels are transformed.
+  @each $prop in (font-size, letter-spacing) {
+    #{$prop}: map-get(map-get($mdl-typography-styles, subheading2), $prop);
+  }
 
   display: inline-block;
   margin-bottom: 8px;
   will-change: opacity, transform, color;
-  // Override mdl-typography changes
-  line-height: 1rem;
 
   &__input {
     @include mdl-theme-prop(color, text-primary-on-light);
@@ -90,7 +95,6 @@ $mdl-textfield-disabled-border-on-dark: rgba(white, .3);
     transform-origin: left top;
     transition: mdl-textfield-transition(transform), mdl-textfield-transition(color);
     cursor: text;
-    will-change: transform, color;
 
     /* stylelint-disable plugin/selector-bem-pattern */
     [dir="rtl"] & {
@@ -168,11 +172,7 @@ $mdl-textfield-disabled-border-on-dark: rgba(white, .3);
 .mdl-textfield--dense {
   margin-top: 12px;
   margin-bottom: 4px;
-
-  .mdl-textfield__input,
-  .mdl-textfield__label {
-    font-size: .813rem;
-  }
+  font-size: .813rem;
 
   .mdl-textfield__label--float-above {
     // NOTE: This is an eyeball'd approximation of what's in the mocks.


### PR DESCRIPTION
* Fixes floating label transforms by using subheading2 instead of
  subheading 1, and only including `font-size` and `line-height`
  measurements within those applications. Note that for dense mode,
  it doesn't look like the `line-height` needs to be changed.
* Remove `will-change` property from label, as parent element already
  has `will-change` and adding it makes pre-floated labels look blurry
  in Chrome.
* Update the password demo to use `pattern` rather than `minlength`,
  which has better cross-browser support.