### PR TITLE
feat(text-field): Full-width support

### DIFF
--- a/demos/textfield.html
+++ b/demos/textfield.html
@@ -37,7 +37,7 @@
       <section id="demo-textfield-wrapper">
         <div class="mdl-textfield">
           <input type="text" class="mdl-textfield__input" id="my-textfield"
-                 aria-controls="my-textfield-helptext">
+                 aria-controls="my-textfield-helptext" data-demo-no-auto-js>
           <label for="my-textfield" class="mdl-textfield__label">Label text</label>
         </div>
         <p id="my-textfield-helptext" class="mdl-textfield-helptext"
@@ -47,7 +47,7 @@
       </section>
       <div>
         <input id="disable" type="checkbox">
-        <label for="disable">Disable</label>
+        <label for="disable">Disabled</label>
       </div>
       <div>
         <input id="rtl" type="checkbox">
@@ -95,7 +95,7 @@
     <section>
       <h2>CSS Only</h2>
       <div class="mdl-form-field mdl-form-field--align-end">
-        <div class="mdl-textfield" data-no-js>
+        <div class="mdl-textfield" data-demo-no-auto-js>
           <input type="text" class="mdl-textfield__input" id="css-only-textfield"
                  placeholder="Name">
         </div>
@@ -121,7 +121,7 @@
       </section>
       <div>
         <input id="multi-disable" type="checkbox">
-        <label for="multi-disable">Disable</label>
+        <label for="multi-disable">Disabled</label>
       </div>
       <div>
         <input id="multi-rtl" type="checkbox">
@@ -139,18 +139,41 @@
     <section>
       <h2>Multi-line Textfields - CSS Only</h2>
       <label for="css-only-multiline" style="margin-bottom:4px;">About you:</label>
-      <div class="mdl-textfield mdl-textfield--multiline" data-no-js>
+      <div class="mdl-textfield mdl-textfield--multiline" data-demo-no-auto-js>
         <textarea class="mdl-textfield__input"
                   id="css-only-multiline"
                   rows="8" cols="40"
                   placeholder="Tell the world something about yourself!"></textarea>
       </div>
     </section>
+    <section>
+      <h2>Full-Width Textfields</h2>
+      <div id="demo-fullwidth-wrapper">
+        <div class="mdl-textfield mdl-textfield--fullwidth" data-demo-no-auto-js>
+          <input class="mdl-textfield__input" type="text" placeholder="Subject" aria-label="Subject">
+        </div>
+        <div class="mdl-textfield mdl-textfield--multiline mdl-textfield--fullwidth" data-demo-no-auto-js>
+          <textarea class="mdl-textfield__input" placeholder="Message" rows="8" cols="40" aria-label="Message"></textarea>
+        </div>
+      </div>
+      <div>
+        <input type="checkbox" id="fullwidth-disable">
+        <label for="fullwidth-disable">Disabled</label>
+      </div>
+      <div>
+        <input type="checkbox" id="fullwidth-dense">
+        <label for="fullwidth-dense">Dense</label>
+      </div>
+      <div>
+        <input type="checkbox" id="fullwidth-dark-theme">
+        <label for="fullwidth-dark-theme">Dark Theme</label>
+      </div>
+    </section>
     <script src="assets/material-design-lite.js" charset="utf-8"></script>
     <script>
       (function() {
         var tfs = document.querySelectorAll(
-          ':not(#textfield-wrapper) .mdl-textfield:not([data-no-js])'
+          '.mdl-textfield:not([data-demo-no-auto-js])'
         );
         for (var i = 0, tf; tf = tfs[i]; i++) {
           mdl.Textfield.attachTo(tf);
@@ -233,6 +256,34 @@
         document.getElementById('multi-required').addEventListener('change', function(evt) {
           var target = evt.target;
           tfRoot.querySelector('.mdl-textfield__input').required = target.checked;
+        });
+      })();
+    </script>
+    <script charset="utf-8">
+      (function() {
+        var section = document.getElementById('demo-fullwidth-wrapper');
+        var tfRoot = section.querySelector('.mdl-textfield');
+        var tfMultiRoot = section.querySelector('.mdl-textfield--multiline');
+        var tf = new mdl.Textfield(tfRoot);
+        var tfMulti = new mdl.Textfield(tfMultiRoot);
+
+        document.getElementById('fullwidth-disable').addEventListener('change', function(evt) {
+          var target = evt.target;
+          [tf, tfMulti].forEach(function(component) {
+            component.disabled = target.checked;
+          });
+        });
+
+        document.getElementById('fullwidth-dense').addEventListener('change', function(evt) {
+          var target = evt.target;
+          [tfRoot, tfMultiRoot].forEach(function(el) {
+            el.classList[target.checked ? 'add' : 'remove']('mdl-textfield--dense');
+          });
+        });
+
+        document.getElementById('fullwidth-dark-theme').addEventListener('change', function(evt) {
+          var target = evt.target;
+          section.classList[target.checked ? 'add' : 'remove']('mdl-theme--dark');
         });
       })();
     </script>

--- a/packages/mdl-textfield/README.md
+++ b/packages/mdl-textfield/README.md
@@ -1,14 +1,5 @@
 # MDL Textfield
 
-> Status:
->
-> - [x] Single-line text fields
-> - [ ] Full-width text fields
-> - [ ] Character counter support
-> - :no_entry_sign: Auto-complete (will be covered in #4500)
->
-> See #4479
-
 The MDL Textfield component provides a textual input field adhering to the [Material Design Specification](https://material.google.com/components/text-fields.html).
 It is fully accessible, ships with RTL support, and includes a gracefully-degraded version that does
 not require any javascript.
@@ -178,6 +169,23 @@ UX for client-side form field validation.
 </div>
 ```
 
+### Full-width
+
+```html
+<div class="mdl-textfield mdl-textfield--fullwidth">
+  <input class="mdl-textfield__input"
+         type="text"
+         placeholder="Full-Width Textfield"
+         aria-label="Full-Width Textfield">
+</div>
+<div class="mdl-textfield mdl-textfield--multiline mdl-textfield--fullwidth">
+  <textarea class="mdl-textfield__input"
+            placeholder="Full-Width multiline textfield"
+            rows="8" cols="40"
+            aria-label="Full-Width multiline textfield"></textarea>
+</div>
+```
+
 ### Using the JS component
 
 MDL Textfield ships with Component / Foundation classes which are used to provide a full-fidelity
@@ -255,7 +263,7 @@ complicated.
 | --- | --- |
 | addClass(className: string) => void | Adds a class to the root element |
 | removeClass(className: string) => void | Removes a class from the root element |
-| addClassToLabel(className: string) => void | Adds a class to the label element. Note that we assume here that if the foundation is being used, the user has opted to put the label inside of the `mdl-textfield` element. We make this assumption in our vanilla component. You could accommodate an optional label by adding a check to make sure there is a label element |
+| addClassToLabel(className: string) => void | Adds a class to the label element. We recommend you add a conditional check here, and in `removeClassFromLabel` for whether or not the label is present so that the JS component could be used with text fields that don't require a label, such as the full-width text field. |
 | removeClassFromLabel(className: string) => void | Removes a class from the label element |
 | addClassToHelptext(className: string) => void | Adds a class to the help text element. Note that in our code we check for whether or not we have a help text element and if we don't, we simply return. |
 | removeClassFromHelptext(className: string) => void | Removes a class from the help text element. |

--- a/packages/mdl-textfield/index.js
+++ b/packages/mdl-textfield/index.js
@@ -58,8 +58,18 @@ export default class MDLTextfield extends MDLComponent {
     return new MDLTextfieldFoundation(Object.assign({
       addClass: className => this.root_.classList.add(className),
       removeClass: className => this.root_.classList.remove(className),
-      addClassToLabel: className => this.label_.classList.add(className),
-      removeClassFromLabel: className => this.label_.classList.remove(className)
+      addClassToLabel: className => {
+        const label = this.label_;
+        if (label) {
+          label.classList.add(className);
+        }
+      },
+      removeClassFromLabel: className => {
+        const label = this.label_;
+        if (label) {
+          label.classList.remove(className);
+        }
+      }
     }, this.getInputAdapterMethods_(), this.getHelptextAdapterMethods_()));
   }
 

--- a/packages/mdl-textfield/mdl-textfield.scss
+++ b/packages/mdl-textfield/mdl-textfield.scss
@@ -34,7 +34,6 @@ $mdl-textfield-disabled-border-on-dark: rgba(white, .3);
 /* postcss-bem-linter: define textfield */
 .mdl-textfield {
   @include mdl-typography-base;
-
   // We use only a subset of the MDL typography values here as changing things such as line-height
   // affects how the labels are transformed.
   @each $prop in (font-size, letter-spacing) {
@@ -115,28 +114,32 @@ $mdl-textfield-disabled-border-on-dark: rgba(white, .3);
   }
 }
 
-.mdl-textfield--upgraded {
+.mdl-textfield--upgraded:not(.mdl-textfield--fullwidth) {
   display: inline-flex;
   position: relative;
   box-sizing: border-box;
   align-items: flex-end;
-  height: 48px;
+
   margin-top: 16px;
 
-  &::after {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    height: 1px;
-    transform: translateY(50%) scaleY(1);
-    transform-origin: center bottom;
-    transition: mdl-textfield-transition(background-color), mdl-textfield-transition(transform);
-    background-color: $mdl-textfield-divider-on-light;
-    content: "";
+  &:not(.mdl-textfield--multiline) {
+    height: 48px;
 
-    @include mdl-theme-dark(".mdl-textfield") {
-      background-color: $mdl-textfield-divider-on-dark;
+    &::after {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      height: 1px;
+      transform: translateY(50%) scaleY(1);
+      transform-origin: center bottom;
+      transition: mdl-textfield-transition(background-color), mdl-textfield-transition(transform);
+      background-color: $mdl-textfield-divider-on-light;
+      content: "";
+
+      @include mdl-theme-dark(".mdl-textfield") {
+        background-color: $mdl-textfield-divider-on-dark;
+      }
     }
   }
 }
@@ -335,6 +338,65 @@ $mdl-textfield-disabled-border-on-dark: rgba(white, .3);
     }
   }
   /* stylelint-enable plugin/selector-bem-pattern */
+}
+
+.mdl-textfield--fullwidth {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+  border: none;
+  border-bottom: 1px solid $mdl-textfield-divider-on-light;
+  outline: none;
+
+  /* stylelint-disable plugin/selector-bem-pattern */
+
+  &:not(.mdl-textfield--multiline) {
+    height: 56px;
+  }
+
+  &.mdl-textfield--multiline {
+    padding: 20px 0 0;
+  }
+
+  &.mdl-textfield--dense {
+    &:not(.mdl-textfield--multiline) {
+      height: 48px;
+    }
+
+    &.mdl-textfield--multiline {
+      padding: 16px 0 0;
+    }
+  }
+
+  &.mdl-textfield--disabled {
+    &,
+    &.mdl-textfield--multiline {
+      border-bottom: 1px dotted $mdl-textfield-divider-on-light;
+    }
+  }
+
+  @include mdl-theme-dark {
+    border-bottom: 1px solid $mdl-textfield-divider-on-dark;
+
+    &.mdl-textfield--disabled {
+      &,
+      &.mdl-textfield--multiline {
+        border-bottom: 1px dotted $mdl-textfield-divider-on-dark;
+      }
+    }
+  }
+
+  /* stylelint-enable plugin/selector-bem-pattern */
+
+  .mdl-textfield__input {
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    resize: none;
+    // Use !important here to override all other border treatments
+    border: none !important;
+  }
 }
 
 // Graceful degredation for css-only inputs

--- a/test/unit/mdl-textfield/mdl-textfield.test.js
+++ b/test/unit/mdl-textfield/mdl-textfield.test.js
@@ -95,12 +95,26 @@ test('#adapter.addClassToLabel adds a class to the label element', t => {
   t.end();
 });
 
+test('#adapter.addClassToLabel does nothing if no label element present', t => {
+  const {root, component} = setupTest();
+  root.removeChild(root.querySelector('.mdl-textfield__label'));
+  t.doesNotThrow(() => component.getDefaultFoundation().adapter_.addClassToLabel('foo'));
+  t.end();
+});
+
 test('#adapter.removeClassFromLabel removes a class from the label element', t => {
   const {root, component} = setupTest();
   const label = root.querySelector('.mdl-textfield__label');
   label.classList.add('foo');
   component.getDefaultFoundation().adapter_.removeClassFromLabel('foo');
   t.false(label.classList.contains('foo'));
+  t.end();
+});
+
+test('#adapter.removeClassFromLabel does nothing if no label element present', t => {
+  const {root, component} = setupTest();
+  root.removeChild(root.querySelector('.mdl-textfield__label'));
+  t.doesNotThrow(() => component.getDefaultFoundation().adapter_.removeClassFromLabel('foo'));
   t.end();
 });
 


### PR DESCRIPTION
* Add styles for full-width text fields
* Make JS Textfield component more resiliant to label omission
* Fix issue where multi-line textfields that were upgraded had double
  bottom borders
* Use better data attr name for excluding auto-initialization of text
  fields within the demo

Closes #4479
[Delivers #129705931]