### PR TITLE
fix(button): Remove text decoration

### DIFF
--- a/packages/mdl-button/mdl-button.scss
+++ b/packages/mdl-button/mdl-button.scss
@@ -38,6 +38,7 @@
   font-weight: 500;
   line-height: 36px; /* Override line-height so text aligns centered */
   text-align: center;
+  text-decoration: none;
   text-transform: uppercase;
   vertical-align: middle;
   box-sizing: border-box;


### PR DESCRIPTION
Removing the text decoration allows anchors to be styled as buttons without receiving their default underlined text.