### PR TITLE
Textfield, floating label font size for invalid state

### DIFF
--- a/src/textfield/_textfield.scss
+++ b/src/textfield/_textfield.scss
@@ -154,7 +154,6 @@
 
   .mdl-textfield--floating-label.is-invalid & {
     color: $input-text-error-color;
-    font-size: $input-text-floating-label-fontsize;
   }
 
   // The after label is the colored underline for the TextField.


### PR DESCRIPTION
> What is the actual behaviour?

Floating label font size for invalid and empty textfield is set to `$input-text-floating-label-fontsize` which is `12px`. So, the font size for empty text-field does not change (no matter if it is focused or not) which is wrong I think, because it is not consistent with valid field behaviour.

> What is the expected behaviour?

In order to be consistent floating-label for invalid textfield should change to 
- `$input-text-font-size` for not focused and empty textfield
- `$input-text-floating-label-fontsize` for focused and/or filled
Just like the valid field behaviour.
