### PR TITLE
Hide menu on tab event

### DIFF
--- a/src/menu/menu.js
+++ b/src/menu/menu.js
@@ -56,6 +56,7 @@
    * @private
    */
   MaterialMenu.prototype.Keycodes_ = {
+    TAB: 9,
     ENTER: 13,
     ESCAPE: 27,
     SPACE: 32,
@@ -235,6 +236,11 @@
         } else if (evt.keyCode === this.Keycodes_.DOWN_ARROW) {
           evt.preventDefault();
           items[0].focus();
+        } else if (evt.keyCode === this.Keycodes_.ESCAPE) {
+          evt.preventDefault();
+          this.hide();
+        } else if (evt.keyCode === this.Keycodes_.TAB) {
+          this.hide();
         }
       }
     }
@@ -281,6 +287,8 @@
           evt.target.click();
         } else if (evt.keyCode === this.Keycodes_.ESCAPE) {
           evt.preventDefault();
+          this.hide();
+        } else if (evt.keyCode === this.Keycodes_.TAB) {
           this.hide();
         }
       }


### PR DESCRIPTION
Addresses this issue: https://github.com/google/material-design-lite/issues/4790

When a menu is open, pressing escape will close it. Also pressing tab will focus on the next item, but also closing the current menu. 

I wasn't sure if the desired behavior is pressing tab when you have an item selected should act as an `ARROW_DOWN`, but if it is, that's an easy fix