### PR TITLE
_radio.scss: scale() instead of scale3d()

### DIFF
--- a/src/radio/_radio.scss
+++ b/src/radio/_radio.scss
@@ -101,13 +101,13 @@
 
   @include material-animation-default(0.28s);
   transition-property: transform;
-  transform: scale3d(0, 0, 0);
+  transform: scale(0, 0);
 
   border-radius: 50%;
   background: $radio-color;
 
   .mdl-radio.is-checked & {
-    transform: scale3d(1, 1, 1);
+    transform: scale(1, 1);
   }
 
   fieldset[disabled] .mdl-radio &,


### PR DESCRIPTION
This should fix the compatibility with Opera 12, which doesn't support scale3d(), but there might be issues with scale() in other browsers: http://stackoverflow.com/questions/9986226/when-scaling-an-element-with-css3-scale-it-becomes-pixelated-until-just-after-t