### PR TITLE
feat(base): Add initialization, DOM events wrapper to component API.

### DIFF
--- a/packages/mdl-base/README.md
+++ b/packages/mdl-base/README.md
@@ -156,9 +156,12 @@ export class MyComponent extends MDLComponent {
 
 | method | description |
 | --- | --- |
+| `initialize(...args)` | Called after the root element is attached to the component, but _before_ the foundation is instantiated. Any positional arguments passed to the component constructor after the root element, along with the optional foundation 2nd argument, will be provided to this method. This is a good place to do any setup work normally done within a constructor function. |
 | `getDefaultFoundation()` | Returns an instance of a foundation class properly configured for the component. Called when no foundation instance is given within the constructor. Subclasses **must** implement this method. |
 | `initialSyncWithDOM()` | Called within the constructor. Subclasses may override this method if they wish to perform initial synchronization of state with the host DOM element. For example, a slider may want to check if its host element contains a pre-set value, and adjust its internal state accordingly. Note that the same caveats apply to this method as to foundation class lifecycle methods. Defaults to a no-op. |
 | `destroy()` | Subclasses may override this method if they wish to perform any additional cleanup work when a component is destroyed. For example, a component may want to deregister a window resize listener. |
+| `listen(type: string, handler: EventListener)` | Adds an event listener to the component's root node for the given `type`. Note that this is simply a proxy to `this.root_.addEventListener`. |
+| `unlisten(type: string, handler: EventListener)` | Removes an event listener from the component's root node. Note that this is simply a proxy to `this.root_.removeEventListener`. |
 | `emit(type: string, data: Object)` | Dispatches a custom event of type `type` with detail `data` from the component's root node. This is the preferred way of dispatching events within our vanilla components. |
 
 #### Static Methods
@@ -172,6 +175,41 @@ In addition to methods inherited, subclasses should implement the following two 
 #### Foundation Lifecycle handling
 
 `MDLComponent` calls its foundation's `init()` function within its _constructor_, and its foundation's `destroy()` function within its own _destroy()_ function. Therefore it's important to remember to _always call super() when overriding destroy()_. Not doing so can lead to leaked resources.
+
+#### Initialization and constructor parameters
+
+If you need to pass in additional parameters into a component's constructor, you can make use of the
+`initialize` method, as shown above. An example of this is passing in a child component as a
+dependency.
+
+```js
+class MyComponent extends MDLComponent {
+  initialize(childComponent = null) {
+    this.child_ = childComponent ?
+      childComponent : new ChildComponent(this.root_.querySelector('.child'));
+  }
+
+  getDefaultFoundation() {
+    return new MyComponentFoundation({
+      doSomethingWithChildComponent: () => this.child_.doSomething(),
+      // ...
+    });
+  }
+}
+```
+
+You could call this code like so:
+
+```js
+const childComponent = new ChildComponent(document.querySelector('.some-child'));
+const myComponent = new MyComponent(
+  document.querySelector('.my-component'), /* foundation */ undefined, childComponent
+);
+// use myComponent
+```
+
+> NOTE: You could also pass in an initialized foundation if you wish. The example above simply
+> showcases how you could pass in initialization arguments without instantiating a foundation.
 
 #### Best Practice: Keep your adapters simple
 

--- a/packages/mdl-base/component.js
+++ b/packages/mdl-base/component.js
@@ -25,11 +25,18 @@ export default class MDLComponent {
     return new MDLComponent(root, new MDLFoundation());
   }
 
-  constructor(root, foundation) {
+  constructor(root, foundation, ...args) {
     this.root_ = root;
+    this.initialize(...args);
     this.foundation_ = foundation === undefined ? this.getDefaultFoundation() : foundation;
     this.foundation_.init();
     this.initialSyncWithDOM();
+  }
+
+  initialize(/* ...args */) {
+    // Subclasses can override this to do any additional setup work that would be considered part of a
+    // "constructor". Essentially, it is a hook into the parent constructor before the foundation is
+    // initialized. Any additional arguments besides root and foundation will be passed in here.
   }
 
   getDefaultFoundation() {
@@ -50,6 +57,18 @@ export default class MDLComponent {
     // Subclasses may implement this method to release any resources / deregister any listeners they have
     // attached. An example of this might be deregistering a resize event from the window object.
     this.foundation_.destroy();
+  }
+
+  // Wrapper method to add an event listener to the component's root element. This is most useful when
+  // listening for custom events.
+  listen(evtType, handler) {
+    this.root_.addEventListener(evtType, handler);
+  }
+
+  // Wrapper method to remove an event listener to the component's root element. This is most useful when
+  // unlistening for custom events.
+  unlisten(evtType, handler) {
+    this.root_.removeEventListener(evtType, handler);
   }
 
   // Fires a cross-browser-compatible custom event from the component root of the given type,


### PR DESCRIPTION
* Adds an `initialize` constructor hook that is called after the root
  element is attached, but before `getDefaultFoundation` is called.
* Adds a simple way of adding / removing event listeners from a
  component's root node, without needing access to the root node itself.

Needed for #4475
[#126819221]