### PR TITLE
Remove 90% width from mdl-card__supporting-text

### DIFF
--- a/src/card/_card.scss
+++ b/src/card/_card.scss
@@ -82,7 +82,6 @@
   line-height: $card-supporting-text-line-height;
   overflow: hidden;
   padding: $card-vertical-padding $card-horizontal-padding;
-  width: 90%;
 
   &.mdl-card--border {
     border-bottom: 1px solid $card-border-color;


### PR DESCRIPTION
The `mdl-card__title` div fills its parent (the card) as it should.

![title](https://user-images.githubusercontent.com/5547518/29039406-71dcb1f4-7bab-11e7-9a5f-e9601b9987dd.png)

However, the `mdl-card__supporting-text` only takes up 90% of the width.

![supporting_text](https://user-images.githubusercontent.com/5547518/29039404-71d802d0-7bab-11e7-9f02-b9b950c8cd74.png)

This doesn't necessarily have a visual impact (certainly not in the example seen here), but is problematic when you have a lot of content or content that is aligned to the right. With the `width` attribute removed from the CSS class, this is solved.

![supporting_text_fixed](https://user-images.githubusercontent.com/5547518/29039405-71db5fb6-7bab-11e7-9ae4-00858e3df2a5.png)