### PR TITLE
fix(ripple): Always animate deactivation deactivating pointer activation

### DIFF
--- a/packages/mdl-ripple/foundation.js
+++ b/packages/mdl-ripple/foundation.js
@@ -143,8 +143,8 @@ export default class MDLRippleFoundation extends MDLFoundation {
       e.type === 'mousedown' || e.type === 'touchstart' || e.type === 'pointerdown'
     );
 
+    activationState.activationStartTime = Date.now();
     requestAnimationFrame(() => {
-      activationState.activationStartTime = Date.now();
       // This needs to be wrapped in an rAF call b/c web browsers
       // report active states inconsistently when they're called within
       // event handling code:
@@ -234,9 +234,9 @@ export default class MDLRippleFoundation extends MDLFoundation {
     }
   }
 
-  animateDeactivation_(e, {wasElementMadeActive, activationStartTime}) {
+  animateDeactivation_(e, {wasActivatedByPointer, wasElementMadeActive, activationStartTime}) {
     const {BG_ACTIVE} = MDLRippleFoundation.cssClasses;
-    if (wasElementMadeActive) {
+    if (wasActivatedByPointer || wasElementMadeActive) {
       this.adapter_.removeClass(BG_ACTIVE);
       const isPointerEvent = (
         e.type === 'touchend' || e.type === 'pointerup' || e.type === 'mouseup'
@@ -259,7 +259,6 @@ export default class MDLRippleFoundation extends MDLFoundation {
       VAR_FG_UNBOUNDED_TRANSFORM_DURATION,
       VAR_FG_APPROX_XF
     } = MDLRippleFoundation.strings;
-
     this.adapter_.updateCssVariable(VAR_FG_APPROX_XF, `scale(${approxCurScale})`);
     this.adapter_.updateCssVariable(VAR_FG_UNBOUNDED_OPACITY_DURATION, `${opacityDuration}ms`);
     this.adapter_.updateCssVariable(VAR_FG_UNBOUNDED_TRANSFORM_DURATION, `${transformDuration}ms`);

--- a/test/unit/mdl-ripple/foundation-deactivation.test.js
+++ b/test/unit/mdl-ripple/foundation-deactivation.test.js
@@ -311,3 +311,22 @@ testFoundation('cancels unbounded deactivation class removal on deactivation', t
   clock.uninstall();
   t.end();
 });
+
+testFoundation('ensures pointer event deactivation occurs even if activation rAF not run', t => {
+  const clock = lolex.install();
+  const {foundation, adapter, mockRaf} = t.data;
+  const handlers = captureHandlers(adapter);
+  td.when(adapter.isUnbounded()).thenReturn(true);
+  foundation.init();
+  mockRaf.flush();
+
+  handlers.mousedown({pageX: 0, pageY: 0});
+  mockRaf.pendingFrames.shift();
+  clock.tick(100);
+  handlers.mouseup();
+  mockRaf.flush();
+
+  t.doesNotThrow(() => td.verify(adapter.addClass(cssClasses.FG_UNBOUNDED_DEACTIVATION)));
+  clock.uninstall();
+  t.end();
+});


### PR DESCRIPTION
Issue arises when deactivation event happens before the activation animation
frame fires.

Also fixes issue in Safari TP where deactivation event was being
triggered before activation animation frame, causing the activation
start time to never be recorded.

Fixes #4821
[Delivers #131734447]