### PR TITLE
Fix the Material Design Introduction link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Gitter version](https://img.shields.io/gitter/room/gitterHQ/gitter.svg)](https://gitter.im/google/material-design-lite)
 [![Dependency Status](https://david-dm.org/google/material-design-lite.svg)](https://david-dm.org/google/material-design-lite)
 
-> An implementation of [Material Design](http://www.google.com/design/spec/material-design/introduction.html)
+> An implementation of [Material Design](https://material.io/design/introduction)
 components in vanilla CSS, JS, and HTML.
 
 Material Design Lite (MDL) lets you add a Material Design look and feel to your


### PR DESCRIPTION
This PR is a fix for the broken link in the README file.

![Screen Shot 2021-06-20 at 1 57 07 AM](https://user-images.githubusercontent.com/16071840/122654707-ea258c80-d16a-11eb-9a17-e7d7a357f4d9.png)
