### PR TITLE
Fix browser native validation message

### DIFF
--- a/src/checkbox/_checkbox.scss
+++ b/src/checkbox/_checkbox.scss
@@ -43,15 +43,10 @@
   .mdl-checkbox.is-upgraded & {
     // Hide input element, while still making it respond to focus.
     position: absolute;
-    width: 0;
-    height: 0;
+    z-index: -1;
     margin: 0;
     padding: 0;
     opacity: 0;
-    -ms-appearance: none;
-    -moz-appearance: none;
-    -webkit-appearance: none;
-    appearance: none;
     border: none;
   }
 }

--- a/src/radio/_radio.scss
+++ b/src/radio/_radio.scss
@@ -43,15 +43,10 @@
   .mdl-radio.is-upgraded & {
     // Hide input element, while still making it respond to focus.
     position: absolute;
+    z-index: -1;
     width: 0;
-    height: 0;
-    margin: 0;
     padding: 0;
     opacity: 0;
-    -ms-appearance: none;
-    -moz-appearance: none;
-    -webkit-appearance: none;
-    appearance: none;
     border: none;
   }
 }


### PR DESCRIPTION
Fix for issue #4990 
The problem was in css properties that prevents native browser validation bubble.
Tested in Safari, FF, Chrome on macOS.