### PR TITLE
Stopped using href attr on tabs if it's undefined

### DIFF
--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -139,7 +139,7 @@
       }
 
       tab.addEventListener('click', function(e) {
-        if (tab.getAttribute('href').charAt(0) === '#') {
+        if (tab.href && tab.href.charAt(0) === '#') {
           e.preventDefault();
           var href = tab.href.split('#')[1];
           var panel = ctx.element_.querySelector('#' + href);


### PR DESCRIPTION
If a user is managing tabs themselves with click callbacks instead of href there would be an error that prints out from trying to get charAt(0) of undefined. This change checks to make sure href exists before getting charAt(0).
Functionally if you're not watching the log window there should be no change.