### PR TITLE
fix(textfield): Disable pointer events for JS Component labels

### DIFF
--- a/packages/mdl-textfield/mdl-textfield.scss
+++ b/packages/mdl-textfield/mdl-textfield.scss
@@ -143,6 +143,10 @@ $mdl-textfield-disabled-border-on-dark: rgba(white, .3);
       }
     }
   }
+
+  .mdl-textfield__label {
+    pointer-events: none;
+  }
 }
 
 .mdl-textfield--focused {


### PR DESCRIPTION
Fixes issue where the label positioned on top of the text field
intercepts the click event the textfield needs to gain focused. This was
originally uncaught because textfield labels were always given a `for`
attribute pointing back to a uniquely ID'd textfield. We cannot,
however, assume this will always be the case.

[ci skip]