### PR TITLE
feat(menu): Add selection event support

### DIFF
--- a/demos/simple-menu.html
+++ b/demos/simple-menu.html
@@ -58,7 +58,10 @@
           Dark mode
         </label>
       </p>
-      <div><button class="toggle">Toggle</button></div>
+      <div>
+        <button class="toggle">Toggle</button>
+        <span>Last Selected item: <em id="last-selected">&lt;none selected&gt;</em></span>
+      </div>
       <div class="mdl-simple-menu">
         <ul class="mdl-simple-menu__items mdl-list" role="menu" aria-hidden="true">
           <li class="mdl-list-item" role="menuitem" tabindex="0">Back</li>
@@ -109,6 +112,13 @@
           }
         });
       }
+
+      var lastSelected = document.getElementById('last-selected');
+      menuEl.addEventListener('MDLSimpleMenu:selected', function(evt) {
+        const detail = evt.detail;
+        lastSelected.textContent = '"' + detail.item.textContent.trim() +
+          '" at index ' + detail.index;
+      });
     </script>
   </body>
 </html>

--- a/packages/mdl-base/README.md
+++ b/packages/mdl-base/README.md
@@ -159,6 +159,7 @@ export class MyComponent extends MDLComponent {
 | `getDefaultFoundation()` | Returns an instance of a foundation class properly configured for the component. Called when no foundation instance is given within the constructor. Subclasses **must** implement this method. |
 | `initialSyncWithDOM()` | Called within the constructor. Subclasses may override this method if they wish to perform initial synchronization of state with the host DOM element. For example, a slider may want to check if its host element contains a pre-set value, and adjust its internal state accordingly. Note that the same caveats apply to this method as to foundation class lifecycle methods. Defaults to a no-op. |
 | `destroy()` | Subclasses may override this method if they wish to perform any additional cleanup work when a component is destroyed. For example, a component may want to deregister a window resize listener. |
+| `emit(type: string, data: Object)` | Dispatches a custom event of type `type` with detail `data` from the component's root node. This is the preferred way of dispatching events within our vanilla components. |
 
 #### Static Methods
 

--- a/packages/mdl-base/component.js
+++ b/packages/mdl-base/component.js
@@ -51,4 +51,18 @@ export default class MDLComponent {
     // attached. An example of this might be deregistering a resize event from the window object.
     this.foundation_.destroy();
   }
+
+  // Fires a cross-browser-compatible custom event from the component root of the given type,
+  // with the given data.
+  emit(evtType, evtData) {
+    let evt;
+    if (typeof CustomEvent === 'function') {
+      evt = new CustomEvent(evtType, {detail: evtData});
+    } else {
+      evt = document.createEvent('CustomEvent');
+      evt.initCustomEvent(evtType, false, false, evtData);
+    }
+
+    this.root_.dispatchEvent(evt);
+  }
 }

--- a/packages/mdl-icon-toggle/index.js
+++ b/packages/mdl-icon-toggle/index.js
@@ -78,7 +78,7 @@ export class MDLIconToggle extends MDLComponent {
       getAttr: (name, value) => this.root_.getAttribute(name, value),
       setAttr: (name, value) => this.root_.setAttribute(name, value),
       rmAttr: (name, value) => this.root_.removeAttribute(name, value),
-      notifyChange: evtData => this.emitChange_(evtData)
+      notifyChange: evtData => this.emit('MDLIconToggle:change', evtData)
     });
   }
 
@@ -105,21 +105,5 @@ export class MDLIconToggle extends MDLComponent {
 
   refreshToggleData() {
     this.foundation_.refreshToggleData();
-  }
-
-  // NOTE(traviskaufman): This will most likely be refactored into a generic event mechanism
-  // within mdl-base at some point. Until the time when it's needed by more than just this component, we'll
-  // keep it simple and local for now.
-  emitChange_(evtData) {
-    const evtType = 'MDLIconToggle:change';
-    let evt;
-    if (typeof CustomEvent === 'function') {
-      evt = new CustomEvent(evtType, {detail: evtData});
-    } else {
-      evt = document.createEvent('CustomEvent');
-      evt.initCustomEvent(evtType, false, false, evtData);
-    }
-
-    this.root_.dispatchEvent(evt);
   }
 }

--- a/packages/mdl-menu/README.md
+++ b/packages/mdl-menu/README.md
@@ -40,8 +40,12 @@ You can start the menu in its open state by adding the `mdl-simple-menu--open` c
 </div>
 ```
 
-
 ### Using the JS Component
+
+> **N.B.**: The use of `role` on both the menu's internal items list, as well as on each item, is
+> _mandatory_. You may either use the role of `menu` on the list with a role of `menuitem` on each
+> list item, or a role of `listbox` on the list with a role of `option` on each list item. Further
+> composite roles may be supported in the future.
 
 MDL Simple Menu ships with a Component / Foundation combo which allows for frameworks to richly integrate the
 correct menu behaviors into idiomatic components.
@@ -108,6 +112,16 @@ import MDLSimpleMenu from 'mdl-menu';
 const menu = new MDLSimpleMenu(document.querySelector('.mdl-simple-menu'));
 ```
 
+#### Handling selection events
+
+When a menu item is selected, the menu component will emit a `MDLSimpleMenu:selected` custom event
+with the following `detail` data:
+
+| property name | type | description |
+| --- | --- | --- |
+| `item` | `HTMLElement` | The DOM element for the selected item |
+| `index` | `number` | The index of the selected item |
+
 ### Using the Foundation Class
 
 MDL Simple Menu ships with an `MDLSimpleMenuFoundation` class that external frameworks and libraries can use to
@@ -123,6 +137,10 @@ The adapter for temporary drawers must provide the following functions, with cor
 | `getInnerDimensions() => {width: number, height: number}` | Returns an object with the items container width and height |
 | `setScale(x: string, y: string) => void` | Sets the transform on the root element to the provided (x, y) scale. |
 | `setInnerScale(x: string, y: string) => void` | Sets the transform on the items container to the provided (x, y) scale. |
-| `getNumberOfItems() => numbers` | Returns the number of elements inside the items container. |
-| `getYParamsForItemAtIndex(index: number) => {top: number, height: number}` | Returns an object with the offset top and offset height values for the element inside the items container at the provided index |
-| `setTransitionDelayForItemAtIndex(index: number, value: string) => void` | Sets the transition delay on the element inside the items container at the provided index to the provided value. |
+| `getNumberOfItems() => numbers` | Returns the number of _item_ elements inside the items container. In our vanilla component, we determine this by counting the number of list items whose `role` attribute corresponds to the correct child role of the role present on the menu list element. For example, if the list element has a role of `menu` this queries for all elements that have a role of `menuitem`. |
+| `registerInteractionHandler(type: string, handler: EventListener) => void` | Adds an event listener `handler` for event type `type`. |
+| `deregisterInteractionHandler(type: string, handler: EventListener) => void` | Removes an event listener `handler` for event type `type`. |
+| `getYParamsForItemAtIndex(index: number) => {top: number, height: number}` | Returns an object with the offset top and offset height values for the _item_ element inside the items container at the provided index. Note that this is an index into the list of _item_ elements, and not necessarily every child element of the list. |
+| `setTransitionDelayForItemAtIndex(index: number, value: string) => void` | Sets the transition delay on the element inside the items container at the provided index to the provided value. The same notice for `index` applies here as above. |
+| `getIndexForEventTarget(target: EventTarget) => number` | Checks to see if the `target` of an event pertains to one of the menu items, and if so returns the index of that item. Returns -1 if the target is not one of the menu items. The same notice for `index` applies here as above. |
+| `notifySelected(evtData: {index: number}) => void` | Dispatches an event notifying listeners that a menu item has been selected. The function should accept an `evtData` parameter containing the an object with an `index` property representing the index of the selected item. Implementations may choose to supplement this data with additional data, such as the item itself. |

--- a/packages/mdl-menu/simple/constants.js
+++ b/packages/mdl-menu/simple/constants.js
@@ -30,6 +30,10 @@ export const strings = {
 };
 
 export const numbers = {
+  // Amount of time to wait before triggering a selected event on the menu. Note that this time
+  // will most likely be bumped up once interactive lists are supported to allow for the ripple to
+  // animate before closing the menu
+  SELECTED_TRIGGER_DELAY: 50,
   // Total duration of the menu animation.
   TRANSITION_DURATION_MS: 300,
   // The menu starts its open animation with the X axis at this time value (0 - 1).
@@ -41,4 +45,14 @@ export const numbers = {
   TRANSITION_Y1: 0,
   TRANSITION_X2: 0.2,
   TRANSITION_Y2: 1
+};
+
+// Mapping between composite aria roles supported by the simple menu to roles owned
+// by that composite role. This should be used in order to query for DOM elements within
+// the menu that represent actual menu items, e.g. `[role="menuitem"]` for a simple menu with
+// role="menu", or `[role="option"]` for a simple menu with role="listbox". For more information
+// see https://www.w3.org/TR/wai-aria/roles#composite.
+export const PARENT_CHILD_ROLES = {
+  menu: 'menuitem',
+  listbox: 'option'
 };

--- a/test/unit/mdl-base/component.test.js
+++ b/test/unit/mdl-base/component.test.js
@@ -104,3 +104,22 @@ test("provides a default destroy() method which calls the foundation's destroy()
   t.doesNotThrow(() => td.verify(foundation.destroy()));
   t.end();
 });
+
+test('#emit dispatches a custom event with the supplied data', t => {
+  const root = document.createElement('div');
+  const f = new FakeComponent(root);
+  const handler = td.func('eventHandler');
+  let evt = null;
+  td.when(handler(td.matchers.isA(Object))).thenDo(evt_ => {
+    evt = evt_;
+  });
+  const data = {evtData: true};
+  const type = 'customeventtype';
+
+  root.addEventListener(type, handler);
+  f.emit(type, data);
+  t.true(evt !== null);
+  t.equal(evt.type, type);
+  t.deepEqual(evt.detail, data);
+  t.end();
+});


### PR DESCRIPTION
Combination of two commits:

feat(base): Add emit() method for dispatching custom events
* Refactor custom event logic out of mdl-icon-toggle

This is needed by mdl-menu as well in order for it to emit events and
therefore work with the select element.

feat(menu): Add selection event support
* Add `MDLSimpleMenu:selected` event which is broadcast when a menu item
  is selected
* Change notion of "items" in menu to mean only item elements which are
  selectable as actual menu items, rather than just children of the
  items container.
* Add logic for validating that a correct `role` attribute is placed on
  the vanilla menu component.

Part of #4475
[#126819221]

Note we should merge this as two separate commits rather than squashing them to keep the change history per-commit clean.