### PR TITLE
feat(textfield): Multi-line support

### DIFF
--- a/demos/textfield.html
+++ b/demos/textfield.html
@@ -111,6 +111,41 @@
         </label>
       </div>
     </section>
+    <section>
+      <h2>Multi-line Textfields</h2>
+      <section id="demo-textfield-multiline-wrapper" style="overflow:hidden;">
+        <div class="mdl-textfield mdl-textfield--multiline">
+          <textarea id="multi-line" class="mdl-textfield__input" rows="8" cols="40"></textarea>
+          <label for="multi-line" class="mdl-textfield__label">Multi-line Label</label>
+        </div>
+      </section>
+      <div>
+        <input id="multi-disable" type="checkbox">
+        <label for="multi-disable">Disable</label>
+      </div>
+      <div>
+        <input id="multi-rtl" type="checkbox">
+        <label for="multi-rtl">RTL</label>
+      </div>
+      <div>
+        <input id="multi-dark-theme" type="checkbox">
+        <label for="multi-dark-theme">Dark Theme</label>
+      </div>
+      <div>
+        <input id="multi-required" type="checkbox">
+        <label for="multi-required">Required</label>
+      </div>
+    </section>
+    <section>
+      <h2>Multi-line Textfields - CSS Only</h2>
+      <label for="css-only-multiline" style="margin-bottom:4px;">About you:</label>
+      <div class="mdl-textfield mdl-textfield--multiline" data-no-js>
+        <textarea class="mdl-textfield__input"
+                  id="css-only-multiline"
+                  rows="8" cols="40"
+                  placeholder="Tell the world something about yourself!"></textarea>
+      </div>
+    </section>
     <script src="assets/material-design-lite.js" charset="utf-8"></script>
     <script>
       (function() {
@@ -171,6 +206,33 @@
           helptext.classList[target.checked ? 'add' : 'remove'](
             'mdl-textfield-helptext--validation-msg'
           );
+        });
+      })();
+    </script>
+    <script>
+      (function() {
+        var section = document.getElementById('demo-textfield-multiline-wrapper');
+        var tfRoot = section.querySelector('.mdl-textfield');
+        var tf = new mdl.Textfield(tfRoot);
+        document.getElementById('multi-disable').addEventListener('change', function(evt) {
+          var target = evt.target;
+          tf.disabled = target.checked;
+        });
+        document.getElementById('multi-rtl').addEventListener('change', function(evt) {
+          var target = evt.target;
+          if (target.checked) {
+            section.setAttribute('dir', 'rtl');
+          } else {
+            section.removeAttribute('dir');
+          }
+        });
+        document.getElementById('multi-dark-theme').addEventListener('change', function(evt) {
+          var target = evt.target;
+          section.classList[target.checked ? 'add' : 'remove']('mdl-theme--dark');
+        });
+        document.getElementById('multi-required').addEventListener('change', function(evt) {
+          var target = evt.target;
+          tfRoot.querySelector('.mdl-textfield__input').required = target.checked;
         });
       })();
     </script>

--- a/packages/mdl-textfield/README.md
+++ b/packages/mdl-textfield/README.md
@@ -157,6 +157,27 @@ UX for client-side form field validation.
 </p>
 ```
 
+### Multi-line - With Javascript
+
+```html
+<div class="mdl-textfield mdl-textfield--multiline">
+  <textarea id="multi-line" class="mdl-textfield__input" rows="8" cols="40"></textarea>
+  <label for="multi-line" class="mdl-textfield__label">Multi-line Label</label>
+</div>
+```
+
+### Multi-line - Gracefully Degraded
+
+```html
+<label for="css-only-multiline">Multi-line label: </label>
+<div class="mdl-textfield mdl-textfield--multiline">
+  <textarea class="mdl-textfield__input"
+            id="css-only-multiline"
+            rows="8" cols="40"
+            placeholder="Tell the world something about yourself!"></textarea>
+</div>
+```
+
 ### Using the JS component
 
 MDL Textfield ships with Component / Foundation classes which are used to provide a full-fidelity

--- a/packages/mdl-textfield/mdl-textfield.scss
+++ b/packages/mdl-textfield/mdl-textfield.scss
@@ -56,7 +56,7 @@ $mdl-textfield-disabled-border-on-dark: rgba(white, .3);
 
     &::placeholder {
       @include mdl-theme-prop(color, text-hint-on-light);
-
+      transition: mdl-textfield-transition(color);
       opacity: 1;
     }
 
@@ -263,43 +263,119 @@ $mdl-textfield-disabled-border-on-dark: rgba(white, .3);
   }
 }
 
+.mdl-textfield--multiline {
+  /* stylelint-disable scss/dollar-variable-pattern */
+  $padding-inset: 4px;
+  $label-offset-y: $padding-inset + 2;
+  $label-offset-x: $padding-inset;
+  /* stylelint-enable scss/dollar-variable-pattern */
+
+  display: flex;
+  height: initial;
+  transition: none;
+
+  &::after {
+    content: initial;
+  }
+
+  /* stylelint-disable plugin/selector-bem-pattern */
+
+  .mdl-textfield__input {
+    padding: $padding-inset;
+    transition: mdl-textfield-transition(border-color);
+    border: 1px solid $mdl-textfield-divider-on-light;
+    border-radius: 2px;
+
+    @include mdl-theme-dark(".mdl-textfield") {
+      border-color: $mdl-textfield-divider-on-dark;
+    }
+
+    &:focus {
+      @include mdl-theme-prop(border-color, primary);
+    }
+
+    &:invalid:not(:focus) {
+      border-color: $mdl-textfield-error-on-light;
+    }
+
+    @include mdl-theme-dark(".mdl-textfield") {
+      &:invalid:not(:focus) {
+        border-color: $mdl-textfield-error-on-dark;
+      }
+    }
+  }
+
+  .mdl-textfield__label {
+    top: $label-offset-y;
+    bottom: initial;
+    left: $label-offset-x;
+
+    [dir="rtl"] & {
+      right: $label-offset-x;
+      left: auto;
+    }
+
+    &--float-above {
+      // Translate above the top of the input, and compensate for the amount of offset needed
+      // to position the label within the bounds of the inset padding.
+      // Note that the scale factor is an eyeball'd approximation of what's shown in the mocks.
+      transform: translateY(calc(-100% - #{$label-offset-y})) scale(.923, .923);
+    }
+  }
+
+  &.mdl-textfield--disabled {
+    border-bottom: none;
+
+    .mdl-textfield__input {
+      border: 1px dotted $mdl-textfield-disabled-border-on-light;
+
+      @include mdl-theme-dark(".mdl-textfield") {
+        border-color: $mdl-textfield-disabled-border-on-dark;
+      }
+    }
+  }
+  /* stylelint-enable plugin/selector-bem-pattern */
+}
+
 // Graceful degredation for css-only inputs
 
 .mdl-textfield {
-  &:not(.mdl-textfield--upgraded) .mdl-textfield__input {
+  &:not(.mdl-textfield--upgraded):not(.mdl-textfield--multiline) .mdl-textfield__input {
     transition: mdl-textfield-transition(border-bottom-color);
     border-bottom: 1px solid $mdl-textfield-divider-on-light;
+  }
 
+  &:not(.mdl-textfield--upgraded) .mdl-textfield__input {
     &:focus {
-      @include mdl-theme-prop(border-bottom-color, primary);
+      @include mdl-theme-prop(border-color, primary);
     }
 
     &:disabled {
       @include mdl-theme-prop(color, text-disabled-on-light);
 
-      border-bottom-style: dotted;
-      border-bottom-color: $mdl-textfield-disabled-border-on-light;
+      border-style: dotted;
+      border-color: $mdl-textfield-disabled-border-on-light;
     }
 
     &:invalid:not(:focus) {
-      border-bottom-color: $mdl-textfield-error-on-light;
+      border-color: $mdl-textfield-error-on-light;
     }
   }
 
   @include mdl-theme-dark {
     &:not(.mdl-textfield--upgraded) .mdl-textfield__input {
       &:not(:focus) {
-        border-bottom-color: rgba(white, .12);
+        border-color: rgba(white, .12);
       }
 
       &:disabled {
         @include mdl-theme-prop(color, text-disabled-on-dark);
 
-        border-bottom-color: $mdl-textfield-disabled-border-on-dark;
+        border-color: $mdl-textfield-disabled-border-on-dark;
       }
 
       &:invalid:not(:focus) {
-        border-bottom-color: $mdl-textfield-error-on-dark;
+        border-color: $mdl-textfield-error-on-dark;
       }
     }
   }


### PR DESCRIPTION
* Adds styles to support multi-line inputs (both with and without JS)

While these multi-line mocks are different than what's shown in the
mocks, we believe it to be better UX for the web platform that interops
well with how the native textarea element behaves.

Also note that this was OK'd by design. Inputs are apparently being iterated
on, but what we've done here aligns with their thinking.

Part of #4479
[Delivers #129705881]