### PR TITLE
fix(radio): add height and vertical-align

### DIFF
--- a/src/radio/_radio.scss
+++ b/src/radio/_radio.scss
@@ -25,7 +25,10 @@
 
   display: inline-block;
 
+  vertical-align: middle;
+
   box-sizing: border-box;
+  height: $radio-label-height;
   margin: 0;
   padding-left: 0;
 


### PR DESCRIPTION
Add height and vertical-align to radio buttons so that radio buttons in list actions align correctly with the content. The added styles are already present in the checkbox component which does not have this issue.

Fiddle: https://jsfiddle.net/xuvryLyg/1/
This example is from the documentation: https://getmdl.io/components/index.html#lists-section

Merging this request would also mean a change to the above linked documentation page. Adding the following fix mentioned in that documentation would align the field incorrectly again:
```
.demo-list-radio {
  display: inline;
}
```
**EDIT:** So the piece of CSS above should just be removed from the documentation. The `display: inline-block` (which is on the radio button component by default) should give the correct result.

Let me know what you think or if I missed something.