### PR TITLE
feat(select): Initial Implementation

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -35,6 +35,7 @@
           <li><a href="fab.html">FAB</a></li>
           <li><a href="icon-toggle.html">Icon Toggle</a></li>
           <li><a href="list.html">List</a></li>
+          <li><a href="select.html">Select</a></li>
           <li><a href="simple-menu.html">Menu (simple)</a></li>
           <li><a href="radio.html">Radio</a></li>
           <li><a href="ripple.html">Ripple</a></li>

--- a/demos/select.html
+++ b/demos/select.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2016 Google Inc. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License
+-->
+<html class="mdl-typography">
+  <head>
+    <meta charset="utf-8">
+    <title>MDL Select Demo</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="assets/material-design-lite.css.js" charset="utf-8"></script>
+    <style type="text/css">
+      .mdl-theme--dark {
+        background-color: #303030;
+      }
+
+      #demo-wrapper {
+        padding: 4px;
+        padding-left: 0;
+      }
+
+      /* Hack to work around style-loader asynchronously loading styles. */
+      /* Equivalent to using mdl-typography's subheading2, which is used in the sass file. */
+      .mdl-select {
+        font-family: Roboto, sans-serif;
+        font-size: 1rem;
+        font-weight: 400;
+        letter-spacing: .04em;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>MDL select</h1>
+      <section>
+        <h2>Fully-Featured Component</h2>
+        <section id="demo-wrapper">
+          <div id="js-select" class="mdl-select" role="listbox" tabindex="0">
+            <span class="mdl-select__selected-text">Pick a food group</span>
+            <div class="mdl-simple-menu mdl-select__menu">
+              <ul class="mdl-list mdl-simple-menu__items">
+                <li class="mdl-list-item" role="option" id="grains" tabindex="0">
+                  Bread, Cereal, Rice, and Pasta
+                </li>
+                <li class="mdl-list-item" role="option" id="vegetables" tabindex="0">
+                  Vegetables
+                </li>
+                <li class="mdl-list-item" role="option" id="fruit" tabindex="0">
+                  Fruit
+                </li>
+                <li class="mdl-list-item" role="option" id="dairy" tabindex="0">
+                  Milk, Yogurt, and Cheese
+                </li>
+                <li class="mdl-list-item" role="option" id="meat" tabindex="0">
+                  Meat, Poultry, Fish, Dry Beans, Eggs, and Nuts
+                </li>
+                <li class="mdl-list-item" role="option" id="fats" tabindex="0">
+                  Fats, Oils, and Sweets
+                </li>
+              </ul>
+            </div>
+          </div>
+        </section>
+        <p>Currently selected: <span id="currently-selected">(none)</span></p>
+        <div>
+          <input type="checkbox" id="dark-theme">
+          <label for="dark-mode">Dark Theme</label>
+        </div>
+        <div>
+          <input type="checkbox" id="rtl">
+          <label for="rtl">RTL</label>
+        </div>
+        <div>
+          <input type="checkbox" id="disabled">
+          <label for="disabled">Disabled</label>
+        </div>
+      </section>
+      <section>
+        <h2>CSS Only</h2>
+        <select class="mdl-select">
+          <option value="" default selected>Pick a food group</option>
+          <option value="grains">Bread, Cereal, Rice, and Pasta</option>
+          <option value="vegetables">Vegetables</option>
+          <option value="fruit">Fruit</option>
+          <option value="dairy">Milk, Yogurt, and Cheese</option>
+          <option value="meat">Meat, Poultry, Fish, Dry Beans, Eggs, and Nuts</option>
+          <option value="fats">Fats, Oils, and Sweets</option>
+        </select>
+      </section>
+      <section>
+        <h2>Custom Menu + Native Menu on mobile</h2>
+        <em>
+          TODO: Present both, maybe have a wrapper element that switches between both and
+          keeps them in sync?
+        </em>
+      </section>
+    </main>
+    <script src="assets/material-design-lite.js"></script>
+    <script>
+      (function() {
+        var MDLSelect = mdl.select.MDLSelect;
+        var root = document.getElementById('js-select');
+        var currentlySelected = document.getElementById('currently-selected');
+        var select = MDLSelect.attachTo(root);
+        root.addEventListener('MDLSelect:change', function() {
+          var item = select.selectedOptions[0];
+          var index = select.selectedIndex;
+          currentlySelected.textContent = '"' + item.textContent + '" at index ' + index;
+        });
+
+        var demoWrapper = document.getElementById('demo-wrapper');
+        var darkThemeCb = document.getElementById('dark-theme');
+        var rtlCb = document.getElementById('rtl');
+        var disabledCb = document.getElementById('disabled');
+
+        darkThemeCb.addEventListener('change', function() {
+          demoWrapper.classList[darkThemeCb.checked ? 'add' : 'remove']('mdl-theme--dark');
+        });
+        rtlCb.addEventListener('change', function() {
+          if (rtlCb.checked) {
+            demoWrapper.setAttribute('dir', 'rtl');
+          } else {
+            demoWrapper.removeAttribute('dir');
+          }
+        });
+        disabledCb.addEventListener('change', function() {
+          select.disabled = disabledCb.checked;
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -39,18 +39,20 @@ const SL_LAUNCHERS = {
     version: 'latest-1',
     platform: 'OS X 10.11'
   },
-  'sl-firefox-stable': {
-    base: 'SauceLabs',
-    browserName: 'firefox',
-    version: 'latest',
-    platform: 'Windows 10'
-  },
-  'sl-firefox-previous': {
-    base: 'SauceLabs',
-    browserName: 'firefox',
-    version: 'latest-1',
-    platform: 'Windows 10'
-  },
+  // NOTE(traviskaufman): Disabling firefox for now as it has been consistently flaky recently. See
+  // https://github.com/google/material-design-lite/issues/4922
+  // 'sl-firefox-stable': {
+  //   base: 'SauceLabs',
+  //   browserName: 'firefox',
+  //   version: 'latest',
+  //   platform: 'Windows 10'
+  // },
+  // 'sl-firefox-previous': {
+  //   base: 'SauceLabs',
+  //   browserName: 'firefox',
+  //   version: 'latest-1',
+  //   platform: 'Windows 10'
+  // },
   'sl-ie': {
     base: 'SauceLabs',
     browserName: 'internet explorer',
@@ -110,9 +112,9 @@ module.exports = function(config) {
     colors: true,
     logLevel: config.LOG_INFO,
     browsers: determineBrowsers(),
-    browserDisconnectTimeout: 20000,
-    browserNoActivityTimeout: 240000,
-    captureTimeout: 120000,
+    browserDisconnectTimeout: 40000,
+    browserNoActivityTimeout: 480000,
+    captureTimeout: 240000,
     concurrency: USING_SL ? 4 : Infinity,
     customLaunchers: SL_LAUNCHERS,
 

--- a/packages/material-design-lite/index.js
+++ b/packages/material-design-lite/index.js
@@ -23,6 +23,7 @@ import * as drawer from 'mdl-drawer';
 import * as textfield from 'mdl-textfield';
 import * as snackbar from 'mdl-snackbar';
 import * as menu from 'mdl-menu';
+import * as select from 'mdl-select';
 import autoInit from 'mdl-auto-init';
 
 // Register all components
@@ -34,6 +35,7 @@ autoInit.register('MDLRadio', radio.MDLRadio);
 autoInit.register('MDLSnackbar', snackbar.MDLSnackbar);
 autoInit.register('MDLTextfield', textfield.MDLTextfield);
 autoInit.register('MDLSimpleMenu', menu.MDLSimpleMenu);
+autoInit.register('MDLSelect', select.MDLSelect);
 
 // Export all components.
 export {
@@ -46,5 +48,6 @@ export {
   drawer,
   textfield,
   menu,
+  select,
   autoInit
 };

--- a/packages/material-design-lite/material-design-lite.scss
+++ b/packages/material-design-lite/material-design-lite.scss
@@ -27,6 +27,7 @@
 @import "mdl-menu/mdl-menu";
 @import "mdl-radio/mdl-radio";
 @import "mdl-ripple/mdl-ripple";
+@import "mdl-select/mdl-select";
 @import "mdl-snackbar/mdl-snackbar";
 @import "mdl-textfield/mdl-textfield";
 @import "mdl-theme/mdl-theme";

--- a/packages/material-design-lite/package.json
+++ b/packages/material-design-lite/package.json
@@ -19,6 +19,7 @@
     "mdl-menu": "^1.0.0",
     "mdl-radio": "^1.0.0",
     "mdl-ripple": "^1.0.0",
+    "mdl-select": "^1.0.0",
     "mdl-snackbar": "^1.0.0",
     "mdl-textfield": "^1.0.0",
     "mdl-theme": "^1.0.0",

--- a/packages/mdl-menu/README.md
+++ b/packages/mdl-menu/README.md
@@ -32,7 +32,7 @@ A simple menu is usually closed, appearing when opened. It is appropriate for an
   focused instead, remove `tabindex="-1"` from the root element.
 
 ```js
-let menu = new mdl.SimpleMenu(document.querySelector('.mdl-simple-menu'));
+let menu = new mdl.menu.SimpleMenu(document.querySelector('.mdl-simple-menu'));
 // Add event listener to some button to toggle the menu on and off.
 document.querySelector('.some-button').addEventListener('click', () => menu.open = !menu.open);
 ```
@@ -108,11 +108,6 @@ classes:
 
 
 ### Using the JS Component
-
-> **N.B.**: The use of `role` on both the menu's internal items list, as well as on each item, is
-> _mandatory_. You may either use the role of `menu` on the list with a role of `menuitem` on each
-> list item, or a role of `listbox` on the list with a role of `option` on each list item. Further
-> composite roles may be supported in the future.
 
 MDL Simple Menu ships with a Component / Foundation combo which allows for frameworks to richly integrate the
 correct menu behaviors into idiomatic components.

--- a/packages/mdl-menu/simple/constants.js
+++ b/packages/mdl-menu/simple/constants.js
@@ -46,13 +46,3 @@ export const numbers = {
   TRANSITION_X2: 0.2,
   TRANSITION_Y2: 1
 };
-
-// Mapping between composite aria roles supported by the simple menu to roles owned
-// by that composite role. This should be used in order to query for DOM elements within
-// the menu that represent actual menu items, e.g. `[role="menuitem"]` for a simple menu with
-// role="menu", or `[role="option"]` for a simple menu with role="listbox". For more information
-// see https://www.w3.org/TR/wai-aria/roles#composite.
-export const PARENT_CHILD_ROLES = {
-  menu: 'menuitem',
-  listbox: 'option'
-};

--- a/packages/mdl-menu/simple/foundation.js
+++ b/packages/mdl-menu/simple/foundation.js
@@ -231,6 +231,7 @@ export default class MDLSimpleMenuFoundation extends MDLFoundation {
     const isTab = key === 'Tab' || keyCode === 9;
     const isArrowUp = key === 'ArrowUp' || keyCode === 38;
     const isArrowDown = key === 'ArrowDown' || keyCode === 40;
+    const isSpace = key === 'Space' || keyCode === 32;
 
     const focusedItemIndex = this.adapter_.getFocusedItemIndex();
     const lastItemIndex = this.adapter_.getNumberOfItems() - 1;
@@ -247,15 +248,18 @@ export default class MDLSimpleMenuFoundation extends MDLFoundation {
       return false;
     }
 
+    // Ensure Arrow{Up,Down} and space do not cause inadvertent scrolling
+    if (isArrowUp || isArrowDown || isSpace) {
+      evt.preventDefault();
+    }
+
     if (isArrowUp) {
       if (focusedItemIndex === 0 || this.adapter_.isFocused()) {
         this.adapter_.focusItemAtIndex(lastItemIndex);
       } else {
         this.adapter_.focusItemAtIndex(focusedItemIndex - 1);
       }
-    }
-
-    if (isArrowDown) {
+    } else if (isArrowDown) {
       if (focusedItemIndex === lastItemIndex || this.adapter_.isFocused()) {
         this.adapter_.focusItemAtIndex(0);
       } else {

--- a/packages/mdl-menu/simple/index.js
+++ b/packages/mdl-menu/simple/index.js
@@ -15,7 +15,6 @@
  */
 
 import {MDLComponent} from 'mdl-base';
-import {PARENT_CHILD_ROLES} from './constants';
 import MDLSimpleMenuFoundation from './foundation';
 import {getTransformPropertyName} from '../util';
 
@@ -57,8 +56,7 @@ export class MDLSimpleMenu extends MDLComponent {
    */
   get items() {
     const {itemsContainer_: itemsContainer} = this;
-    const childRole = PARENT_CHILD_ROLES[itemsContainer.getAttribute('role')];
-    return [].slice.call(itemsContainer.querySelectorAll(`[role="${childRole}"]`));
+    return [].slice.call(itemsContainer.querySelectorAll('.mdl-list-item[role]'));
   }
 
   getDefaultFoundation() {
@@ -122,23 +120,5 @@ export class MDLSimpleMenu extends MDLComponent {
         this.root_.style.bottom = 'bottom' in position ? position.bottom : null;
       }
     });
-  }
-
-  initialSyncWithDOM() {
-    this.validateRole_();
-  }
-
-  validateRole_() {
-    const VALID_ROLES = Object.keys(PARENT_CHILD_ROLES);
-    const role = this.itemsContainer_.getAttribute('role');
-    if (!role) {
-      throw new Error(
-        'Missing "role" attribute on menu items list element. A "role" attribute is needed for the menu to ' +
-        `function properly. Please choose one of ${VALID_ROLES}`
-      );
-    }
-    if (VALID_ROLES.indexOf(role) < 0) {
-      throw new Error(`Invalid menu items list role "${role}." Please choose one of ${VALID_ROLES}`);
-    }
   }
 }

--- a/packages/mdl-select/README.md
+++ b/packages/mdl-select/README.md
@@ -1,0 +1,270 @@
+# MDL Select
+
+> **Status:**
+> - [x] Pure CSS Select
+> - [x] Initial Functionality / Styles for JS Select
+> - [ ] Select Menu Auto-positioning
+> - [ ] Multi-select
+
+MDL Select provides a material design single-option select menu. It functions analogously to the
+browser's native `<select>` element, and includes a gracefully degraded version that can be used
+in conjunction with the browser's native element. Both are fully accessible, and fully RTL-aware.
+
+## Installation
+
+> NOTE: Installation will be available via npm post-alpha.
+
+## Usage
+
+### Using the full-fidelity JS component
+
+```html
+<div class="mdl-select" role="listbox" tabindex="0">
+  <span class="mdl-select__selected-text">Pick a food group</span>
+  <div class="mdl-simple-menu mdl-select__menu">
+    <ul class="mdl-list mdl-simple-menu__items">
+      <li class="mdl-list-item" role="option" id="grains" tabindex="0">
+        Bread, Cereal, Rice, and Pasta
+      </li>
+      <li class="mdl-list-item" role="option" id="vegetables" tabindex="0">
+        Vegetables
+      </li>
+      <li class="mdl-list-item" role="option" id="fruit" tabindex="0">
+        Fruit
+      </li>
+      <li class="mdl-list-item" role="option" id="dairy" tabindex="0">
+        Milk, Yogurt, and Cheese
+      </li>
+      <li class="mdl-list-item" role="option" id="meat" tabindex="0">
+        Meat, Poultry, Fish, Dry Beans, Eggs, and Nuts
+      </li>
+      <li class="mdl-list-item" role="option" id="fats" tabindex="0">
+        Fats, Oils, and Sweets
+      </li>
+    </ul>
+  </div>
+</div>
+```
+
+Then with JS
+
+```js
+import {MDLSelect} from 'mdl-select';
+
+const select = new MDLSelect(document.querySelector('.mdl-select'));
+select.listen('MDLSelect:change', () => {
+  alert(`Selected "${select.selectedOptions[0].textContent}" at index ${select.selectedIndex}"`);
+});
+```
+
+Note that you can include mdl-select via a UMD bundle, which will be available post-alpha.
+
+> Note that the full-fidelity version of MDL Select requires you to manually include the styles for
+[mdl-menu](../mdl-menu) and [mdl-list](../mdl-list). If you are using the
+[material-design-lite](../material-design-lite) package, this is taken care of for you and you
+simply need to import the main stylesheet. Otherwise, _you must ensure that you manually include the
+style dependencies for both the mdl-list and mdl-menu for this component to function properly._
+
+#### Select with pre-selected option
+
+> TK
+
+#### Disabled select
+
+> TK
+
+### Using the Pure CSS Select
+
+The `mdl-select` CSS class also works on browser's native `<select>` elements, allowing for a
+seamless, un-invasive experience in browsers where a native select may be more appropriate, such as
+on a mobile device. It does not require any javascript, nor any CSS for `mdl-menu` or `mdl-list`.
+
+```html
+<select class="mdl-select">
+  <option value="" default selected>Pick a food group</option>
+  <option value="grains">Bread, Cereal, Rice, and Pasta</option>
+  <option value="vegetables">Vegetables</option>
+  <option value="fruit">Fruit</option>
+  <option value="dairy">Milk, Yogurt, and Cheese</option>
+  <option value="meat">Meat, Poultry, Fish, Dry Beans, Eggs, and Nuts</option>
+  <option value="fats">Fats, Oils, and Sweets</option>
+</select>
+```
+
+### MDL Select Component API
+
+The MDL Select component API is modeled after a subset of the `HTMLSelectElement` functionality, and
+is outlined below.
+
+#### Properties
+
+| Property Name | Type | Description |
+| --- | --- | --- |
+| `options` | `HTMLElement[]` | _(read-only)_ An _array_ of menu items comprising the select's options. |
+| `selectedIndex` | `number` | The index of the currently selected option. Set to -1 if no option is currently selected. Changing this property will update the select element. |
+| `selectedOptions` | `HTMLElement[]` | _(read-only)_ A NodeList of either the currently selected option, or no elements if nothing is selected. |
+| `disabled` | `boolean` | Whether or not the component is disabled. Settings this sets the disabled state on the component. |
+
+#### Methods
+
+| Method Signature | Description |
+| --- | --- |
+| `item(index: number) => HTMLElement?` | Analogous to `HTMLSelectElement.prototype.item`. Returns the option at the specified index, or `null` if the index is out of bounds. }
+| `nameditem(key: string) => HTMLElement?` | Analogous to `HTMLSelectElement.prototype.nameditem`. Returns the options either whose `id` equals the given `key`, or whose `name` attribute equals the given `key`. Returns `null` if no item with an `id` or `name` attribute of the specified key is found. |
+
+#### Events
+
+The MDL Select JS component emits an `MDLSelect:change` event when the selected option changes as
+the result of a user action.
+
+## Using the foundation class
+
+MDL Select ships with a foundation class that framework authors can use to integrate MDL Select
+into their custom components. Note that due to the nature of MDL Select, the adapter is quite
+complex. We try to provide as much guidance as possible, but we encourage developers to reach out
+to use via GH Issues or on Gitter if they run into problems.
+
+### Notes for component implementors
+
+The `MDLSelectFoundation` expects that the select component _controls an instance of
+`MDLSimpleMenu`_. We achieve this via composition in our vanilla `MDLSelect` component, and
+recommend a similar approach for framework authors.
+
+`MDLSelectFoundation` also has the ability to resize itself whenever its options change, via the
+`resize()` method. We recommend calling this method on initialization, or when the menu items are
+modified. For example, if building a react component, it may be appropriate to call `resize()`
+within `componentDidUpdate`.
+
+### Adapter API
+
+| Method Signature | Description |
+| --- | --- |
+| `addClass(className: string) => void` | Adds a class to the root element. |
+| `removeClass(className: string) => void` | Removes a class from the root element. |
+| `setAttr(attr: string, value: string) => void` | Sets attribute `name` to value `value` on the root element. |
+| `rmAttr(attr: string) => void` | Removes attribute `attr` from the root element. |
+| `registerInteractionHandler(type: string, handler: EventListener) => void` | Adds an event listener `handler` for event type `type` on the root element. |
+| `deregisterInteractionHandler(type: string, handler: EventListener) => void` | Removes an event listener `handler` for event type `type` on the root element. |
+| `focus() => void` | Focuses the root element |
+| `makeTabbable() => void` | Allows the root element to be tab-focused via keyboard. We achieve this by setting the root element's `tabIndex` property to `0`. |
+| `makeUntabbable() => void` | Disallows the root element to be tab-focused via keyboard. We achieve this by setting the root element's `tabIndex` property to `-1`. |
+| `getComputedStyleValue(propertyName: string) => string` | Get the root element's computed style value of the given dasherized css property `propertyName`. We achieve this via `getComputedStyle(...).getPropertyValue(propertyName). `|
+| `setStyle(propertyName: string, value: string) => void` | Sets a dasherized css property `propertyName` to the value `value` on the root element. We achieve this via `root.style.setProperty(propertyName, value)`. |
+| `create2dRenderingContext() => {font: string, measureText: (string) => {width: number}}` | Returns an object which has the shape of a CanvasRenderingContext2d instance. Namely, it has a string property `font` which is writable, and a method `measureText` which given a string of text returns an object containing a `width` property specifying how wide that text should be rendered in the `font` specified by the font property. An easy way to achieve this is simply `document.createElement('canvas').getContext('2d');`. |
+| `openMenu(focusIndex: string) => void` | Opens the select's menu with focus on the option at the given `focusIndex`. The focusIndex is guaranteed to be in bounds. |
+| `setSelectedTextContent(selectedTextContent: string) => void` | Sets the text content of the `.mdl-select__selected-text` element to `selectedTextContent`. |
+| `getNumberOfOptions() => number` | Returns the number of options contained in the select's menu. |
+| `getTextForOptionAtIndex(index: number) => string` | Returns the text content for the option at the specified index within the select's menu. |
+| `setAttrForOptionAtIndex(index: number, attr: string, value: string) => void` | Sets an attribute `attr` to value `value` for the option at the specified index within the select's menu. |
+| `rmAttrForOptionAtIndex(index: number, attr: string) => void` | Removes an attribute `attr` for the option at the specified index within the select's menu. |
+| `registerMenuInteractionHandler(type: string, handler: EventListener) => void` | Registers an event listener on the menu component's root element. Note that we will always listen for `MDLSimpleMenu:selected` for change events, and `MDLSimpleMenu:cancel` to know that we need to close the menu. If you are using a different events system, you could check the event type for either one of these strings and take the necessary steps to wire it up. |
+| `deregisterMenuInteractionHandler(type: string, handler: EventListener) => void` | Opposite of `registerMenuInteractionHandler`. |
+
+### The full foundation API
+
+#### MDLSelectFoundation.getSelectedIndex() => number
+
+Returns the index of the currently selected option. Returns -1 if no option is currently selected.
+
+#### MDLSelectFoundation.setSelectedIndex(selectedIndex: number) => void
+
+Sets the selected index of the component.
+
+#### MDLSelectFoundation.isDisabled() => boolean
+
+Returns whether or not the select is disabled.
+
+#### MDLSelectFoundation.setDisabled(disabled: boolean) => void
+
+Enables/disables the select.
+
+## Theming
+
+The select's bottom border is set to the current theme's primary color when focused. The select is
+fully dark theme aware.
+
+## Tips / Tricks
+
+### Switching between selects for better cross-device UX
+
+Selects are a tricky beast on the web. Many times, a custom select component will work well on large
+devices with mouse/keyboard capability, but fail miserably on smaller-scale devices without
+fine-grained pointer capability, such as a phone. Because `mdl-select` works on native selects, you
+can easily switch between a custom select on larger devices and a native element on smaller ones.
+
+First, wrap both a custom select and a native select within a wrapper element, let's call it the
+`select-manager`.
+
+```html
+<div class="select-manager">
+  <!-- Custom MDL Select, shown on desktop -->
+  <div class="mdl-select" role="listbox" tabindex="0">
+    <span class="mdl-select__selected-text">Pick one</span>
+    <div class="mdl-simple-menu mdl-select__menu">
+      <ul class="mdl-list mdl-simple-menu__items">
+        <li class="mdl-list-item" role="option" id="a" tabindex="0">A</li>
+        <li class="mdl-list-item" role="option" id="b" tabindex="0">B</li>
+        <li class="mdl-list-item" role="option" id="c" tabindex="0">C</li>
+      </ul>
+    </div>
+  </div>
+  <!-- Native element, shown on mobile devices -->
+  <select class="mdl-select">
+    <option value="" selected disabled>Pick one</option>
+    <option value="a">A</option>
+    <option value="b">B</option>
+    <option value="c">C</option>
+  </select>
+</div>
+```
+
+Then, write some CSS that implements a media query checking for a small screen as well as
+[course pointer interaction](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/pointer). This
+will ensure that the custom select will still be present on smaller devices that do have
+mouse/keyboard capability, such as a hybrid tablet or a small browser window on a desktop.
+
+```css
+.select-manager > select.mdl-select {
+  display: none;
+}
+
+@media (max-width: 600px) and (pointer: coarse) {
+  .select-manager > .mdl-select[role="listbox"] {
+    display: none;
+  }
+
+  .select-manager > select.mdl-select {
+    display: block;
+  }
+}
+```
+
+Finally, we need to be able to react to events and keep each component in sync. We can do this in
+a few lines of JS, and check where the event came from by looking at its `type`. If it came from the
+custom component, the type will be `MDLSelect:change`, otherwise it will simply be `change`.
+
+```js
+const selectManager = document.querySelector('.select-manager');
+const selects = {
+  custom: MDLSelect.attachTo(selectManager.querySelector('.mdl-select[role="listbox"]')),
+  native: MDLSelect.attachTo(selectManager.querySelector('select.mdl-select'))
+};
+const changeHandler = ({type}) =>  {
+  let changedSelect, selectToUpdate, value;
+  if (type === 'MDLSelect:change') {
+    changedSelect = selects.custom;
+    selectToUpdate = selects.native;
+    value = changedSelect.selectedOptions[0].id;
+  } else {
+    changeSelect = selects.native;
+    selectToUpdate = selects.custom;
+    value = changedSelect.selectedOptions[0].value;
+  }
+  selectToUpdate.selectedIndex = changedSelect.selectedIndex;
+  console.info('Selected value', value);
+};
+selects.custom.listen('MDLSelect:change', changeHandler);
+selects.native.addEventListener('change', changeHandler);
+```
+
+We are looking into building this functionality into `MDLSelect` in the future.

--- a/packages/mdl-select/foundation.js
+++ b/packages/mdl-select/foundation.js
@@ -1,0 +1,199 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {MDLFoundation} from 'mdl-base';
+
+const ROOT = 'mdl-select';
+const OPENER_KEYS = [
+  {key: 'ArrowUp', keyCode: 38, forType: 'keydown'},
+  {key: 'ArrowDown', keyCode: 40, forType: 'keydown'},
+  {key: 'Space', keyCode: 32, forType: 'keyup'}
+];
+
+export default class MDLSelectFoundation extends MDLFoundation {
+  static get cssClasses() {
+    return {
+      ROOT,
+      OPEN: `${ROOT}--open`,
+      DISABLED: `${ROOT}--disabled`
+    };
+  }
+
+  static get defaultAdapter() {
+    return {
+      addClass: (/* className: string */) => {},
+      removeClass: (/* className: string */) => {},
+      setAttr: (/* attr: string, value: string */) => {},
+      rmAttr: (/* attr: string */) => {},
+      registerInteractionHandler: (/* type: string, handler: EventListener */) => {},
+      deregisterInteractionHandler: (/* type: string, handler: EventListener */) => {},
+      focus: () => {},
+      makeTabbable: () => {},
+      makeUntabbable: () => {},
+      getComputedStyleValue: (/* propertyName: string */) => /* string */ '',
+      setStyle: (/* propertyName: string, value: string */) => {},
+      create2dRenderingContext: () => /* {font: string, measureText: (string) => {width: number}} */ ({
+        font: '',
+        measureText: () => ({width: 0})
+      }),
+      openMenu: (/* focusIndex: number */) => {},
+      setSelectedTextContent: (/* textContent: string */) => {},
+      getNumberOfOptions: () => /* number */ 0,
+      getTextForOptionAtIndex: (/* index: number */) => /* string */ '',
+      setAttrForOptionAtIndex: (/* index: number, attr: string, value: string */) => {},
+      rmAttrForOptionAtIndex: (/* index: number, attr: string */) => {},
+      registerMenuInteractionHandler: (/* type: string, handler: EventListener */) => {},
+      deregisterMenuInteractionHandler: (/* type: string, handler: EventListener */) => {},
+      notifyChange: () => {}
+    };
+  }
+
+  constructor(adapter) {
+    super(Object.assign(MDLSelectFoundation.defaultAdapter, adapter));
+    this.ctx_ = null;
+    this.selectedIndex_ = -1;
+    this.disabled_ = false;
+    this.displayHandler_ = evt => {
+      evt.preventDefault();
+      this.open_();
+    };
+    this.displayViaKeyboardHandler_ = evt => this.handleDisplayViaKeyboard_(evt);
+    this.selectionHandler_ = ({detail}) => {
+      const {index} = detail;
+      this.close_();
+      if (index !== this.selectedIndex_) {
+        this.setSelectedIndex(index);
+        this.adapter_.notifyChange();
+      }
+    };
+    this.cancelHandler_ = () => {
+      this.close_();
+    };
+  }
+
+  init() {
+    this.ctx_ = this.adapter_.create2dRenderingContext();
+    this.adapter_.registerInteractionHandler('click', this.displayHandler_);
+    this.adapter_.registerInteractionHandler('keydown', this.displayViaKeyboardHandler_);
+    this.adapter_.registerInteractionHandler('keyup', this.displayViaKeyboardHandler_);
+    this.adapter_.registerMenuInteractionHandler('MDLSimpleMenu:selected', this.selectionHandler_);
+    this.adapter_.registerMenuInteractionHandler('MDLSimpleMenu:cancel', this.cancelHandler_);
+    this.resize();
+  }
+
+  destroy() {
+    // Drop reference to context object to prevent potential leaks
+    this.ctx_ = null;
+    this.adapter_.deregisterInteractionHandler('click', this.displayHandler_);
+    this.adapter_.deregisterInteractionHandler('keydown', this.displayViaKeyboardHandler_);
+    this.adapter_.deregisterInteractionHandler('keyup', this.displayViaKeyboardHandler_);
+    this.adapter_.deregisterMenuInteractionHandler('MDLSimpleMenu:selected', this.selectionHandler_);
+    this.adapter_.deregisterMenuInteractionHandler('MDLSimpleMenu:cancel', this.cancelHandler_);
+  }
+
+  getSelectedIndex() {
+    return this.selectedIndex_;
+  }
+
+  setSelectedIndex(index) {
+    const prevSelectedIndex = this.selectedIndex_;
+    if (prevSelectedIndex >= 0) {
+      this.adapter_.rmAttrForOptionAtIndex(this.selectedIndex_, 'aria-selected');
+    }
+
+    this.selectedIndex_ = index >= 0 && index < this.adapter_.getNumberOfOptions() ? index : -1;
+    let selectedTextContent = '';
+    if (this.selectedIndex_ >= 0) {
+      selectedTextContent = this.adapter_.getTextForOptionAtIndex(this.selectedIndex_).trim();
+      this.adapter_.setAttrForOptionAtIndex(this.selectedIndex_, 'aria-selected', 'true');
+    }
+    this.adapter_.setSelectedTextContent(selectedTextContent);
+  }
+
+  isDisabled() {
+    return this.disabled_;
+  }
+
+  setDisabled(disabled) {
+    const {DISABLED} = MDLSelectFoundation.cssClasses;
+    this.disabled_ = disabled;
+    if (this.disabled_) {
+      this.adapter_.addClass(DISABLED);
+      this.adapter_.setAttr('aria-disabled', 'true');
+      this.adapter_.makeUntabbable();
+    } else {
+      this.adapter_.removeClass(DISABLED);
+      this.adapter_.rmAttr('aria-disabled');
+      this.adapter_.makeTabbable();
+    }
+  }
+
+  resize() {
+    const font = this.adapter_.getComputedStyleValue('font');
+    const letterSpacing = parseFloat(this.adapter_.getComputedStyleValue('letter-spacing'));
+    if (font) {
+      this.ctx_.font = font;
+    } else {
+      const primaryFontFamily = this.adapter_.getComputedStyleValue('font-family').split(',')[0];
+      const fontSize = this.adapter_.getComputedStyleValue('font-size');
+      this.ctx_.font = `${fontSize} ${primaryFontFamily}`;
+    }
+
+    let maxTextLength = 0;
+    for (let i = 0, l = this.adapter_.getNumberOfOptions(); i < l; i++) {
+      const txt = this.adapter_.getTextForOptionAtIndex(i).trim();
+      const {width} = this.ctx_.measureText(txt);
+      const addedSpace = letterSpacing * txt.length;
+      maxTextLength = Math.max(maxTextLength, Math.ceil(width + addedSpace));
+    }
+    this.adapter_.setStyle('width', `${maxTextLength}px`);
+  }
+
+  open_() {
+    const {OPEN} = MDLSelectFoundation.cssClasses;
+    const focusIndex = this.selectedIndex_ < 0 ? 0 : this.selectedIndex_;
+    this.adapter_.addClass(OPEN);
+    this.adapter_.openMenu(focusIndex);
+  }
+
+  close_() {
+    const {OPEN} = MDLSelectFoundation.cssClasses;
+    this.adapter_.removeClass(OPEN);
+    this.adapter_.focus();
+  }
+
+  handleDisplayViaKeyboard_(evt) {
+    // We use a hard-coded 2 instead of Event.AT_TARGET to avoid having to reference a browser
+    // global.
+    const EVENT_PHASE_AT_TARGET = 2;
+    if (evt.eventPhase !== EVENT_PHASE_AT_TARGET) {
+      return;
+    }
+
+    // Prevent pressing space down from scrolling the page
+    const isSpaceDown = evt.type === 'keydown' && (evt.key === 'Space' || evt.keyCode === 32);
+    if (isSpaceDown) {
+      evt.preventDefault();
+    }
+
+    const isOpenerKey = OPENER_KEYS.some(({key, keyCode, forType}) => {
+      return evt.type === forType && (evt.key === key || evt.keyCode === keyCode);
+    });
+    if (isOpenerKey) {
+      this.displayHandler_(evt);
+    }
+  }
+}

--- a/packages/mdl-select/index.js
+++ b/packages/mdl-select/index.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {MDLComponent} from 'mdl-base';
+import {MDLSimpleMenu} from 'mdl-menu';
+
+import MDLSelectFoundation from './foundation';
+
+export {MDLSelectFoundation};
+
+export class MDLSelect extends MDLComponent {
+  static attachTo(root) {
+    return new MDLSelect(root);
+  }
+
+  get options() {
+    return this.menu_.items;
+  }
+
+  get selectedOptions() {
+    return this.root_.querySelectorAll('[aria-selected]');
+  }
+
+  get selectedIndex() {
+    return this.foundation_.getSelectedIndex();
+  }
+
+  set selectedIndex(selectedIndex) {
+    this.foundation_.setSelectedIndex(selectedIndex);
+  }
+
+  get disabled() {
+    return this.foundation_.isDisabled();
+  }
+
+  set disabled(disabled) {
+    this.foundation_.setDisabled(disabled);
+  }
+
+  item(index) {
+    return this.options[index] || null;
+  }
+
+  nameditem(key) {
+    // NOTE: IE11 precludes us from using Array.prototype.find
+    for (let i = 0, options = this.options, option; (option = options[i]); i++) {
+      if (option.id === key || option.getAttribute('name') === key) {
+        return option;
+      }
+    }
+    return null;
+  }
+
+  initialize(menu = null) {
+    this.menu_ = menu ? menu : new MDLSimpleMenu(this.root_.querySelector('.mdl-select__menu'));
+    this.selectedText_ = this.root_.querySelector('.mdl-select__selected-text');
+  }
+
+  getDefaultFoundation() {
+    return new MDLSelectFoundation({
+      addClass: className => this.root_.classList.add(className),
+      removeClass: className => this.root_.classList.remove(className),
+      setAttr: (attr, value) => this.root_.setAttribute(attr, value),
+      rmAttr: (attr, value) => this.root_.removeAttribute(attr, value),
+      registerInteractionHandler: (type, handler) => this.root_.addEventListener(type, handler),
+      deregisterInteractionHandler: (type, handler) => this.root_.removeEventListener(type, handler),
+      focus: () => this.root_.focus(),
+      makeTabbable: () => {
+        this.root_.tabIndex = 0;
+      },
+      makeUntabbable: () => {
+        this.root_.tabIndex = -1;
+      },
+      getComputedStyleValue: prop => window.getComputedStyle(this.root_).getPropertyValue(prop),
+      setStyle: (propertyName, value) => this.root_.style.setProperty(propertyName, value),
+      create2dRenderingContext: () => document.createElement('canvas').getContext('2d'),
+      openMenu: focusIndex => this.menu_.show({focusIndex}),
+      setSelectedTextContent: selectedTextContent => {
+        this.selectedText_.textContent = selectedTextContent;
+      },
+      getNumberOfOptions: () => this.options.length,
+      getTextForOptionAtIndex: index => this.options[index].textContent,
+      setAttrForOptionAtIndex: (index, attr, value) => this.options[index].setAttribute(attr, value),
+      rmAttrForOptionAtIndex: (index, attr) => this.options[index].removeAttribute(attr),
+      registerMenuInteractionHandler: (type, handler) => this.menu_.listen(type, handler),
+      deregisterMenuInteractionHandler: (type, handler) => this.menu_.unlisten(type, handler),
+      notifyChange: () => this.emit('MDLSelect:change', this)
+    });
+  }
+
+  initialSyncWithDOM() {
+    const selectedOption = this.selectedOptions[0];
+    const idx = selectedOption ? this.options.indexOf(selectedOption) : -1;
+    if (idx >= 0) {
+      this.selectedIndex = idx;
+    }
+
+    if (this.root_.getAttribute('aria-disabled') === 'true') {
+      this.disabled = true;
+    }
+  }
+}

--- a/packages/mdl-select/mdl-select.scss
+++ b/packages/mdl-select/mdl-select.scss
@@ -1,0 +1,167 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import "mdl-animation/functions";
+@import "mdl-typography/mixins";
+@import "mdl-theme/mixins";
+@import "mdl-rtl/mixins";
+
+@mixin mdl-select-dd-arrow-svg-bg_($fill-hex-number: 000000, $opacity: .54) {
+  // stylelint-disable scss/dollar-variable-pattern
+  background-image: url(data:image/svg+xml,%3Csvg%20width%3D%2210px%22%20height%3D%225px%22%20viewBox%3D%227%2010%2010%205%22%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%3E%0A%20%20%20%20%3Cpolygon%20id%3D%22Shape%22%20stroke%3D%22none%22%20fill%3D%22%23#{$fill-hex-number}%22%20fill-rule%3D%22evenodd%22%20opacity%3D%22#{$opacity}%22%20points%3D%227%2010%2012%2015%2017%2010%22%3E%3C%2Fpolygon%3E%0A%3C%2Fsvg%3E);
+  // stylelint-enable scss/dollar-variable-pattern
+}
+
+// postcss-bem-linter: define select
+.mdl-select {
+  @include mdl-typography(subheading2);
+  @include mdl-theme-prop(color, text-primary-on-light);
+  @include mdl-rtl-reflexive-box(padding, right, 24px);
+
+  // Resets for <select> element
+  appearance: none;
+  &::-ms-expand {
+    display: none;
+  }
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  height: 32px;
+  transition:
+    mdl-animation-exit(border-bottom-color, 150ms),
+    mdl-animation-exit(background-color, 150ms);
+
+  border: none;
+  border-bottom: 1px solid rgba(black, .12);
+  border-radius: 0;
+  background: none;
+  background-repeat: no-repeat;
+  background-position: right center;
+
+  @include mdl-select-dd-arrow-svg-bg_;
+
+  font-family: Roboto, sans-serif;
+  font-size: .936rem;
+  cursor: pointer;
+
+  &:focus {
+    @include mdl-theme-prop(border-bottom-color, primary);
+    outline: none;
+    background-color: rgba(black, .06);
+  }
+
+  @include mdl-rtl {
+    background-position: left center;
+  }
+
+  @include mdl-theme-dark {
+    @include mdl-theme-prop(color, text-primary-on-dark);
+    @include mdl-select-dd-arrow-svg-bg_(ffffff);
+    border-bottom: 1px solid rgba(white, .12);
+
+    &:focus {
+      @include mdl-theme-prop(border-bottom-color, primary);
+      background-color: rgba(white, .09);
+    }
+  }
+
+  &__menu {
+    position: fixed;
+    // TODO: https://www.pivotaltracker.com/story/show/129706423
+    top: 0;
+    left: 0;
+    transform-origin: center center;
+  }
+
+  &__selected-text {
+    transition:
+      mdl-animation-exit(opacity, 125ms),
+      mdl-animation-exit(transform, 125ms);
+  }
+}
+
+.mdl-select--open {
+  .mdl-select__selected-text {
+    transform: translateY(8px);
+    transition:
+      mdl-animation-enter(opacity, 125ms, 125ms),
+      mdl-animation-enter(transform, 125ms, 125ms);
+    opacity: 0;
+  }
+}
+
+.mdl-select--disabled,
+.mdl-select[disabled] {
+  @include mdl-theme-prop(color, text-disabled-on-light);
+  @include mdl-select-dd-arrow-svg-bg_(000000, .38);
+  border-bottom-style: dotted;
+  cursor: default;
+  pointer-events: none;
+  // Imitate native disabled functionality
+  user-select: none;
+
+  @include mdl-theme-dark(".mdl-select", true) {
+    @include mdl-theme-prop(color, text-disabled-on-dark);
+    @include mdl-select-dd-arrow-svg-bg_(ffffff, .38);
+    border-bottom: 1px dotted rgba(white, .38);
+  }
+}
+
+// postcss-bem-linter: end
+
+.mdl-select__menu {
+  .mdl-list-item {
+    @include mdl-typography(subheading2);
+    @include mdl-theme-prop(color, text-secondary-on-light);
+
+    &[aria-selected="true"] {
+      @include mdl-theme-prop(color, text-primary-on-light);
+    }
+
+    @include mdl-theme-dark(".mdl-select") {
+      @include mdl-theme-prop(color, text-secondary-on-dark);
+
+      &[aria-selected="true"] {
+        @include mdl-theme-prop(color, text-primary-on-dark);
+      }
+    }
+  }
+
+  .mdl-list-group,
+  .mdl-list-group > .mdl-list-item:first-child {
+    margin-top: 12px;
+  }
+
+  .mdl-list-group {
+    @include mdl-theme-prop(color, text-hint-on-light);
+    font-weight: normal;
+
+    .mdl-list-item {
+      @include mdl-theme-prop(color, text-primary-on-light);
+    }
+  }
+
+  @include mdl-theme-dark(".mdl-select") {
+    .mdl-list-group {
+      @include mdl-theme-prop(color, text-hint-on-dark);
+
+      .mdl-list-item {
+        @include mdl-theme-prop(color, text-primary-on-dark);
+      }
+    }
+  }
+}

--- a/packages/mdl-select/package.json
+++ b/packages/mdl-select/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "mdl-select",
+  "description": "A material design select menu, with multi-select support",
+  "version": "1.0.0",
+  "license": "Apache-2.0",
+  "main": "index.js",
+  "dependencies": {
+    "mdl-animation": "^1.0.0",
+    "mdl-base": "^1.0.0",
+    "mdl-list": "^1.0.0",
+    "mdl-menu": "^1.0.0",
+    "mdl-rtl": "^1.0.0",
+    "mdl-theme": "^1.0.0",
+    "mdl-typography": "^1.0.0"
+  }
+}

--- a/test/unit/mdl-menu/mdl-simple-menu.test.js
+++ b/test/unit/mdl-menu/mdl-simple-menu.test.js
@@ -56,20 +56,6 @@ test('get/set open', t => {
   t.end();
 });
 
-test('constructor throws if no role on menu items', t => {
-  t.throws(() => new MDLSimpleMenu(bel`
-    <div class="mdl-simple-menu"><ul class="mdl-simple-menu__items"></ul></div>
-  `));
-  t.end();
-});
-
-test('constructor throws if role on menu is invalid (not menu or listbox)', t => {
-  t.throws(() => new MDLSimpleMenu(bel`
-    <div class="mdl-simple-menu"><ul class="mdl-simple-menu__items" role="dialog"></ul></div>
-  `));
-  t.end();
-});
-
 test('items returns all menu items', t => {
   const {root, component} = setupTest();
   const items = [].slice.call(root.querySelectorAll('[role="menuitem"]'));

--- a/test/unit/mdl-menu/simple.foundation.test.js
+++ b/test/unit/mdl-menu/simple.foundation.test.js
@@ -771,6 +771,27 @@ test('on ArrowDown keydown on the first element, it moves to the second', t => {
   t.end();
 });
 
+test('on ArrowDown keydown prevents default on the event', t => {
+  const {foundation, mockAdapter} = setupTest();
+  const handlers = captureHandlers(mockAdapter, 'registerInteractionHandler');
+  const clock = lolex.install();
+  const raf = createMockRaf();
+  const target = {};
+  const preventDefault = td.func('event.preventDefault');
+  td.when(mockAdapter.getNumberOfItems()).thenReturn(3);
+  td.when(mockAdapter.getFocusedItemIndex()).thenReturn(0);
+
+  foundation.init();
+  handlers.keydown({target, key: 'ArrowDown', preventDefault});
+  clock.tick(numbers.SELECTED_TRIGGER_DELAY);
+  raf.flush();
+  t.doesNotThrow(() => td.verify(preventDefault()));
+
+  raf.restore();
+  clock.uninstall();
+  t.end();
+});
+
 test('on ArrowUp keydown on the first element, it moves to the last', t => {
   const {foundation, mockAdapter} = setupTest();
   const handlers = captureHandlers(mockAdapter, 'registerInteractionHandler');
@@ -805,6 +826,48 @@ test('on ArrowUp keydown on the last element, it moves to the previous', t => {
   clock.tick(numbers.SELECTED_TRIGGER_DELAY);
   raf.flush();
   t.doesNotThrow(() => td.verify(mockAdapter.focusItemAtIndex(1)));
+
+  raf.restore();
+  clock.uninstall();
+  t.end();
+});
+
+test('on ArrowUp keydown prevents default on the event', t => {
+  const {foundation, mockAdapter} = setupTest();
+  const handlers = captureHandlers(mockAdapter, 'registerInteractionHandler');
+  const clock = lolex.install();
+  const raf = createMockRaf();
+  const target = {};
+  const preventDefault = td.func('event.preventDefault');
+  td.when(mockAdapter.getNumberOfItems()).thenReturn(3);
+  td.when(mockAdapter.getFocusedItemIndex()).thenReturn(2);
+
+  foundation.init();
+  handlers.keydown({target, key: 'ArrowUp', preventDefault});
+  clock.tick(numbers.SELECTED_TRIGGER_DELAY);
+  raf.flush();
+  t.doesNotThrow(() => td.verify(preventDefault()));
+
+  raf.restore();
+  clock.uninstall();
+  t.end();
+});
+
+test('on spacebar keydown prevents default on the event', t => {
+  const {foundation, mockAdapter} = setupTest();
+  const handlers = captureHandlers(mockAdapter, 'registerInteractionHandler');
+  const clock = lolex.install();
+  const raf = createMockRaf();
+  const target = {};
+  const preventDefault = td.func('event.preventDefault');
+  td.when(mockAdapter.getNumberOfItems()).thenReturn(3);
+  td.when(mockAdapter.getFocusedItemIndex()).thenReturn(2);
+
+  foundation.init();
+  handlers.keydown({target, key: 'Space', preventDefault});
+  clock.tick(numbers.SELECTED_TRIGGER_DELAY);
+  raf.flush();
+  t.doesNotThrow(() => td.verify(preventDefault()));
 
   raf.restore();
   clock.uninstall();

--- a/test/unit/mdl-select/foundation-events.test.js
+++ b/test/unit/mdl-select/foundation-events.test.js
@@ -1,0 +1,228 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import test from 'tape';
+import td from 'testdouble';
+
+import {setupFoundationTest} from '../helpers/setup';
+import {captureHandlers} from '../helpers/foundation';
+
+import MDLSelectFoundation from '../../../packages/mdl-select/foundation';
+
+const {cssClasses} = MDLSelectFoundation;
+
+function setupTest() {
+  const {foundation, mockAdapter} = setupFoundationTest(MDLSelectFoundation);
+  td.when(mockAdapter.getNumberOfOptions()).thenReturn(2);
+  td.when(mockAdapter.getTextForOptionAtIndex(td.matchers.isA(Number))).thenReturn('text');
+  td.when(mockAdapter.create2dRenderingContext()).thenReturn({
+    font: '',
+    measureText: () => ({width: 100})
+  });
+  td.when(mockAdapter.getComputedStyleValue('font')).thenReturn('16px Times');
+  const handlers = captureHandlers(mockAdapter, 'registerInteractionHandler');
+  const menuHandlers = captureHandlers(mockAdapter, 'registerMenuInteractionHandler');
+  foundation.init();
+
+  return {foundation, mockAdapter, handlers, menuHandlers};
+}
+
+function createEvent(data) {
+  return Object.assign({preventDefault: td.func('.preventDefault')}, data);
+}
+
+test('on click opens the menu', t => {
+  const {mockAdapter, handlers} = setupTest();
+  handlers.click(createEvent());
+  t.doesNotThrow(() => td.verify(mockAdapter.addClass(cssClasses.OPEN)), 'adds the open class');
+  t.doesNotThrow(
+    () => td.verify(mockAdapter.openMenu(0)), 'opens the menu'
+  );
+  t.end();
+});
+
+test('on click opens the menu focused at the selected index, if any', t => {
+  const {foundation, mockAdapter, handlers} = setupTest();
+  foundation.setSelectedIndex(1);
+  handlers.click(createEvent());
+  t.doesNotThrow(() => td.verify(mockAdapter.openMenu(1)));
+  t.end();
+});
+
+test('on click cancels the event to prevent it from propagating', t => {
+  const {handlers} = setupTest();
+  const evt = createEvent();
+  handlers.click(evt);
+  t.doesNotThrow(() => td.verify(evt.preventDefault()));
+  t.end();
+});
+
+test('on ArrowUp keydown on the select itself opens the menu', t => {
+  const {mockAdapter, handlers} = setupTest();
+  const evt = createEvent({key: 'ArrowUp', eventPhase: Event.AT_TARGET});
+  handlers.keydown(evt);
+  t.doesNotThrow(() => td.verify(mockAdapter.addClass(cssClasses.OPEN)), 'adds the open class');
+  t.doesNotThrow(
+    () => td.verify(mockAdapter.openMenu(0)), 'opens the menu'
+  );
+  t.doesNotThrow(() => td.verify(evt.preventDefault()), 'calls event.preventDefault()');
+  t.end();
+});
+
+test('on ArrowUp keydown works with keyCode', t => {
+  const {mockAdapter, handlers} = setupTest();
+  const evt = createEvent({keyCode: 38, eventPhase: Event.AT_TARGET});
+  handlers.keydown(evt);
+  t.doesNotThrow(() => td.verify(mockAdapter.addClass(cssClasses.OPEN)));
+  t.end();
+});
+
+test('on ArrowUp keydown does not open the menu on bubbled events', t => {
+  const {mockAdapter, handlers} = setupTest();
+  const evt = createEvent({key: 'ArrowUp', eventPhase: Event.BUBBLING_PHASE});
+  handlers.keydown(evt);
+  t.doesNotThrow(() => td.verify(mockAdapter.addClass(cssClasses.OPEN), {times: 0}));
+  t.end();
+});
+
+test('on ArrowDown keydown on the select itself opens the menu', t => {
+  const {mockAdapter, handlers} = setupTest();
+  const evt = createEvent({key: 'ArrowDown', eventPhase: Event.AT_TARGET});
+  handlers.keydown(evt);
+  t.doesNotThrow(() => td.verify(mockAdapter.addClass(cssClasses.OPEN)), 'adds the open class');
+  t.doesNotThrow(
+    () => td.verify(mockAdapter.openMenu(0)), 'opens the menu'
+  );
+  t.doesNotThrow(() => td.verify(evt.preventDefault()), 'calls event.preventDefault()');
+  t.end();
+});
+
+test('on ArrowDown keydown works with keyCode', t => {
+  const {mockAdapter, handlers} = setupTest();
+  const evt = createEvent({keyCode: 40, eventPhase: Event.AT_TARGET});
+  handlers.keydown(evt);
+  t.doesNotThrow(() => td.verify(mockAdapter.addClass(cssClasses.OPEN)));
+  t.end();
+});
+
+test('on ArrowDown keydown does not open the menu on bubbled events', t => {
+  const {mockAdapter, handlers} = setupTest();
+  const evt = createEvent({key: 'ArrowDown', eventPhase: Event.BUBBLING_PHASE});
+  handlers.keydown(evt);
+  t.doesNotThrow(() => td.verify(mockAdapter.addClass(cssClasses.OPEN), {times: 0}));
+  t.end();
+});
+
+test('on Space keydown prevents default to prevent page from scrolling', t => {
+  const {handlers} = setupTest();
+  const evt = createEvent({key: 'Space', eventPhase: Event.AT_TARGET});
+  handlers.keydown(evt);
+  t.doesNotThrow(() => td.verify(evt.preventDefault()));
+  t.end();
+});
+
+test('on Space keydown works with keyCode', t => {
+  const {handlers} = setupTest();
+  const evt = createEvent({keyCode: 32, eventPhase: Event.AT_TARGET});
+  handlers.keydown(evt);
+  t.doesNotThrow(() => td.verify(evt.preventDefault()));
+  t.end();
+});
+
+test('on Space keyup on the select itself opens the menu', t => {
+  const {mockAdapter, handlers} = setupTest();
+  const evt = createEvent({key: 'Space', eventPhase: Event.AT_TARGET});
+  handlers.keyup(evt);
+  t.doesNotThrow(() => td.verify(mockAdapter.addClass(cssClasses.OPEN)), 'adds the open class');
+  t.doesNotThrow(
+    () => td.verify(mockAdapter.openMenu(0)), 'opens the menu'
+  );
+  t.doesNotThrow(() => td.verify(evt.preventDefault()), 'calls event.preventDefault()');
+  t.end();
+});
+
+test('on Space keyup works with keyCode', t => {
+  const {mockAdapter, handlers} = setupTest();
+  const evt = createEvent({keyCode: 32, eventPhase: Event.AT_TARGET});
+  handlers.keyup(evt);
+  t.doesNotThrow(() => td.verify(mockAdapter.addClass(cssClasses.OPEN)));
+  t.end();
+});
+
+test('on Space keyup does not open the menu on bubbled events', t => {
+  const {mockAdapter, handlers} = setupTest();
+  const evt = createEvent({key: 'Space', eventPhase: Event.BUBBLING_PHASE});
+  handlers.keydown(evt);
+  t.doesNotThrow(() => td.verify(mockAdapter.addClass(cssClasses.OPEN), {times: 0}));
+  t.end();
+});
+
+test('on MDLSimpleMenu:selected updates the selected index to that given by the event', t => {
+  const {foundation, menuHandlers} = setupTest();
+  const selected = menuHandlers['MDLSimpleMenu:selected'];
+  selected(createEvent({detail: {index: 1}}));
+  t.equal(foundation.getSelectedIndex(), 1);
+  t.end();
+});
+
+test('on MDLSimpleMenu:selected fires a change event', t => {
+  const {mockAdapter, menuHandlers} = setupTest();
+  const selected = menuHandlers['MDLSimpleMenu:selected'];
+  selected(createEvent({detail: {index: 1}}));
+  t.doesNotThrow(() => td.verify(mockAdapter.notifyChange()));
+  t.end();
+});
+
+test('on MDLSimpleMenu:selected does not fire change event if the index is already the selected index', t => {
+  const {foundation, mockAdapter, menuHandlers} = setupTest();
+  const selected = menuHandlers['MDLSimpleMenu:selected'];
+  foundation.setSelectedIndex(1);
+  selected({detail: {index: 1}});
+  t.doesNotThrow(() => td.verify(mockAdapter.notifyChange(), {times: 0}));
+  t.end();
+});
+
+test('on MDLSimpleMenu:selected closes the menu', t => {
+  const {mockAdapter, menuHandlers} = setupTest();
+  const selected = menuHandlers['MDLSimpleMenu:selected'];
+  selected(createEvent({detail: {index: 1}}));
+  t.doesNotThrow(() => td.verify(mockAdapter.removeClass(cssClasses.OPEN)));
+  t.end();
+});
+
+test('on MDLSimpleMenu:selected refocuses on the select element', t => {
+  const {mockAdapter, menuHandlers} = setupTest();
+  const selected = menuHandlers['MDLSimpleMenu:selected'];
+  selected(createEvent({detail: {index: 1}}));
+  t.doesNotThrow(() => td.verify(mockAdapter.focus()));
+  t.end();
+});
+
+test('on MDLSimpleMenu:cancel closes the menu', t => {
+  const {mockAdapter, menuHandlers} = setupTest();
+  const cancel = menuHandlers['MDLSimpleMenu:cancel'];
+  cancel(createEvent());
+  t.doesNotThrow(() => td.verify(mockAdapter.removeClass(cssClasses.OPEN)));
+  t.end();
+});
+
+test('on MDLSimpleMenu:cancel re-focuses the select element', t => {
+  const {mockAdapter, menuHandlers} = setupTest();
+  const cancel = menuHandlers['MDLSimpleMenu:cancel'];
+  cancel(createEvent());
+  t.doesNotThrow(() => td.verify(mockAdapter.removeClass(cssClasses.OPEN)));
+  t.end();
+});

--- a/test/unit/mdl-select/foundation.test.js
+++ b/test/unit/mdl-select/foundation.test.js
@@ -1,0 +1,249 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import test from 'tape';
+import td from 'testdouble';
+
+import {setupFoundationTest} from '../helpers/setup';
+import {captureHandlers, verifyDefaultAdapter} from '../helpers/foundation';
+
+import MDLSelectFoundation from '../../../packages/mdl-select/foundation';
+
+test('exports cssClasses', t => {
+  t.true('cssClasses' in MDLSelectFoundation);
+  t.end();
+});
+
+test('default adapter returns a complete adapter implementation', t => {
+  verifyDefaultAdapter(MDLSelectFoundation, [
+    'addClass', 'removeClass', 'setAttr', 'rmAttr', 'registerInteractionHandler',
+    'deregisterInteractionHandler', 'focus', 'makeTabbable', 'makeUntabbable',
+    'getComputedStyleValue', 'setStyle', 'create2dRenderingContext', 'openMenu',
+    'setSelectedTextContent', 'getNumberOfOptions', 'getTextForOptionAtIndex',
+    'setAttrForOptionAtIndex', 'rmAttrForOptionAtIndex', 'registerMenuInteractionHandler',
+    'deregisterMenuInteractionHandler', 'notifyChange'
+  ], t);
+  t.end();
+});
+
+function setupTest() {
+  return setupFoundationTest(MDLSelectFoundation);
+}
+
+test('#getSelectedIndex returns -1 if never set', t => {
+  const {foundation} = setupTest();
+  t.equal(foundation.getSelectedIndex(), -1);
+  t.end();
+});
+
+test('#setSelectedIndex updates the selected index', t => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.getNumberOfOptions()).thenReturn(2);
+  td.when(mockAdapter.getTextForOptionAtIndex(1)).thenReturn('');
+  foundation.setSelectedIndex(1);
+  t.equal(foundation.getSelectedIndex(), 1);
+  t.end();
+});
+
+test('#setSelectedIndex sets the trimmed text content of the selected item as selected text content', t => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.getNumberOfOptions()).thenReturn(2);
+  td.when(mockAdapter.getTextForOptionAtIndex(1)).thenReturn('   \nselected text ');
+  foundation.setSelectedIndex(1);
+  t.doesNotThrow(() => td.verify(mockAdapter.setSelectedTextContent('selected text')));
+  t.end();
+});
+
+test('#setSelectedIndex sets aria-selected to "true" on the selected item', t => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.getNumberOfOptions()).thenReturn(2);
+  td.when(mockAdapter.getTextForOptionAtIndex(1)).thenReturn('');
+  foundation.setSelectedIndex(1);
+  t.doesNotThrow(() => td.verify(mockAdapter.setAttrForOptionAtIndex(1, 'aria-selected', 'true')));
+  t.end();
+});
+
+test('#setSelectedIndex removes aria-selected from the previously selected item, if any', t => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.getNumberOfOptions()).thenReturn(2);
+  td.when(mockAdapter.getTextForOptionAtIndex(0)).thenReturn('');
+  td.when(mockAdapter.getTextForOptionAtIndex(1)).thenReturn('');
+  foundation.setSelectedIndex(0);
+  foundation.setSelectedIndex(1);
+  t.doesNotThrow(() => td.verify(mockAdapter.rmAttrForOptionAtIndex(0, 'aria-selected')));
+  t.end();
+});
+
+test('#setSelectedIndex clears the select if given index is < 0', t => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.getNumberOfOptions()).thenReturn(2);
+  foundation.setSelectedIndex(-15);
+  t.doesNotThrow(() => td.verify(mockAdapter.setSelectedTextContent('')));
+  t.equal(foundation.getSelectedIndex(), -1);
+  t.end();
+});
+
+test('#setSelectedIndex clears the select if given index is >= the number of options', t => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.getNumberOfOptions()).thenReturn(2);
+  foundation.setSelectedIndex(2);
+  t.doesNotThrow(() => td.verify(mockAdapter.setSelectedTextContent('')));
+  t.equal(foundation.getSelectedIndex(), -1);
+  t.end();
+});
+
+test('#isDisabled returns false by default', t => {
+  const {foundation} = setupTest();
+  t.false(foundation.isDisabled());
+  t.end();
+});
+
+test('#setDisabled sets disabled to true when true', t => {
+  const {foundation} = setupTest();
+  foundation.setDisabled(true);
+  t.true(foundation.isDisabled());
+  t.end();
+});
+
+test('#setDisabled adds the disabled class when true', t => {
+  const {foundation, mockAdapter} = setupTest();
+  foundation.setDisabled(true);
+  t.doesNotThrow(() => td.verify(mockAdapter.addClass(MDLSelectFoundation.cssClasses.DISABLED)));
+  t.end();
+});
+
+test('#setDisabled adds aria-disabled="true" when true', t => {
+  const {foundation, mockAdapter} = setupTest();
+  foundation.setDisabled(true);
+  t.doesNotThrow(() => td.verify(mockAdapter.setAttr('aria-disabled', 'true')));
+  t.end();
+});
+
+test('#setDisabled makes the select unfocusable when true', t => {
+  const {foundation, mockAdapter} = setupTest();
+  foundation.setDisabled(true);
+  t.doesNotThrow(() => td.verify(mockAdapter.makeUntabbable()));
+  t.end();
+});
+
+test('#setDisabled sets disabled to false when false', t => {
+  const {foundation} = setupTest();
+  foundation.setDisabled(false);
+  t.false(foundation.isDisabled());
+  t.end();
+});
+
+test('#setDisabled removes the disabled class when false', t => {
+  const {foundation, mockAdapter} = setupTest();
+  foundation.setDisabled(false);
+  t.doesNotThrow(() => td.verify(mockAdapter.removeClass(MDLSelectFoundation.cssClasses.DISABLED)));
+  t.end();
+});
+
+test('#setDisabled removes the aria-disabled attr when false', t => {
+  const {foundation, mockAdapter} = setupTest();
+  foundation.setDisabled(false);
+  t.doesNotThrow(() => td.verify(mockAdapter.rmAttr('aria-disabled')));
+  t.end();
+});
+
+test('#setDisabled makes the select focusable when false', t => {
+  const {foundation, mockAdapter} = setupTest();
+  foundation.setDisabled(false);
+  t.doesNotThrow(() => td.verify(mockAdapter.makeTabbable()));
+  t.end();
+});
+
+test('#resize resizes the element to the longest-length option', t => {
+  const {foundation, mockAdapter} = setupTest();
+  const ctx = td.object({
+    font: 'default font',
+    measureText: () => {}
+  });
+  td.when(mockAdapter.create2dRenderingContext()).thenReturn(ctx);
+  td.when(mockAdapter.getComputedStyleValue('font')).thenReturn('16px Roboto');
+  td.when(mockAdapter.getComputedStyleValue('letter-spacing')).thenReturn('2.5px');
+
+  // Add space on last option to test trimming
+  const opts = ['longer', 'longest', '     short     '];
+  const widths = [100, 200, 50];
+  td.when(mockAdapter.getNumberOfOptions()).thenReturn(opts.length);
+  opts.forEach((txt, i) => {
+    td.when(mockAdapter.getTextForOptionAtIndex(i)).thenReturn(txt);
+    td.when(ctx.measureText(txt.trim())).thenReturn({width: widths[i]});
+  });
+
+  foundation.init();
+  foundation.resize();
+  t.equal(ctx.font, '16px Roboto');
+  // ceil(letter-spacing * 'longest'.length + longest measured width)
+  const expectedWidth = Math.ceil((2.5 * 7) + Math.max(...widths));
+  t.doesNotThrow(() => td.verify(mockAdapter.setStyle('width', `${expectedWidth}px`)));
+  t.end();
+});
+
+test('#resize falls back to font-{family,size} if shorthand is not supported', t => {
+  const {foundation, mockAdapter} = setupTest();
+  const ctx = td.object({
+    font: 'default font',
+    measureText: () => {}
+  });
+  td.when(mockAdapter.create2dRenderingContext()).thenReturn(ctx);
+  td.when(mockAdapter.getComputedStyleValue('font')).thenReturn(null);
+  td.when(mockAdapter.getComputedStyleValue('font-size')).thenReturn('16px');
+  td.when(mockAdapter.getComputedStyleValue('font-family')).thenReturn('Roboto,sans-serif');
+  td.when(mockAdapter.getComputedStyleValue('letter-spacing')).thenReturn('2.5px');
+
+  // Add space on last option to test trimming
+  const opts = ['longer', 'longest', '     short     '];
+  const widths = [100, 200, 50];
+  td.when(mockAdapter.getNumberOfOptions()).thenReturn(opts.length);
+  opts.forEach((txt, i) => {
+    td.when(mockAdapter.getTextForOptionAtIndex(i)).thenReturn(txt);
+    td.when(ctx.measureText(txt.trim())).thenReturn({width: widths[i]});
+  });
+
+  foundation.init();
+  foundation.resize();
+  t.equal(ctx.font, '16px Roboto');
+  // ceil(letter-spacing * 'longest'.length + longest measured width)
+  const expectedWidth = Math.ceil((2.5 * 7) + Math.max(...widths));
+  t.doesNotThrow(() => td.verify(mockAdapter.setStyle('width', `${expectedWidth}px`)));
+  t.end();
+});
+
+test('#destroy deregisters all events registered within init()', t => {
+  const {foundation, mockAdapter} = setupTest();
+  td.when(mockAdapter.create2dRenderingContext()).thenReturn({});
+  td.when(mockAdapter.getComputedStyleValue('font')).thenReturn('16px Times');
+  const handlers = captureHandlers(mockAdapter, 'registerInteractionHandler');
+  const menuHandlers = captureHandlers(mockAdapter, 'registerMenuInteractionHandler');
+  foundation.init();
+  foundation.destroy();
+  Object.keys(handlers).forEach(type => {
+    t.doesNotThrow(
+      () => td.verify(mockAdapter.deregisterInteractionHandler(type, td.matchers.isA(Function))),
+      `Deregisters ${type} interaction handler`
+    );
+  });
+  Object.keys(menuHandlers).forEach(type => {
+    t.doesNotThrow(
+      () => td.verify(mockAdapter.deregisterMenuInteractionHandler(type, td.matchers.isA(Function))),
+      `Deregisters ${type} menu interaction handler`
+    );
+  });
+  t.end();
+});

--- a/test/unit/mdl-select/mdl-select.test.js
+++ b/test/unit/mdl-select/mdl-select.test.js
@@ -1,0 +1,333 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import test from 'tape';
+import bel from 'bel';
+import domEvents from 'dom-events';
+import td from 'testdouble';
+
+import {MDLSelect} from '../../../packages/mdl-select';
+
+class FakeMenu {
+  constructor() {
+    this.items = [
+      bel`<div id="item-1">Item 1</div>`,
+      bel`<div id="item-2">Item 2</div>`,
+      bel`<div id="item-3">Item 3</div>`
+    ];
+    this.listen = td.func('menu.listen');
+    this.unlisten = td.func('menu.unlisten');
+    this.show = td.func('menu.show');
+    this.hide = td.func('menu.hide');
+  }
+}
+
+function getFixture() {
+  return bel`
+    <div class="mdl-select" role="listbox" tabindex="0">
+      <span class="mdl-select__selected-text">Pick a food group</span>
+      <div class="mdl-select__menu mdl-simple-menu">
+        <ul class="mdl-simple-menu__items">
+          <li class="mdl-list-item" role="option" tabindex="0">An option</li>
+        </ul>
+      </div>
+    </div>
+  `;
+}
+
+test('attachTo returns a component instance', t => {
+  t.true(MDLSelect.attachTo(getFixture()) instanceof MDLSelect);
+  t.end();
+});
+
+function setupTest() {
+  const menu = new FakeMenu();
+  const fixture = getFixture();
+  const component = new MDLSelect(fixture, /* foundation */ undefined, menu);
+  return {menu, fixture, component};
+}
+
+test('options returns the menu items', t => {
+  const {menu, component} = setupTest();
+  t.equal(component.options, menu.items);
+  t.end();
+});
+
+test('selectOptions returns a NodeList containing the node with "aria-selected" as an attr', t => {
+  const {component, fixture} = setupTest();
+  const option = fixture.querySelector('[role="option"]');
+  t.equal(component.selectedOptions.length, 0, 'No selected options when none selected');
+  option.setAttribute('aria-selected', 'true');
+  t.equal(component.selectedOptions.length, 1, 'One selected option when element has aria-selected');
+  t.equal(component.selectedOptions[0], option, 'Option within selected options is the selected option');
+  t.end();
+});
+
+test('#get/setSelectedIndex', t => {
+  const {component} = setupTest();
+  t.equal(component.selectedIndex, -1);
+  component.selectedIndex = 1;
+  t.equal(component.selectedIndex, 1);
+  t.end();
+});
+
+test('#get/setDisabled', t => {
+  const {component} = setupTest();
+  t.equal(component.disabled, false);
+  component.disabled = true;
+  t.true(component.disabled);
+  t.end();
+});
+
+test('#item returns the menu item at the specified index', t => {
+  const {menu, component} = setupTest();
+  t.equal(component.item(1), menu.items[1]);
+  t.end();
+});
+
+test('#item returns null if index out of bounds', t => {
+  const {component} = setupTest();
+  t.equal(component.item(100), null);
+  t.end();
+});
+
+test('#nameditem returns the item whose id matches the given key', t => {
+  const {menu, component} = setupTest();
+  t.equal(component.nameditem('item-1'), menu.items[0]);
+  t.end();
+});
+
+test('#nameditem returns the item whose "name" key matches the given key', t => {
+  const {menu, component} = setupTest();
+  const item = menu.items[0];
+  const name = item.id;
+  item.id = '';
+  item.removeAttribute('id');
+  item.setAttribute('name', name);
+  t.equal(component.nameditem(name), menu.items[0]);
+  t.end();
+});
+
+test('#nameditem returns null when no id or name matches the given key', t => {
+  const {component} = setupTest();
+  t.equal(component.nameditem('nonexistant'), null);
+  t.end();
+});
+
+test('#initialSyncWithDOM sets the selected index if a menu item contains an aria-selected attribute', t => {
+  const menu = new FakeMenu();
+  const fixture = getFixture();
+  // Insert menu item into fixture to pretend like the fake menu items are part of the component under test.
+  menu.items[1].setAttribute('aria-selected', 'true');
+  fixture.appendChild(menu.items[1]);
+
+  const component = new MDLSelect(fixture, /* foundation */ undefined, menu);
+  t.equal(component.selectedIndex, 1);
+  t.end();
+});
+
+test('#initialSyncWithDOM disables the menu if aria-disabled="true" is found on the element', t => {
+  const fixture = getFixture();
+  fixture.setAttribute('aria-disabled', 'true');
+  const component = new MDLSelect(fixture);
+  t.true(component.disabled);
+  t.end();
+});
+
+test('adapter#addClass adds a class to the root element', t => {
+  const {component, fixture} = setupTest();
+  component.getDefaultFoundation().adapter_.addClass('foo');
+  t.true(fixture.classList.contains('foo'));
+  t.end();
+});
+
+test('adapter#removeClass removes a class from the root element', t => {
+  const {component, fixture} = setupTest();
+  fixture.classList.add('foo');
+  component.getDefaultFoundation().adapter_.removeClass('foo');
+  t.false(fixture.classList.contains('foo'));
+  t.end();
+});
+
+test('adapter#setAttr sets an attribute with a given value on the root element', t => {
+  const {component, fixture} = setupTest();
+  component.getDefaultFoundation().adapter_.setAttr('aria-disabled', 'true');
+  t.equal(fixture.getAttribute('aria-disabled'), 'true');
+  t.end();
+});
+
+test('adapter#rmAttr removes an attribute from the root element', t => {
+  const {component, fixture} = setupTest();
+  fixture.setAttribute('aria-disabled', 'true');
+  component.getDefaultFoundation().adapter_.rmAttr('aria-disabled');
+  t.false(fixture.hasAttribute('aria-disabled'));
+  t.end();
+});
+
+test('adapter#registerInteractionHandler adds an event listener to the root element', t => {
+  const {component, fixture} = setupTest();
+  const listener = td.func('eventlistener');
+  component.getDefaultFoundation().adapter_.registerInteractionHandler('click', listener);
+  domEvents.emit(fixture, 'click');
+  t.doesNotThrow(() => td.verify(listener(td.matchers.anything())));
+  t.end();
+});
+
+test('adapter#deregisterInteractionHandler removes an event listener from the root element', t => {
+  const {component, fixture} = setupTest();
+  const listener = td.func('eventlistener');
+  fixture.addEventListener('click', listener);
+  component.getDefaultFoundation().adapter_.deregisterInteractionHandler('click', listener);
+  domEvents.emit(fixture, 'click');
+  t.doesNotThrow(() => td.verify(listener(td.matchers.anything()), {times: 0}));
+  t.end();
+});
+
+test('adapter#focus focuses on the root element', t => {
+  const {component, fixture} = setupTest();
+  const handler = td.func('fixture focus handler');
+  fixture.addEventListener('focus', handler);
+  document.body.appendChild(fixture);
+
+  component.getDefaultFoundation().adapter_.focus();
+  t.equal(document.activeElement, fixture);
+
+  document.body.removeChild(fixture);
+  t.end();
+});
+
+test('adapter#makeTabbable sets the root element\'s tabindex to 0', t => {
+  const {component, fixture} = setupTest();
+  fixture.tabIndex = -1;
+  component.getDefaultFoundation().adapter_.makeTabbable();
+  t.equal(fixture.tabIndex, 0);
+  t.end();
+});
+
+test('adapter#makeUntabbable sets the root element\'s tabindex to -1', t => {
+  const {component, fixture} = setupTest();
+  fixture.tabIndex = 0;
+  component.getDefaultFoundation().adapter_.makeUntabbable();
+  t.equal(fixture.tabIndex, -1);
+  t.end();
+});
+
+test('adapter#getComputedStyleValue gets the computed style value of the prop from the root element', t => {
+  const {component, fixture} = setupTest();
+  document.body.appendChild(fixture);
+  fixture.style.width = '500px';
+  t.equal(
+    component.getDefaultFoundation().adapter_.getComputedStyleValue('width'),
+    getComputedStyle(fixture).getPropertyValue('width')
+  );
+  document.body.removeChild(fixture);
+  t.end();
+});
+
+test('adapter#setStyle sets the given style propertyName to the given value', t => {
+  const {component, fixture} = setupTest();
+  component.getDefaultFoundation().adapter_.setStyle('font-size', '13px');
+  t.equal(fixture.style.getPropertyValue('font-size'), '13px');
+  t.end();
+});
+
+test('adapter#create2dRenderingContext returns a CanvasRenderingContext2d instance', t => {
+  const {component} = setupTest();
+  const fakeCtx = {};
+  const fakeCanvas = {
+    getContext: td.func('canvas.getContext')
+  };
+  const origCreateElement = document.createElement;
+  document.createElement = td.func('document.createElement');
+
+  td.when(fakeCanvas.getContext('2d')).thenReturn(fakeCtx);
+  td.when(document.createElement('canvas')).thenReturn(fakeCanvas);
+
+  const ctx = component.getDefaultFoundation().adapter_.create2dRenderingContext();
+  t.equal(ctx, fakeCtx);
+
+  document.createElement = origCreateElement;
+  t.end();
+});
+
+test('adapter#openMenu shows the menu with the given focusIndex', t => {
+  const {component, menu} = setupTest();
+  component.getDefaultFoundation().adapter_.openMenu(1);
+  t.doesNotThrow(() => td.verify(menu.show({focusIndex: 1})));
+  t.end();
+});
+
+test('adapter#setSelectedTextContent sets the textContent of the selected text el', t => {
+  const {component, fixture} = setupTest();
+  component.getDefaultFoundation().adapter_.setSelectedTextContent('content');
+  t.equal(fixture.querySelector('.mdl-select__selected-text').textContent, 'content');
+  t.end();
+});
+
+test('adapter#getNumberOfOptions returns the length of the component\'s options property', t => {
+  const {component} = setupTest();
+  t.equal(component.getDefaultFoundation().adapter_.getNumberOfOptions(), component.options.length);
+  t.end();
+});
+
+test('adapter#getTextForOptionAtIndex gets the text content for the option at the given index', t => {
+  const {component} = setupTest();
+  t.equal(
+    component.getDefaultFoundation().adapter_.getTextForOptionAtIndex(1),
+    component.options[1].textContent
+  );
+  t.end();
+});
+
+test('adapter#setAttrForOptionAtIndex sets an attribute to the given value for the option at the ' +
+     'given index', t => {
+  const {component} = setupTest();
+  component.getDefaultFoundation().adapter_.setAttrForOptionAtIndex(1, 'aria-disabled', 'true');
+  t.equal(component.options[1].getAttribute('aria-disabled'), 'true');
+  t.end();
+});
+
+test('adapter#rmAttrForOptionAtIndex removes the given attribute for the option at the given index', t => {
+  const {component} = setupTest();
+  component.options[1].setAttribute('aria-disabled', 'true');
+  component.getDefaultFoundation().adapter_.rmAttrForOptionAtIndex(1, 'aria-disabled');
+  t.false(component.options[1].hasAttribute('aria-disabled'));
+  t.end();
+});
+
+test('adapter#registerMenuInteractionHandler listens for an interaction handler on the menu', t => {
+  const {component, menu} = setupTest();
+  const handler = () => {};
+  component.getDefaultFoundation().adapter_.registerMenuInteractionHandler('evt', handler);
+  t.doesNotThrow(() => td.verify(menu.listen('evt', handler)));
+  t.end();
+});
+
+test('adapter#deregisterMenuInteractionHandler unlistens for an interaction handler on the menu', t => {
+  const {component, menu} = setupTest();
+  const handler = () => {};
+  component.getDefaultFoundation().adapter_.deregisterMenuInteractionHandler('evt', handler);
+  t.doesNotThrow(() => td.verify(menu.unlisten('evt', handler)));
+  t.end();
+});
+
+test('adapter#notifyChange emits an "MDLSelect:change" custom event from the root element', t => {
+  const {component, fixture} = setupTest();
+  const handler = td.func('MDLSelect:change handler');
+  fixture.addEventListener('MDLSelect:change', handler);
+  component.getDefaultFoundation().adapter_.notifyChange();
+  t.end();
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,6 +36,7 @@ module.exports = [{
     menu: [path.resolve('./packages/mdl-menu/index.js')],
     radio: [path.resolve('./packages/mdl-radio/index.js')],
     ripple: [path.resolve('./packages/mdl-ripple/index.js')],
+    select: [path.resolve('./packages/mdl-select/index.js')],
     snackbar: [path.resolve('./packages/mdl-snackbar/index.js')],
     textfield: [path.resolve('./packages/mdl-textfield/index.js')]
   },
@@ -93,6 +94,7 @@ module.exports = [{
     'mdl.menu': path.resolve('./packages/mdl-menu/mdl-menu.scss'),
     'mdl.radio': path.resolve('./packages/mdl-radio/mdl-radio.scss'),
     'mdl.ripple': path.resolve('./packages/mdl-ripple/mdl-ripple.scss'),
+    'mdl.select': path.resolve('./packages/mdl-select/mdl-select.scss'),
     'mdl.snackbar': path.resolve('./packages/mdl-snackbar/mdl-snackbar.scss'),
     'mdl.textfield': path.resolve('./packages/mdl-textfield/mdl-textfield.scss'),
     'mdl.theme': path.resolve('./packages/mdl-theme/mdl-theme.scss'),


### PR DESCRIPTION
* Remove restriction on menu roles. Simply look for any `mdl-list-item`
  with a `role` attribute when querying for menu items.
* Implement select UI with MDL simple menu.
* Implement Pure CSS version on top of browser's select element
* Bump up karma timeouts in a blind effort to decrease TravisCI
  flakiness

NOTE: Auto-positioning the select menu still needs to be done.

Part of #4475
[Delivers #126819221]