### PR TITLE
feat(Card): enable border for mdl-card__supporting-text

### DIFF
--- a/src/card/_card.scss
+++ b/src/card/_card.scss
@@ -84,6 +84,10 @@
   overflow: hidden;
   padding: $card-vertical-padding $card-horizontal-padding;
   width: 90%;
+
+  &.mdl-card--border {
+    border-bottom: 1px solid $card-border-color;
+  }
 }
 
 .mdl-card__actions {


### PR DESCRIPTION
I believe we should also enable border for `mdl-card__supporting-text` as well.

Usage:

```html
<div class="mdl-card__supporting-text mdl-card--border">
Now I can have divisions inside my card
</div>
```