### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Setup the repo:
 
 ```
 git clone https://github.com/google/material-design-lite.git && cd material-design-lite
+git checkout master
 npm i
 ```
 


### PR DESCRIPTION
The default checked out branch isn't the master. So turns necessary checkout master before install deps.