### PR TITLE
fix(textfield): Ensure upgraded underline expands on focus

### DIFF
--- a/packages/mdl-textfield/mdl-textfield.scss
+++ b/packages/mdl-textfield/mdl-textfield.scss
@@ -155,7 +155,7 @@ $mdl-textfield-disabled-border-on-dark: rgba(white, .3);
     @include mdl-theme-prop(color, primary);
   }
 
-  &::after {
+  &.mdl-textfield--upgraded:not(.mdl-textfield--fullwidth):not(.mdl-textfield--multiline)::after {
     @include mdl-textfield-after-styles;
 
     @include mdl-theme-dark(".mdl-textfield", true) {


### PR DESCRIPTION
Fixes issue where underline on upgraded text fields was not expanding
correctly, due to a higher-specificity rule overriding it.

Hotfix, so no GH/Tracker issue.