### PR TITLE
Adding the corrected URL in Readme.md, docs/_pages/faq.md, docs/_templates/components.html, src/INTRODUCTION.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Gitter version](https://img.shields.io/gitter/room/gitterHQ/gitter.svg)](https://gitter.im/google/material-design-lite)
 [![Dependency Status](https://david-dm.org/google/material-design-lite.svg)](https://david-dm.org/google/material-design-lite)
 
-> An implementation of [Material Design](http://www.google.com/design/spec/material-design/introduction.html)
+> An implementation of [Material Design](http://www.google.com/design/spec/introduction)
 components in vanilla CSS, JS, and HTML.
 
 Material Design Lite (MDL) lets you add a Material Design look and feel to your

--- a/docs/_pages/faq.md
+++ b/docs/_pages/faq.md
@@ -35,7 +35,7 @@ include_prefix: ../
 
 <h2 id="where-should-i-use">Where should I use Material Design Lite (MDL)?</h2>
 
-If you’re interested in a [Material Design](http://www.google.com/design/spec/introduction) experience using vanilla Web technologies like CSS, JavaScript and HTML, MDL might be a useful option to consider. We optimise for websites heavy on content, such as marketing pages, articles, blogs and general web content that isn’t particularly app-y.  If you just want to pick some colors, customise a template and ship a Material experience, we try to help make that process simpler.
+If you’re interested in a [Material Design](https://www.google.com/design/spec/introduction) experience using vanilla Web technologies like CSS, JavaScript and HTML, MDL might be a useful option to consider. We optimise for websites heavy on content, such as marketing pages, articles, blogs and general web content that isn’t particularly app-y.  If you just want to pick some colors, customise a template and ship a Material experience, we try to help make that process simpler.
 
 Whilst there exist several community-driven options for Material Design, our experience has shown that there are several gaps in the Material specification when it comes to the web. Rather than guessing how these gaps should be filled (something we know the community has struggled with), we’ve opted for a close collaboration with the Material Design team to provide a Material library that is both spec compatible for today and provides guidance on aspects of the spec still being evolved.
 

--- a/docs/_pages/faq.md
+++ b/docs/_pages/faq.md
@@ -35,7 +35,7 @@ include_prefix: ../
 
 <h2 id="where-should-i-use">Where should I use Material Design Lite (MDL)?</h2>
 
-If you’re interested in a [Material Design](https://www.google.com/design/spec/material-design/introduction.html) experience using vanilla Web technologies like CSS, JavaScript and HTML, MDL might be a useful option to consider. We optimise for websites heavy on content, such as marketing pages, articles, blogs and general web content that isn’t particularly app-y.  If you just want to pick some colors, customise a template and ship a Material experience, we try to help make that process simpler.
+If you’re interested in a [Material Design](http://www.google.com/design/spec/introduction) experience using vanilla Web technologies like CSS, JavaScript and HTML, MDL might be a useful option to consider. We optimise for websites heavy on content, such as marketing pages, articles, blogs and general web content that isn’t particularly app-y.  If you just want to pick some colors, customise a template and ship a Material experience, we try to help make that process simpler.
 
 Whilst there exist several community-driven options for Material Design, our experience has shown that there are several gaps in the Material specification when it comes to the web. Rather than guessing how these gaps should be filled (something we know the community has struggled with), we’ve opted for a close collaboration with the Material Design team to provide a Material library that is both spec compatible for today and provides guidance on aspects of the spec still being evolved.
 

--- a/docs/_templates/components.html
+++ b/docs/_templates/components.html
@@ -30,7 +30,7 @@
         innovation and possibility of technology and science." Understanding the
         goals and principles of Material Design is critical to the proper use of
         the Material Design Lite components. If you have not yet read the
-        <a href="http://www.google.com/design/spec/material-design/introduction.html">Material Design Introduction</a>
+        <a href="http://www.google.com/design/spec/introduction">Material Design Introduction</a>
         you should do so before attempting to use the components.
             </dd>
           </dl>

--- a/src/INTRODUCTION.md
+++ b/src/INTRODUCTION.md
@@ -1,7 +1,7 @@
 # Material Design Lite
 
 ## Introduction
-**Material Design Light (MDL)** is a library of components for web developers based on Google's **Material Design** philosophy: "A visual language for our users that synthesizes the classic principles of good design with the innovation and possibility of technology and science." Understanding the goals and principles of Material Design is critical to the proper use of the MDL components. If you have not yet read the [Material Design Introduction](http://www.google.com/design/spec/material-design/introduction.html), you should do so before attempting to use the components.
+**Material Design Light (MDL)** is a library of components for web developers based on Google's **Material Design** philosophy: "A visual language for our users that synthesizes the classic principles of good design with the innovation and possibility of technology and science." Understanding the goals and principles of Material Design is critical to the proper use of the MDL components. If you have not yet read the [Material Design Introduction](http://www.google.com/design/spec/introduction), you should do so before attempting to use the components.
 
 The MDL components are created with CSS, JavaScript, and HTML. You can use the components to construct web pages and web apps that are attractive, consistent, and functional. Pages developed with MDL will adhere to modern web design principles like browser portability, device independence, and graceful degradation.
 


### PR DESCRIPTION
The link is given in the main files is http://material.io/design/material-design/introduction.html and this does not exist and the actual link which is valid for this is http://www.google.com/design/spec/introduction and Here is the screenshot of both the links

The link is given before is 👇

![Corrected link ](https://user-images.githubusercontent.com/69708924/131252722-97917e21-6af3-4446-9031-9f62dd3296cc.png)

After Adding the correct link is 👇

![Given link](https://user-images.githubusercontent.com/69708924/131252715-465a8fdd-bb1d-4261-820e-4435a0a4fcb8.png)
