### PR TITLE
Remove CSS dependency on .is-small-screen class

### DIFF
--- a/src/layout/_layout.scss
+++ b/src/layout/_layout.scss
@@ -47,15 +47,18 @@
   overflow-x: hidden;
   position: relative;
   -webkit-overflow-scrolling: touch;
-}
 
-// Utility classes for screen sizes.
-.mdl-layout.is-small-screen .mdl-layout--large-screen-only {
-  display: none;
-}
-
-.mdl-layout:not(.is-small-screen) .mdl-layout--small-screen-only {
-  display: none;
+  // Utility classes for screen sizes.
+  @media screen and (max-width: $layout-screen-size-threshold) {
+    & .mdl-layout--large-screen-only {
+      display: none;
+    }
+  }
+  @media screen and (min-width: $layout-screen-size-threshold + 1px) {
+    & .mdl-layout--small-screen-only {
+      display: none;
+    }
+  }
 }
 
 .mdl-layout__container {
@@ -251,13 +254,11 @@
       min-height: $layout-mobile-header-height;
     }
 
-    .mdl-layout--fixed-drawer.is-upgraded:not(.is-small-screen) > & {
-      margin-left: $layout-drawer-width;
-      width: calc(100% - #{$layout-drawer-width});
-    }
-
     @media screen and (min-width: $layout-screen-size-threshold + 1px) {
       .mdl-layout--fixed-drawer > & {
+        margin-left: $layout-drawer-width;
+        width: calc(100% - #{$layout-drawer-width});
+
         .mdl-layout__header-row {
           padding-left: 40px;
         }


### PR DESCRIPTION
## Problem: Layout component styling on .is-small-screen

There are three `mdl-layout` styling features that depend on the `.is-small-screen` class. Currently that class is attached in JS, meaning there is a visible delay between page load and JS registration before the style is applied. Those styles also aren't applied if JS is disabled. This is unnecessary - all three styles should be JS-independent. They are:

1. `.mdl-layout--large-screen-only`, which hides an element (`display: none`) if the screen is 1024px or smaller.
2. `.mdl-layout--small-screen-only`, which hides an element (`display: none`) if the screen is 1025px or larger.
3. `.mdl-layout--fixed-drawer .mdl-layout__header`, which shifts the header to the right if the screen is 1025px or larger and there is a fixed drawer (note the fixed drawer is shown in this condition regardless of JS registration, so the header should also be shifted regardless).

### Fix

`.is-small-screen` is being attached in JS based on `window.matchMedia('(max-width: 1024px)')`. The exact same media query can be used in CSS instead to generate these styles directly. In fact, that media query is already used frequently elsewhere in the `mdl-layout` CSS.

This hotfix keeps the JS media query and generation of the `.is-small-screen` class, but removes all three CSS dependencies on that class.