### PR TITLE
set is_dirty when placeholder exists

### DIFF
--- a/src/textfield/textfield.js
+++ b/src/textfield/textfield.js
@@ -175,7 +175,7 @@
    * @public
    */
   MaterialTextfield.prototype.checkDirty = function() {
-    if (this.input_.value && this.input_.value.length > 0) {
+    if ((this.input_.value && this.input_.value.length > 0) || this.input_.placeholder) {
       this.element_.classList.add(this.CssClasses_.IS_DIRTY);
     } else {
       this.element_.classList.remove(this.CssClasses_.IS_DIRTY);


### PR DESCRIPTION
set is_dirty when placeholder exists. Prior to this change, mdl textfield titles would overlap with the placeholder text. This ensures the mdl title is properly moved up if placeholder text is set.