### PR TITLE
Copy edits to the Getting started doc

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,18 +1,17 @@
 > NOTE: We have yet to publish our initial release to npm. However, once we do, the installation
 instructions will work.
 
-# Getting Started
+# Getting started
 
 This guide will help you get started using MDLv2 on your own sites and within your own projects.
 
 > If you are interested in integrating MDLv2 into a framework, or building a component library for
 your framework that wraps MDLv2, check out our [framework integration guide](./integrating-into-frameworks.md).
 
-## MDL Quick Start: Building a simple greeting app
+## MDL quick start: building a simple greeting app
 
 The best way to learn any new technology is to get your hands dirty and build something with it, so
-that's what we'll do here! We'll be building a simple web page which lets you enter a first and/or
-last name, and then greets you using your name. You can see a finished example [here](https://plnkr.co/edit/ahd84pIgOF7OTKgavvPP?p=preview).
+that is what we will do here!  We will be building a simple greeting page which lets you enter a name and greets you as such. Here is the [finished example](https://plnkr.co/edit/ahd84pIgOF7OTKgavvPP?p=preview).
 
 As you go through this guide, we encourage you to code along with it. By the end, you will have
 learned the fundamentals incorporating MDLv2 into simple sites, as well as worked with some of the
@@ -20,35 +19,31 @@ components we have to offer.
 
 ### Setting up the project
 
-First, let's set up our project. Throughout this guide, we'll assume you have a recent version of
-[NodeJS](https://nodejs.org/en/) and [npm](https://www.npmjs.com/) available on your `$PATH`. You can get the latest NodeJS download [here](https://nodejs.org/en/download/), or use a
-tool like [nvm](https://github.com/creationix/nvm) to install it.
+Before setting up the project, you will need to have a recent version of [NodeJS](https://nodejs.org/). Install it with the [NodeJS installer](https://nodejs.org/en/download/) or through [nvm](https://github.com/creationix/nvm). The [npm](https://www.npmjs.com/) command should made be available on your `$PATH`.
 
-Once node is installed, create a directory for the site, and install MDLv2 inside of it.
+Let's begin creating the project by first creating the directory for the app and add MDLv2. 
+This will install MDLv2 into the `node_modules` folder inside of the `greeting-app` directory.
 
 ```
 mkdir greeting-app
 cd greeting-app
-npm init -y # adds a package.json file into the directory
+npm init -y  # adds a package.json file into the directory
 npm install --save material-design-lite
 ```
 
-This will install MDLv2 into the `node_modules` folder inside of the `greeting-app` directory.
-
-While we're at it, let's also install [live-server](http://tapiov.net/live-server/) so we can
-develop our greeting app using a local server, and have it automatically reload when we make
-changes.
+We recommend installing and using [live-server](http://tapiov.net/live-server/) as the local 
+development server that will automatically reload when changes are made.
 
 ```
 npm install --global live-server
 ```
 
 The `--global` flag tells npm to install the package globally, so that the `live-server` program
-will be available on your path.
+will be available on your `$PATH`.
 
 ### Creating the skeleton index.html file
 
-Now that we have a sane environment set up, let's create a simple `index.html` file, and include
+Now that we have a the environment set up, let us create a simple `index.html` file, and include
 the assets needed for MDLv2. Put the following within `index.html` in the `greeting-app` directory:
 
 ```html
@@ -69,9 +64,14 @@ the assets needed for MDLv2. Put the following within `index.html` in the `greet
 </html>
 ```
 
-To view the page, run `live-server` within the `greeting-app` directory. This will open up your
+View this page by running `live-server` within the `greeting-app` directory. This will open up your
 browser to the URL which is serving our `index.html` file. You can leave `live-server` running for
 the duration of this guide.
+
+```
+cd greeting-app
+live-server
+```
 
 Let's take a look at a few aspects of the above HTML.
 
@@ -80,22 +80,21 @@ Let's take a look at a few aspects of the above HTML.
   JavaScript is only necessary for dynamic components whose UI needs to be made aware of events
   happening on the page. As we develop our greeting app, we'll
   add in the necessary JavaScript.
-* **No automatic DOM rendering** - For all components, MDL does not render _any_ DOM elements
+* **No automatic DOM rendering** - For all components, MDLv2 does not render _any_ DOM elements
   itself. MDLv2 is similar to [Bootstrap](http://getbootstrap.com/) in this respect; it expects you to render the DOM using the proper CSS classes. This avoids a litany of problems for integrating MDL into
   complex applications.
 * **Elements are not natively styled** - Notice how above, we give the `<html>` element a class of
   `mdl-typography`, the `<h1>` element a class of `mdl-typography--display1`, and the button a class
-  of `mdl-button`, along with multiple _modifier classes_. We _never_ make any assumptions about
+  of `mdl-button`, along with multiple _modifier classes_. MDLv2 _never_ makes any assumptions about
   which elements are being used for our components, instead relying on CSS classes for maximum
-  flexibility. Our CSS class names follow a slightly modified version of the [BEM](http://getbem.com/) system.
+  flexibility. MDLv2's CSS class names follow a slightly modified version of the [BEM](http://getbem.com/) system.
 
 ### Adding in JavaScript for dynamic components
 
-Now that we've gotten the gist of MDLv2, let's build our greeting app. The app consists of
-two input fields (for first and last name) and a submit button. Because Material Design
-text input fields contain a lot of functionality, we must include JavaScript to provide a
-full-fidelity experience for them. Furthermore, it would be nice if our submit button featured a
-ripple effect. We can include that using JavaScript as well.
+Now that we've gotten the gist of MDLv2, let us continue to build our greeting app. 
+
+The app consists of two input fields and a submit button. Material Design text input 
+fields and buttons contain a lot of dynamism and animation that require the usage of JavaScript.
 
 > Note that we currently have an [issue out](https://github.com/google/material-design-lite/issues/4614) to integrate ripples directly into buttons.
 
@@ -144,26 +143,26 @@ Replace the contents of the `<body>` tag in `index.html` with the following:
 <script>window.mdl.autoInit();</script>
 ```
 
-If you save the file return to your browser, you'll now see that we have two very nicely styled
-form fields, as well as a button that - when pressed - displays a material ink ripple. The ripple is a bit subtle though - we'll address that shortly. For now, let's go back and take a look at
-what we just wrote.
+Once the changes are made, return to your browser and you will see two very nicely styled form
+fields along with a Material Design styled button. The button shows an ink ripple effect when pressed. For now, the ripple is a fairly subtle that will be addressed shortly.
 
-The two main things to notice are the `data-mdl-auto-init` attributes, as well as the final script
-tag, which simply calls `window.mdl.autoInit()`. Unlike MDLv1, **MDLv2 does not
-instantiate any components automatically.** This avoids the headaches involved with hacking around
-lifecycle handlers that we saw with MDLv1 when trying to use it within more complex sites.
+Two important points that are demonstrated in the code that was added:
+
+#### MDLv2 does not instantiate any components automatically
+
+This avoids the headaches involved with  lifecycle handlers management in MDLv1. 
+Initialization is done through the `data-mdl-auto-init` attributes added
+to those elements that are initialized when mdl.autoInit() is called.
 
 When `mdl.autoInit()` is called, it looks for all elements with a `data-mdl-auto-init` attribute,
-and attaches the MDL JS Component with the given class name to that element (the actual
-mechanics are a bit more complicated, but for now this is essentially all you need to understand about
-what it's doing). So when it sees `MDLTextfield`, it instantiates a [MDLTextfield](../packages/mdl-textfield) instance
-to the corresponding elements. It does the same thing for the button, attaching a [MDLRipple](../packages/mdl-ripple)
-instance to the element.
+and attaches the MDL JS Component with the given class name to that element.. So when it sees `MDLTextfield`, 
+it instantiates a [MDLTextfield](../packages/mdl-textfield) instance to the corresponding elements. 
+It does the same thing for the button, attaching a [MDLRipple](../packages/mdl-ripple) instance to the element.
 
 It is worth noting that `mdl.autoInit` is provided _purely_ as a convenience function, and is not
 required to actually use the components. It is, however, the simplest way to get up and running
 quickly, and recommended for static sites that use the comprehensive `material-design-lite` library.
-Speaking of which, this is a great time to talk about a fundamental aspect of MDLv2:
+
 
 #### All components are modular
 
@@ -209,7 +208,7 @@ following below the last `<script>` tag within the `<body>`:
 When you save the file and the page reloads, you should be able to type your name into the form,
 hit the button, and get a pleasant greeting :wave:
 
-### Changing the Theme
+### Changing the theme
 
 You may have noticed that the button background, as well as the label and underline on focused text
 input fields, defaults to the Indigo 500 (`#673AB7`) color from the [Material Design color palette](https://material.google.com/style/color.html#color-color-palette).
@@ -217,7 +216,7 @@ This is part of the default theme that ships with MDL; it uses Indigo 500 for a 
 Pink A200 (`#FF4081`) for an accent color. Let's change the theme's primary color.
 
 A common misconception when implementing Material Design is that the colors you use _must_ come from
-the Material Palette. This is not true at all. The only defining guideline for color within Material
+the Material Design color palette. This is not true at all. The only defining guideline for color within Material
 Design is that it has "bold hues juxtaposed with muted environments, deep shadows, and bright
 highlights". Let's change our theme's primary color to `#0E4EAD`, the "Afternoon_Skyblue" color from
 the [Deep_Skyblues Colourlovers Palette](http://www.colourlovers.com/palette/334208/Deep_Skyblues).
@@ -239,14 +238,15 @@ fields are now a nice, dark shade of blue.
 > Note that using CSS Variables is just one way of theming using MDLv2. Check out our
 [theming documentation](./theming.md) _(coming soon!)_ for more info.
 
-### Finishing Touches: Adding some custom styles
+### Finishing touches: adding custom styles
 
 Every site is different, and we cannot hope to build a user interface library that
-anticipates every design choice a user may want. Because MDLv2 uses plain old CSS, it is
-trivial to customize and modify its styles to your liking. Let's change the ripple color to be a
+anticipates every design choice a user may want.  MDLv2 uses plain old CSS to make it trivial to 
+customize and modify its styles to your liking. Let's change the ripple color to be a
 more opaque shade of white, as well as add some auxiliary styles to bump up the vertical spacing
-between the form fields and the submit button. Add the following to the `<style>` tag within
-`<head>`:
+between the form fields and the submit button. 
+
+Add the following to the `<style>` tag within `<head>`:
 
 ```css
 .mdl-ripple-surface.mdl-ripple-upgraded.mdl-button--primary::before,
@@ -259,12 +259,12 @@ between the form fields and the submit button. Add the following to the `<style>
 }
 ```
 
-Congrats! You've built your first MDLv2 app! In the process, you've learned the basics of MDL,
+Congrats! You've built your first MDLv2 app! In the process, you've learned the basics of MDLv2,
 how to easily add components to a page, and how to customize and theme MDL to your liking.
 
-## Next Steps
+## Next steps
 
-If you're looking to incorporate MDL Components into a framework like Angular or React, check our
+If you're looking to incorporate MDLv2 Components into a framework like Angular or React, check our
 [framework integration guide](./integrating-into-frameworks.md). You can also take a look at our
 [examples](../examples) directory which contains examples integrating MDLv2 components into popular
 front-end frameworks. It also shows how you can use our source ES2015 and SCSS files directly within

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,7 +43,7 @@ will be available on your `$PATH`.
 
 ### Creating the skeleton index.html file
 
-Now that we have a the environment set up, let us create a simple `index.html` file, and include
+Now that we have the environment set up, create a simple `index.html` file, and include
 the assets needed for MDLv2. Put the following within `index.html` in the `greeting-app` directory:
 
 ```html

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,7 +11,7 @@ your framework that wraps MDLv2, check out our [framework integration guide](./i
 ## MDL quick start: building a simple greeting app
 
 The best way to learn any new technology is to get your hands dirty and build something with it, so
-that is what we will do here!  We will be building a simple greeting page which lets you enter a name and greets you as such. Here is the [finished example](https://plnkr.co/edit/ahd84pIgOF7OTKgavvPP?p=preview).
+that is what we will do here!  You will be building a simple greeting page which lets you enter a name and greets you as such. Here is the [finished example](https://plnkr.co/edit/ahd84pIgOF7OTKgavvPP?p=preview).
 
 As you go through this guide, we encourage you to code along with it. By the end, you will have
 learned the fundamentals incorporating MDLv2 into simple sites, as well as worked with some of the
@@ -43,7 +43,7 @@ will be available on your `$PATH`.
 
 ### Creating the skeleton index.html file
 
-Now that we have the environment set up, create a simple `index.html` file, and include
+Now that you have the environment set up, create a simple `index.html` file, and include
 the assets needed for MDLv2. Put the following within `index.html` in the `greeting-app` directory:
 
 ```html
@@ -166,7 +166,7 @@ quickly, and recommended for static sites that use the comprehensive `material-d
 
 #### All components are modular
 
-Although when we initially set up this project we installed the `material-design-lite` package, that
+Although when you initially set up this project you installed the `material-design-lite` package, that
 package is simply a thin wrapper around individual component packages, such as [mdl-typography](../packages/mdl-typography), [mdl-button](../packages/mdl-button), [mdl-textfield](../packages/mdl-textfield), and [mdl-ripple](../packages/mdl-ripple).
 Even the `autoInit()` function [lives in its own package](../packages/mdl-auto-init), which the
 `material-design-lite` package uses to register all of the individual components to their names used


### PR DESCRIPTION
Sentence casing titles.
Simplifying the beginning paragraphs.
Restructured parts of the content in the "Adding Javascript" section.
Updated some references from MDL to MDLv2 to be consistent across the doc.