### PR TITLE
Fix the broken link in README.md file (Material Design Introduction link)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Gitter version](https://img.shields.io/gitter/room/gitterHQ/gitter.svg)](https://gitter.im/google/material-design-lite)
 [![Dependency Status](https://david-dm.org/google/material-design-lite.svg)](https://david-dm.org/google/material-design-lite)
 
-> An implementation of [Material Design](http://www.google.com/design/spec/material-design/introduction.html)
+> An implementation of [Material Design](https://material.io/design/introduction)
 components in vanilla CSS, JS, and HTML.
 
 Material Design Lite (MDL) lets you add a Material Design look and feel to your


### PR DESCRIPTION
Broken Link - https://material.io/design/material-design/introduction.html
Updated Link - https://material.io/design/introduction
![Screenshot from 2021-08-31 20-07-04](https://user-images.githubusercontent.com/51878265/131524579-2c225af5-7431-47b7-b8d4-7aa707659e09.png)
