### PR TITLE
Show tooltips on element focus

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -136,7 +136,9 @@
         this.boundMouseLeaveAndScrollHandler = this.hideTooltip_.bind(this);
         this.forElement_.addEventListener('mouseenter', this.boundMouseEnterHandler, false);
         this.forElement_.addEventListener('touchend', this.boundMouseEnterHandler, false);
+        this.forElement_.addEventListener('focus', this.boundMouseEnterHandler, false);
         this.forElement_.addEventListener('mouseleave', this.boundMouseLeaveAndScrollHandler, false);
+        this.forElement_.addEventListener('blur', this.boundMouseLeaveAndScrollHandler, false);
         window.addEventListener('scroll', this.boundMouseLeaveAndScrollHandler, true);
         window.addEventListener('touchstart', this.boundMouseLeaveAndScrollHandler);
       }


### PR DESCRIPTION
As per the [Material Design specs](https://material.io/components/tooltips):

> Tooltips display informative text when users hover over, **focus on**, or tap an element.
 
Tooltips should be shown when an element is focused, which is useful for example during tab navigation on a page.